### PR TITLE
Fix profile navigation and show username

### DIFF
--- a/lib/assets/translations/app_translations.dart
+++ b/lib/assets/translations/app_translations.dart
@@ -35,6 +35,7 @@ class AppTranslations extends Translations {
           'logout': 'Logout',
           'home_page': 'Home Page',
           'signed_in': 'You are now signed in!',
+          'signed_in_as': 'Signed in as @username',
           'delete_account': 'Delete Account',
           'delete_account_confirmation': 'Are you sure you want to delete your account?',
           'cancel': 'Cancel',
@@ -105,6 +106,7 @@ class AppTranslations extends Translations {
           'logout': 'Cerrar sesión',
           'home_page': 'Página de inicio',
           'signed_in': '¡Has iniciado sesión!',
+          'signed_in_as': 'Conectado como @username',
           'delete_account': 'Eliminar cuenta',
           'delete_account_confirmation':
               '¿Está seguro de que desea eliminar su cuenta?',

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -23,6 +23,11 @@ class HomePage extends StatelessWidget {
                     : Icons.dark_mode),
                 onPressed: themeController.toggleTheme, // Toggle the theme on press
               )),
+          IconButton(
+            icon: const Icon(Icons.person),
+            tooltip: 'profile'.tr,
+            onPressed: () => Get.toNamed('/profile'),
+          )
         ],
       ),
       body: ResponsiveLayout(
@@ -34,6 +39,7 @@ class HomePage extends StatelessWidget {
   }
 
   Widget _buildContent(BuildContext context, double width) {
+    final authController = Get.find<AuthController>();
     return Center(
       child: Container(
         padding: const EdgeInsets.all(16),
@@ -41,16 +47,11 @@ class HomePage extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-          Text(
-            'signed_in'.tr,
-            style: const TextStyle(fontSize: 24),
-            textAlign: TextAlign.center,
-          ),
-          const SizedBox(height: 20),
-          ElevatedButton(
-            onPressed: () => Get.toNamed('/profile'),
-            child: Text('profile'.tr),
-          ),
+          Obx(() => Text(
+                'signed_in_as'.trParams({'username': authController.username.value}),
+                style: const TextStyle(fontSize: 24),
+                textAlign: TextAlign.center,
+              )),
           const SizedBox(height: 20),
           ElevatedButton(
               onPressed: () async {
@@ -60,11 +61,6 @@ class HomePage extends StatelessWidget {
                 Get.offAllNamed('/');
               },
               child: Text('logout'.tr),
-            ),
-            const SizedBox(height: 10),
-            ElevatedButton(
-              onPressed: Get.find<AuthController>().deleteUsername,
-              child: Text('delete_username'.tr),
             ),
           ],
         ),


### PR DESCRIPTION
## Summary
- add translations for showing current user
- show username on home page
- replace profile button with icon in the app bar
- remove delete username option

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684377c136d4832daba5fc9ea4cd69bb