### PR TITLE
Fix loop on username page

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -80,9 +80,13 @@ class AuthController extends GetxController {
       await account.get();
       bool hasUsername = await ensureUsername();
       if (hasUsername) {
-        await Get.offAllNamed('/home');
+        if (Get.currentRoute != '/home') {
+          await Get.offAllNamed('/home');
+        }
       } else {
-        await Get.offAllNamed('/set_username');
+        if (Get.currentRoute != '/set_username') {
+          await Get.offAllNamed('/set_username');
+        }
       }
     } on AppwriteException catch (e) {
       logger.i('No active session: $e');

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,7 +7,7 @@ import 'pages/set_username_page.dart';
 import 'themes/app_theme.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import '../controllers/theme_controller.dart'; // Import the ThemeController
+import 'controllers/theme_controller.dart'; // Import the ThemeController
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 Future<void> main() async {


### PR DESCRIPTION
## Summary
- avoid re-navigation loop in `checkExistingSession`
- correct path to `ThemeController`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435458b924832dbfe19410a42bc58c