### PR TITLE
Fix username cache usage

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -353,18 +353,24 @@ class AuthController extends GetxController {
           return true;
         }
       }
+
+      // If no username found on server, clear any cached value
+      await prefs.remove('username');
+      username.value = '';
+      profilePictureUrl.value = '';
+      return false;
     } catch (e) {
       logger.e('Error fetching username from server', error: e);
-    }
 
-    // Fallback to cached username if available
-    final cachedName = prefs.getString('username');
-    if (cachedName != null) {
-      username.value = cachedName;
-      return true;
-    }
+      // Fallback to cached username only when the server cannot be reached
+      final cachedName = prefs.getString('username');
+      if (cachedName != null) {
+        username.value = cachedName;
+        return true;
+      }
 
-    return false;
+      return false;
+    }
   }
 
   Future<void> _promptForUsername(


### PR DESCRIPTION
## Summary
- clear any cached username when server has no username
- only fall back to cached username if fetching from server fails

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_68437cd17b64832d960236da334a95d3