### PR TITLE
Fix profile page redirection

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -91,7 +91,8 @@ class AuthController extends GetxController {
       await account.get();
       bool hasUsername = await ensureUsername();
       if (hasUsername) {
-        if (Get.currentRoute != '/home') {
+        // Only redirect to home when coming from unauthenticated routes
+        if (Get.currentRoute == '/' || Get.currentRoute == '/set_username') {
           await Get.offAllNamed('/home');
         }
       } else {


### PR DESCRIPTION
## Summary
- prevent `checkExistingSession` from forcing a navigation to `/home` when already on an authenticated route

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843791fc00c832d989229fe266711a5