### PR TITLE
Fix cached username persisting after logout

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -748,6 +748,12 @@ class AuthController extends GetxController {
     } catch (e) {
       logger.e('Error deleting session', error: e);
     } finally {
+      try {
+        final prefs = await SharedPreferences.getInstance();
+        await prefs.remove('username');
+      } catch (e) {
+        logger.e('Error clearing cached username', error: e);
+      }
       clearControllers();
       isOTPSent.value = false;
       username.value = '';


### PR DESCRIPTION
## Summary
- clear cached username in SharedPreferences when logging out

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f31d8cdc832d99983786741ad5dc