### PR TITLE
Fix username page errors on account switch

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -49,10 +49,7 @@ class HomePage extends StatelessWidget {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () async {
-                await Get.find<AuthController>().account.deleteSession(sessionId: 'current');
-                Get.find<AuthController>().clearControllers();
-                Get.find<AuthController>().isOTPSent.value = false;
-                Get.offAllNamed('/');
+                await Get.find<AuthController>().logout();
               },
               child: Text('logout'.tr),
             ),


### PR DESCRIPTION
## Summary
- cancel OTP timers after verification
- clear username state in controller resets
- add a dedicated `logout` helper on `AuthController`
- use the new logout method from the home page

## Testing
- `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`

------
https://chatgpt.com/codex/tasks/task_e_684371a4ca60832d916ac644414170be