### PR TITLE
Improve responsive layout

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/auth_controller.dart';
 import '../controllers/theme_controller.dart';  // Import the ThemeController
+import '../widgets/responsive_layout.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
@@ -24,32 +25,38 @@ class HomePage extends StatelessWidget {
               )),
         ],
       ),
-      body: Center(
-        child: Container(
-          padding: const EdgeInsets.all(16),
-          width: MediaQuery.of(context).size.width * 0.9 > 600
-              ? 600
-              : MediaQuery.of(context).size.width * 0.9,
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              Text(
-                'signed_in'.tr,
-                style: const TextStyle(fontSize: 24),
-                textAlign: TextAlign.center,
-              ),
-              const SizedBox(height: 20),
-              ElevatedButton(
-                onPressed: () async {
-                  await Get.find<AuthController>().account.deleteSession(sessionId: 'current');
-                  Get.find<AuthController>().clearControllers();
-                  Get.find<AuthController>().isOTPSent.value = false;
-                  Get.offAllNamed('/');
-                },
-                child: Text('logout'.tr),
-              ),
-            ],
-          ),
+      body: ResponsiveLayout(
+        mobile: (_) => _buildContent(context, MediaQuery.of(context).size.width * 0.9),
+        tablet: (_) => _buildContent(context, 500),
+        desktop: (_) => _buildContent(context, 600),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, double width) {
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        width: width,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text(
+              'signed_in'.tr,
+              style: const TextStyle(fontSize: 24),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () async {
+                await Get.find<AuthController>().account.deleteSession(sessionId: 'current');
+                Get.find<AuthController>().clearControllers();
+                Get.find<AuthController>().isOTPSent.value = false;
+                Get.offAllNamed('/');
+              },
+              child: Text('logout'.tr),
+            ),
+          ],
         ),
       ),
     );

--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -1,29 +1,36 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/auth_controller.dart';
+import '../widgets/responsive_layout.dart';
 
 class SignInPage extends GetView<AuthController> {
   const SignInPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    final size = MediaQuery.of(context).size;
-
     return Scaffold(
       appBar: AppBar(
         title: Text('email_sign_in'.tr),
       ),
       body: Obx(() {
-        return Center(
-          child: SingleChildScrollView(
-            child: Container(
-              padding: const EdgeInsets.all(16),
-              width: size.width * 0.9 > 400 ? 400 : size.width * 0.9,
-              child: controller.isOTPSent.value ? _otpForm() : _emailForm(),
-            ),
-          ),
+        return ResponsiveLayout(
+          mobile: (_) => _buildForm(context, MediaQuery.of(context).size.width * 0.9),
+          tablet: (_) => _buildForm(context, 500),
+          desktop: (_) => _buildForm(context, 400),
         );
       }),
+    );
+  }
+
+  Widget _buildForm(BuildContext context, double width) {
+    return Center(
+      child: SingleChildScrollView(
+        child: Container(
+          padding: const EdgeInsets.all(16),
+          width: width,
+          child: controller.isOTPSent.value ? _otpForm() : _emailForm(),
+        ),
+      ),
     );
   }
 

--- a/lib/widgets/responsive_layout.dart
+++ b/lib/widgets/responsive_layout.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+/// Simple responsive layout widget with mobile, tablet and desktop breakpoints.
+class ResponsiveLayout extends StatelessWidget {
+  const ResponsiveLayout({
+    super.key,
+    required this.mobile,
+    this.tablet,
+    this.desktop,
+  });
+
+  /// Widget to display on mobile (<600px width).
+  final WidgetBuilder mobile;
+
+  /// Widget to display on tablet (>=600px and <1024px). Falls back to [mobile]
+  /// when null.
+  final WidgetBuilder? tablet;
+
+  /// Widget to display on desktop (>=1024px). Falls back to [tablet] or [mobile]
+  /// when null.
+  final WidgetBuilder? desktop;
+
+  /// Returns true when the current screen width is considered mobile.
+  static bool isMobile(BuildContext context) =>
+      MediaQuery.of(context).size.width < 600;
+
+  /// Returns true when the current screen width is considered tablet.
+  static bool isTablet(BuildContext context) =>
+      MediaQuery.of(context).size.width >= 600 &&
+      MediaQuery.of(context).size.width < 1024;
+
+  /// Returns true when the current screen width is considered desktop.
+  static bool isDesktop(BuildContext context) =>
+      MediaQuery.of(context).size.width >= 1024;
+
+  @override
+  Widget build(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width >= 1024 && desktop != null) {
+      return desktop!(context);
+    } else if (width >= 600 && tablet != null) {
+      return tablet!(context);
+    } else {
+      return mobile(context);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- make sign in page and home page responsive with new `ResponsiveLayout`
- add helper widget for responsiveness across mobile, tablet and desktop

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68433cb2d9ac832da131362e872f75da