### PR TITLE
Improve OTP feedback and validation

### DIFF
--- a/lib/assets/translations/app_translations.dart
+++ b/lib/assets/translations/app_translations.dart
@@ -27,6 +27,7 @@ class AppTranslations extends Translations {
           'invalid_email_message': 'Please enter a valid email address.',
           'invalid_otp': 'Invalid OTP',
           'invalid_otp_message': 'Please enter a valid 6-digit OTP.',
+          'incorrect_otp_message': 'The OTP you entered is incorrect or expired.',
           'wait': 'Wait',
           'no_internet': 'No Internet',
           'check_internet': 'Please check your internet connection.',
@@ -97,6 +98,8 @@ class AppTranslations extends Translations {
           'invalid_otp': 'OTP inválido',
           'invalid_otp_message':
               'Por favor, introduzca un OTP de 6 dígitos válido.',
+          'incorrect_otp_message':
+              'El código que ingresó es incorrecto o ha expirado.',
           'wait': 'Espere',
           'no_internet': 'Sin internet',
           'check_internet': 'Por favor, revise su conexión a internet.',

--- a/lib/pages/set_username_page.dart
+++ b/lib/pages/set_username_page.dart
@@ -36,11 +36,20 @@ class SetUsernamePage extends GetView<AuthController> {
                             onPressed: controller.clearUsernameInput,
                           )
                         : null,
-                  ),
-                  onChanged: controller.onUsernameChanged,
                 ),
-                const SizedBox(height: 8),
-                Obx(() {
+                onChanged: controller.onUsernameChanged,
+              ),
+              Obx(() => controller.usernameError.value.isEmpty
+                  ? const SizedBox.shrink()
+                  : Padding(
+                      padding: const EdgeInsets.only(top: 8),
+                      child: Text(
+                        controller.usernameError.value,
+                        style: const TextStyle(color: Colors.red),
+                      ),
+                    )),
+              const SizedBox(height: 8),
+              Obx(() {
                   if (!controller.hasCheckedUsername.value) {
                     return const SizedBox.shrink();
                   }

--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -51,7 +51,17 @@ class SignInPage extends GetView<AuthController> {
             border: const OutlineInputBorder(),
           ),
           keyboardType: TextInputType.emailAddress,
+          onChanged: (_) => controller.emailError.value = '',
         ),
+        Obx(() => controller.emailError.value.isEmpty
+            ? const SizedBox.shrink()
+            : Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  controller.emailError.value,
+                  style: const TextStyle(color: Colors.red),
+                ),
+              )),
         const SizedBox(height: 20),
         SizedBox(
           width: double.infinity,
@@ -89,7 +99,17 @@ class SignInPage extends GetView<AuthController> {
             border: const OutlineInputBorder(),
           ),
           keyboardType: TextInputType.number,
+          onChanged: (_) => controller.otpError.value = '',
         ),
+        Obx(() => controller.otpError.value.isEmpty
+            ? const SizedBox.shrink()
+            : Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  controller.otpError.value,
+                  style: const TextStyle(color: Colors.red),
+                ),
+              )),
         const SizedBox(height: 20),
         SizedBox(
           width: double.infinity,


### PR DESCRIPTION
## Summary
- add error message fields in `AuthController`
- display field error messages in sign in and username pages
- add new translation key for incorrect OTP
- expand OTP validation to catch server errors
- reset errors when fields change

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441bd08f60832d8fcee4eafbf304d8