### PR TITLE
Fix OTP logout flow

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -206,6 +206,8 @@ class AuthController extends GetxController {
   }
 
   Future<void> verifyOTP() async {
+    // Close any open snackbars to avoid context issues when navigating
+    Get.closeAllSnackbars();
     String otp = otpController.text.trim();
 
     if (!isValidOTP(otp)) {

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -55,6 +55,7 @@ class HomePage extends StatelessWidget {
           const SizedBox(height: 20),
           ElevatedButton(
               onPressed: () async {
+                Get.closeAllSnackbars();
                 await Get.find<AuthController>().account.deleteSession(sessionId: 'current');
                 Get.find<AuthController>().clearControllers();
                 Get.find<AuthController>().isOTPSent.value = false;

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -70,6 +70,7 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
               );
               if (confirm ?? false) {
+                Get.closeAllSnackbars();
                 await Get.find<AuthController>()
                     .account
                     .deleteSession(sessionId: 'current');


### PR DESCRIPTION
## Summary
- resolve overlay assertion when logging out or verifying OTP
- close any snackbars before navigating away

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437b8bd098832dbad24bdd6c86cb01