### PR TITLE
Fix OTP page cleanup

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -54,15 +54,11 @@ class HomePage extends StatelessWidget {
               )),
           const SizedBox(height: 20),
           ElevatedButton(
-              onPressed: () async {
-                Get.closeAllSnackbars();
-                await Get.find<AuthController>().account.deleteSession(sessionId: 'current');
-                Get.find<AuthController>().clearControllers();
-                Get.find<AuthController>().isOTPSent.value = false;
-                Get.offAllNamed('/');
-              },
-              child: Text('logout'.tr),
-            ),
+            onPressed: () async {
+              await Get.find<AuthController>().logout();
+            },
+            child: Text('logout'.tr),
+          ),
           ],
         ),
       ),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -70,12 +70,7 @@ class _SettingsPageState extends State<SettingsPage> {
                 ),
               );
               if (confirm ?? false) {
-                Get.closeAllSnackbars();
-                await Get.find<AuthController>()
-                    .account
-                    .deleteSession(sessionId: 'current');
-                Get.find<AuthController>().clearControllers();
-                Get.offAllNamed('/');
+                await Get.find<AuthController>().logout();
               }
             },
           ),


### PR DESCRIPTION
## Summary
- ensure keyboard is closed during OTP verification
- reset auth controllers after verifying OTP
- reset controller completely when logging out

## Testing
- `flutter test` *(fails: command not found)*
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684383235bf0832d96178687f7ea1043