### PR TITLE
Fix import path for theme controller

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,7 +6,7 @@ import 'pages/home_page.dart';
 import 'themes/app_theme.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import '../controllers/theme_controller.dart'; // Import the ThemeController
+import 'controllers/theme_controller.dart'; // Import the ThemeController
 
 void main() {
   runApp(const MyApp());


### PR DESCRIPTION
## Summary
- fix incorrect relative import in `lib/main.dart`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432d34e01c832da5147cfc83c54f8b