### PR TITLE
Handle null userId in verifyOTP

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -263,6 +263,16 @@ class AuthController extends GetxController {
       await ensureUsername();
     } on AppwriteException {
       logger.i('No existing session, verifying OTP...');
+      if (userId == null) {
+        logger.e('verifyOTP called with null userId');
+        Get.snackbar(
+          'error'.tr,
+          'unauthorized'.tr,
+          snackPosition: SnackPosition.BOTTOM,
+        );
+        isLoading.value = false;
+        return;
+      }
       try {
         await account.updateMagicURLSession(
           userId: userId!,


### PR DESCRIPTION
## Summary
- ensure verifyOTP aborts when userId is missing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442085a0c4832daf6662bcb093d2f2