### PR TITLE
Fix profile creation timestamp

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -505,6 +505,8 @@ class AuthController extends GetxController {
           'username': name,
           'firstName': '',
           'lastName': '',
+          'createdAt': DateTime.now().toUtc().toIso8601String(),
+          'UpdateAt': DateTime.now().toUtc().toIso8601String(),
         },
         permissions: [
           Permission.read(Role.user(uid)),


### PR DESCRIPTION
## Summary
- add `createdAt` and `UpdateAt` when saving a user profile

## Testing
- `python -m pytest`
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436a589208832daa6263e6e5d9d0ec