### PR TITLE
Load Appwrite config from env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1
+APPWRITE_PROJECT_ID=65f5a3e4bd0514b418a4

--- a/README.md
+++ b/README.md
@@ -14,3 +14,14 @@ A few resources to get you started if this is your first Flutter project:
 For help getting started with Flutter development, view the
 [online documentation](https://docs.flutter.dev/), which offers tutorials,
 samples, guidance on mobile development, and a full API reference.
+
+## Environment Configuration
+
+Create a `.env` file in the project root with the following variables:
+
+```
+APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1
+APPWRITE_PROJECT_ID=65f5a3e4bd0514b418a4
+```
+
+The file is referenced in `pubspec.yaml` so it will be bundled automatically when running the application.

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -5,6 +5,7 @@ import 'package:appwrite/appwrite.dart';
 import 'package:logger/logger.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:email_validator/email_validator.dart'; // Added for email validation
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 class AuthController extends GetxController {
   final Client client = Client();
@@ -32,16 +33,16 @@ class AuthController extends GetxController {
   static const int resendCooldownDuration = 60; // in seconds
   static const int otpExpirationDuration = 300; // in seconds
 
-  // Constants for Appwrite configuration
-  static const String appwriteEndpoint =
-      'https://cloud.appwrite.io/v1'; // Your Appwrite endpoint
-  static const String appwriteProjectId =
-      '65f5a3e4bd0514b418a4'; // Your Appwrite project ID
+  // Environment variable keys
+  static const String _endpointKey = 'APPWRITE_ENDPOINT';
+  static const String _projectIdKey = 'APPWRITE_PROJECT_ID';
 
   @override
   void onInit() {
     super.onInit();
-    client.setEndpoint(appwriteEndpoint).setProject(appwriteProjectId);
+    final endpoint = dotenv.env[_endpointKey] ?? '';
+    final projectId = dotenv.env[_projectIdKey] ?? '';
+    client.setEndpoint(endpoint).setProject(projectId);
 
     account = Account(client);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,8 +7,11 @@ import 'themes/app_theme.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import '../controllers/theme_controller.dart'; // Import the ThemeController
+import 'package:flutter_dotenv/flutter_dotenv.dart';
 
-void main() {
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load(fileName: '.env');
   runApp(const MyApp());
 }
 


### PR DESCRIPTION
## Summary
- add `.env` with Appwrite settings
- load env file before running the app
- read Appwrite endpoint and project ID from env in `AuthController`
- document env setup in README

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432f1a5b08832dbeb41db3c0cec5f0