### PR TITLE
Clean up username screen UI

### DIFF
--- a/lib/pages/set_username_page.dart
+++ b/lib/pages/set_username_page.dart
@@ -26,20 +26,6 @@ class SetUsernamePage extends GetView<AuthController> {
         child: Obx(() => Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                FutureBuilder<String?>(
-                  future: controller.fetchCurrentUserId(),
-                  builder: (context, snapshot) {
-                    if (snapshot.connectionState == ConnectionState.waiting) {
-                      return const SizedBox.shrink();
-                    }
-                    final id = snapshot.data;
-                    if (id == null) {
-                      return const SizedBox.shrink();
-                    }
-                    return Text('user_id_label'.trParams({'id': id}));
-                  },
-                ),
-                const SizedBox(height: 8),
                 TextField(
                   controller: controller.usernameController,
                   decoration: InputDecoration(
@@ -52,13 +38,6 @@ class SetUsernamePage extends GetView<AuthController> {
                         : null,
                   ),
                   onChanged: controller.onUsernameChanged,
-                ),
-                const SizedBox(height: 8),
-                ElevatedButton(
-                  onPressed: controller.isCheckingUsername.value
-                      ? null
-                      : controller.checkUsernameAvailability,
-                  child: Text('check_availability'.tr),
                 ),
                 const SizedBox(height: 8),
                 Obx(() {


### PR DESCRIPTION
## Summary
- remove user ID debug text and check availability button
- tidy up username form layout

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68436f3c62b8832dac9191a9c63f9055