### PR TITLE
Add username setup flow

### DIFF
--- a/lib/assets/translations/app_translations.dart
+++ b/lib/assets/translations/app_translations.dart
@@ -53,6 +53,9 @@ class AppTranslations extends Translations {
         'delete_username': 'Delete Username',
         'username_deleted': 'Username deleted',
         'failed_to_delete_username': 'Failed to delete username',
+        'invalid_username': 'Invalid username',
+        'invalid_username_message':
+            'Usernames must be 3-15 characters and can include letters, numbers, and underscores.',
         },
         'es_ES': {
           'app_name': 'StarChat',
@@ -109,6 +112,9 @@ class AppTranslations extends Translations {
         'delete_username': 'Eliminar nombre de usuario',
         'username_deleted': 'Nombre de usuario eliminado',
         'failed_to_delete_username': 'No se pudo eliminar el nombre de usuario',
+        'invalid_username': 'Nombre de usuario inválido',
+        'invalid_username_message':
+            'Los nombres deben tener entre 3 y 15 caracteres y solo pueden incluir letras, números y guiones bajos.',
         },
       };
 }

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -20,6 +20,10 @@ class AuthController extends GetxController {
   final isCheckingUsername = false.obs;
   final usernameAvailable = false.obs;
   final username = ''.obs;
+  final isUsernameValid = false.obs;
+  Timer? _usernameDebounce;
+  static const Duration usernameDebounceDuration = Duration(milliseconds: 500);
+  late TextEditingController usernameController;
 
   late TextEditingController emailController;
   late TextEditingController otpController;
@@ -62,6 +66,7 @@ class AuthController extends GetxController {
 
     emailController = TextEditingController();
     otpController = TextEditingController();
+    usernameController = TextEditingController();
 
     account = Account(client);
     databases = Databases(client);
@@ -73,6 +78,7 @@ class AuthController extends GetxController {
   void onClose() {
     emailController.dispose();
     otpController.dispose();
+    usernameController.dispose();
     cancelTimers();
     super.onClose();
   }
@@ -81,9 +87,12 @@ class AuthController extends GetxController {
     try {
       isLoading.value = true;
       await account.get();
-      await Get.offAllNamed('/home');
-      await Future.delayed(const Duration(milliseconds: 100));
-      await ensureUsername();
+      bool hasUsername = await ensureUsername();
+      if (hasUsername) {
+        await Get.offAllNamed('/home');
+      } else {
+        await Get.offAllNamed('/set_username');
+      }
     } on AppwriteException catch (e) {
       logger.i('No active session: $e');
     } catch (e) {
@@ -100,6 +109,10 @@ class AuthController extends GetxController {
   bool isValidOTP(String otp) {
     final otpRegex = RegExp(r'^\d{6}$');
     return otpRegex.hasMatch(otp);
+  }
+  bool isValidUsername(String name) {
+    final usernameRegex = RegExp(r'^[a-zA-Z0-9_]{3,15}\$');
+    return usernameRegex.hasMatch(name);
   }
 
   Future<void> sendOTP() async {
@@ -211,9 +224,12 @@ class AuthController extends GetxController {
           secret: otp,
         );
 
-        await Get.offAllNamed('/home');
-        await Future.delayed(const Duration(milliseconds: 100));
-        await ensureUsername();
+        bool hasUsername = await ensureUsername();
+        if (hasUsername) {
+          await Get.offAllNamed('/home');
+        } else {
+          await Get.offAllNamed('/set_username');
+        }
       } on AppwriteException catch (e) {
         logger.e('AppwriteException in verifyOTP', error: e);
         String errorMessage = 'failed_to_verify_otp'.tr;
@@ -294,16 +310,18 @@ class AuthController extends GetxController {
   void clearControllers() {
     emailController.dispose();
     otpController.dispose();
+    usernameController.dispose();
+    usernameController = TextEditingController();
     emailController = TextEditingController();
     otpController = TextEditingController();
     cancelTimers();
   }
 
-  Future<void> ensureUsername() async {
+  Future<bool> ensureUsername() async {
     final prefs = await SharedPreferences.getInstance();
     if (prefs.getString('username') != null) {
       username.value = prefs.getString('username')!;
-      return;
+      return true;
     }
 
     final dbId = dotenv.env[_databaseIdKey] ?? 'StarChat_DB';
@@ -322,14 +340,14 @@ class AuthController extends GetxController {
         if (data['username'] != null && data['username'] != '') {
           username.value = data['username'];
           await prefs.setString('username', username.value);
-          return;
+          return true;
         }
       }
     } catch (e) {
       logger.e('Error fetching username', error: e);
     }
 
-    await _promptForUsername(dbId, collectionId, uid, prefs);
+    return false;
   }
 
   Future<void> _promptForUsername(
@@ -430,6 +448,45 @@ class AuthController extends GetxController {
     } catch (e) {
       logger.e('Error saving username', error: e);
     }
+  }
+
+  void onUsernameChanged(String value) {
+    usernameController.text = value;
+    isUsernameValid.value = isValidUsername(value);
+    if (!isUsernameValid.value) {
+      usernameAvailable.value = false;
+      _usernameDebounce?.cancel();
+      return;
+    }
+    _usernameDebounce?.cancel();
+    _usernameDebounce = Timer(usernameDebounceDuration, () {
+      _checkUsernameAvailability(value);
+    });
+  }
+
+  Future<void> submitUsername() async {
+    final name = usernameController.text.trim();
+    if (!isValidUsername(name)) {
+      Get.snackbar('error'.tr, 'invalid_username_message'.tr,
+          snackPosition: SnackPosition.BOTTOM);
+      return;
+    }
+    isLoading.value = true;
+    await _checkUsernameAvailability(name);
+    if (!usernameAvailable.value) {
+      isLoading.value = false;
+      Get.snackbar('error'.tr, 'username_taken'.tr,
+          snackPosition: SnackPosition.BOTTOM);
+      return;
+    }
+    final prefs = await SharedPreferences.getInstance();
+    final dbId = dotenv.env[_databaseIdKey] ?? 'StarChat_DB';
+    final collectionId = dotenv.env[_profilesCollectionKey] ?? 'user_profiles';
+    final session = await account.get();
+    final uid = session.$id;
+    await _saveUsername(dbId, collectionId, uid, name, prefs);
+    isLoading.value = false;
+    Get.offAllNamed('/home');
   }
 
   Future<void> deleteUsername() async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'bindings/auth_binding.dart';
 import 'pages/sign_in_page.dart';
 import 'pages/home_page.dart';
+import 'pages/set_username_page.dart';
 import 'themes/app_theme.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -36,6 +37,11 @@ class MyApp extends StatelessWidget {
             GetPage(
               name: '/',
               page: () => const SignInPage(),
+              binding: AuthBinding(),
+            ),
+            GetPage(
+              name: '/set_username',
+              page: () => const SetUsernamePage(),
               binding: AuthBinding(),
             ),
             GetPage(

--- a/lib/pages/set_username_page.dart
+++ b/lib/pages/set_username_page.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/auth_controller.dart';
+import '../widgets/responsive_layout.dart';
+
+class SetUsernamePage extends GetView<AuthController> {
+  const SetUsernamePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('enter_username'.tr)),
+      body: ResponsiveLayout(
+        mobile: (_) => _buildForm(context, MediaQuery.of(context).size.width * 0.9),
+        tablet: (_) => _buildForm(context, 500),
+        desktop: (_) => _buildForm(context, 400),
+      ),
+    );
+  }
+
+  Widget _buildForm(BuildContext context, double width) {
+    return Center(
+      child: Container(
+        padding: const EdgeInsets.all(16),
+        width: width,
+        child: Obx(() => Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                TextField(
+                  controller: controller.usernameController,
+                  decoration: InputDecoration(
+                    labelText: 'username'.tr,
+                    suffixIcon: controller.isCheckingUsername.value
+                        ? const SizedBox(
+                            width: 20,
+                            height: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2),
+                          )
+                        : Icon(
+                            controller.isUsernameValid.value && controller.usernameAvailable.value
+                                ? Icons.check
+                                : Icons.close,
+                            color: controller.isUsernameValid.value && controller.usernameAvailable.value
+                                ? Colors.green
+                                : Colors.red,
+                          ),
+                  ),
+                  onChanged: controller.onUsernameChanged,
+                ),
+                const SizedBox(height: 20),
+                SizedBox(
+                  width: double.infinity,
+                  child: Obx(() => ElevatedButton(
+                        onPressed: controller.isLoading.value ||
+                                !controller.isUsernameValid.value ||
+                                !controller.usernameAvailable.value
+                            ? null
+                            : controller.submitUsername,
+                        child: controller.isLoading.value
+                            ? const CircularProgressIndicator()
+                            : Text('save'.tr),
+                      )),
+                ),
+              ],
+            )),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- set username after OTP verification
- add dedicated page for choosing usernames
- add validity checks and debounce
- update translations

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68434c532094832d8f0703839c60f7e3