### PR TITLE
Fix OTP verification and account deletion

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -181,7 +181,7 @@ class AuthController extends GetxController {
     } on AppwriteException {
       logger.i('No existing session, verifying OTP...');
       try {
-        await account.createSession(
+        await account.updateMagicURLSession(
           userId: userId!,
           secret: otp,
         );
@@ -273,7 +273,7 @@ class AuthController extends GetxController {
   Future<void> deleteUserAccount() async {
     isLoading.value = true;
     try {
-      await account.deleteIdentity(identityId: userId!);
+      await account.delete();
       logger.i('Account deleted successfully');
       clearControllers();
       isOTPSent.value = false;


### PR DESCRIPTION
## Summary
- use `updateMagicURLSession` to verify OTP
- remove identity deletion and call `account.delete()` to remove the user's account

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68432f364ffc832da59bca01ea35e637