### PR TITLE
Fix logout navigation

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -742,6 +742,20 @@ class AuthController extends GetxController {
     }
   }
 
+  Future<void> logout() async {
+    try {
+      await account.deleteSession(sessionId: 'current');
+    } catch (e) {
+      logger.e('Error deleting session', error: e);
+    } finally {
+      clearControllers();
+      isOTPSent.value = false;
+      username.value = '';
+      profilePictureUrl.value = '';
+      Get.offAllNamed('/');
+    }
+  }
+
   Future<void> updateProfilePicture(File file) async {
     isLoading.value = true;
     final bucketId = dotenv.env[_bucketIdKey] ?? 'profile_pics';

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -54,15 +54,12 @@ class HomePage extends StatelessWidget {
               )),
           const SizedBox(height: 20),
           ElevatedButton(
-              onPressed: () async {
-                Get.closeAllSnackbars();
-                await Get.find<AuthController>().account.deleteSession(sessionId: 'current');
-                Get.find<AuthController>().clearControllers();
-                Get.find<AuthController>().isOTPSent.value = false;
-                Get.offAllNamed('/');
-              },
-              child: Text('logout'.tr),
-            ),
+            onPressed: () async {
+              Get.closeAllSnackbars();
+              await Get.find<AuthController>().logout();
+            },
+            child: Text('logout'.tr),
+          ),
           ],
         ),
       ),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -71,11 +71,7 @@ class _SettingsPageState extends State<SettingsPage> {
               );
               if (confirm ?? false) {
                 Get.closeAllSnackbars();
-                await Get.find<AuthController>()
-                    .account
-                    .deleteSession(sessionId: 'current');
-                Get.find<AuthController>().clearControllers();
-                Get.offAllNamed('/');
+                await Get.find<AuthController>().logout();
               }
             },
           ),


### PR DESCRIPTION
## Summary
- add a dedicated `logout` helper in `AuthController`
- switch Home and Settings pages to call `logout()`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68438469838c832d8e73fc2696d2c5e6