### PR TITLE
Fix username dialog and allow reset

### DIFF
--- a/lib/assets/translations/app_translations.dart
+++ b/lib/assets/translations/app_translations.dart
@@ -50,6 +50,9 @@ class AppTranslations extends Translations {
         'username_taken': 'Username already taken',
         'username_available': 'Username available',
         'save': 'Save',
+        'delete_username': 'Delete Username',
+        'username_deleted': 'Username deleted',
+        'failed_to_delete_username': 'Failed to delete username',
         },
         'es_ES': {
           'app_name': 'StarChat',
@@ -101,8 +104,11 @@ class AppTranslations extends Translations {
           'enter_username': 'Elige un nombre de usuario',
           'username': 'Nombre de usuario',
           'username_taken': 'El nombre ya está en uso',
-          'username_available': 'Nombre disponible',
-          'save': 'Guardar',
+        'username_available': 'Nombre disponible',
+        'save': 'Guardar',
+        'delete_username': 'Eliminar nombre de usuario',
+        'username_deleted': 'Nombre de usuario eliminado',
+        'failed_to_delete_username': 'No se pudo eliminar el nombre de usuario',
         },
       };
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -56,6 +56,11 @@ class HomePage extends StatelessWidget {
               },
               child: Text('logout'.tr),
             ),
+            const SizedBox(height: 10),
+            ElevatedButton(
+              onPressed: Get.find<AuthController>().deleteUsername,
+              child: Text('delete_username'.tr),
+            ),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- initialize server-side client for username checks
- show username dialog after navigating home
- add ability to delete username and button on home page
- update translations

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843452bdeec832d922b028a4228f58f