### PR TITLE
Fix logout redirection

### DIFF
--- a/lib/bindings/auth_binding.dart
+++ b/lib/bindings/auth_binding.dart
@@ -4,6 +4,9 @@ import '../controllers/auth_controller.dart';
 class AuthBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut<AuthController>(() => AuthController(), fenix: true);
+    // Keep a single instance of AuthController alive for the
+    // entire application lifecycle to preserve state such as
+    // the `justLoggedOut` flag during navigation.
+    Get.put<AuthController>(AuthController(), permanent: true);
   }
 }

--- a/lib/bindings/splash_binding.dart
+++ b/lib/bindings/splash_binding.dart
@@ -5,10 +5,11 @@ import '../controllers/auth_controller.dart';
 class SplashBinding extends Bindings {
   @override
   void dependencies() {
-    // Ensure AuthController is available
-    Get.lazyPut<AuthController>(() => AuthController(), fenix: true);
-    
-    // Initialize SplashController
+    // Ensure a permanent AuthController is available before
+    // running splash logic.
+    Get.put<AuthController>(AuthController(), permanent: true);
+
+    // Initialize SplashController lazily
     Get.lazyPut<SplashController>(() => SplashController());
   }
 }


### PR DESCRIPTION
## Summary
- preserve `AuthController` instance across routes
- ensure splash uses same permanent controller

## Testing
- `python --version`
- `npm --version`
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68441d0cd6ac832d80657a609240cf3f