### PR TITLE
Skip splash screen on app start

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'bindings/auth_binding.dart';
-import 'bindings/splash_binding.dart';
 import 'pages/sign_in_page.dart';
 import 'pages/home_page.dart';
-import 'pages/splash_screen.dart';
 import 'themes/app_theme.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -32,14 +30,9 @@ class MyApp extends StatelessWidget {
           themeMode: themeController.isDarkMode.value
               ? ThemeMode.dark
               : ThemeMode.light, // Reactive theme
-          initialBinding: SplashBinding(), // Initial Binding for dependencies
-          initialRoute: '/splash',
+          initialBinding: AuthBinding(),
+          initialRoute: '/',
           getPages: [
-            GetPage(
-              name: '/splash',
-              page: () => const SplashScreen(),
-              binding: SplashBinding(),
-            ),
             GetPage(
               name: '/',
               page: () => const SignInPage(),


### PR DESCRIPTION
## Summary
- boot directly into the sign-in page

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684333fd8774832d9cfb2d525299b290