### PR TITLE
Fix user profile permissions and add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ APPWRITE_ENDPOINT=https://cloud.appwrite.io/v1
 APPWRITE_PROJECT_ID=65f5a3e4bd0514b418a4
 APPWRITE_DATABASE_ID=StarChat_DB
 USER_PROFILES_COLLECTION_ID=user_profiles
+APPWRITE_API_KEY=<your_appwrite_api_key>
 ```
 
 The file is referenced in `pubspec.yaml` so it will be bundled automatically when running the application.
+
+## Updating Collection Permissions
+
+To adjust permissions for the user profiles collection, run the helper script using your Appwrite API key:
+
+```bash
+python update_collection_permissions.py
+```
+
+Ensure the environment variables above are exported or stored in your `.env` file before running the script.

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -508,6 +508,11 @@ class AuthController extends GetxController {
           'createdAt': DateTime.now().toIso8601String(),
           'updatedAt': DateTime.now().toIso8601String(),
         },
+        permissions: [
+          Permission.read(Role.user(uid)),
+          Permission.update(Role.user(uid)),
+          Permission.delete(Role.user(uid)),
+        ],
       );
       username.value = name;
       await prefs.setString('username', name);

--- a/update_collection_permissions.py
+++ b/update_collection_permissions.py
@@ -1,0 +1,40 @@
+import os
+from appwrite.client import Client
+from appwrite.services.databases import Databases
+from appwrite.permission import Permission
+from appwrite.role import Role
+
+def main():
+    endpoint = os.environ.get("APPWRITE_ENDPOINT")
+    project = os.environ.get("APPWRITE_PROJECT_ID")
+    api_key = os.environ.get("APPWRITE_API_KEY")
+    database_id = os.environ.get("APPWRITE_DATABASE_ID")
+    collection_id = os.environ.get("USER_PROFILES_COLLECTION_ID")
+
+    if not all([endpoint, project, api_key, database_id, collection_id]):
+        raise RuntimeError("Missing required environment variables")
+
+    client = Client()
+    client.set_endpoint(endpoint).set_project(project).set_key(api_key)
+
+    databases = Databases(client)
+    collection = databases.get_collection(database_id=database_id, collection_id=collection_id)
+
+    permissions = [
+        Permission.create(Role.users()),
+        Permission.read(Role.any()),
+        Permission.update(Role.users()),
+        Permission.delete(Role.users()),
+    ]
+
+    databases.update_collection(
+        database_id=database_id,
+        collection_id=collection_id,
+        name=collection['name'],
+        permissions=permissions,
+        document_security=True,
+    )
+    print(f"Collection '{collection['name']}' permissions updated")
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- ensure profile documents include read/update/delete permissions for the user
- provide helper script to update collection permissions via API key
- document environment variable for API key and script usage

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684365f5c754832d8cc2e5b5352481fb