### PR TITLE
Improve OTP verification messages

### DIFF
--- a/lib/assets/translations/app_translations.dart
+++ b/lib/assets/translations/app_translations.dart
@@ -27,7 +27,7 @@ class AppTranslations extends Translations {
           'invalid_email_message': 'Please enter a valid email address.',
           'invalid_otp': 'Invalid OTP',
           'invalid_otp_message': 'Please enter a valid 6-digit OTP.',
-          'incorrect_otp_message': 'The OTP you entered is incorrect or expired.',
+          'incorrect_otp_message': 'The OTP you entered is incorrect.',
           'wait': 'Wait',
           'no_internet': 'No Internet',
           'check_internet': 'Please check your internet connection.',
@@ -99,7 +99,7 @@ class AppTranslations extends Translations {
           'invalid_otp_message':
               'Por favor, introduzca un OTP de 6 dígitos válido.',
           'incorrect_otp_message':
-              'El código que ingresó es incorrecto o ha expirado.',
+              'El código que ingresó es incorrecto.',
           'wait': 'Espere',
           'no_internet': 'Sin internet',
           'check_internet': 'Por favor, revise su conexión a internet.',

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -249,6 +249,14 @@ class AuthController extends GetxController {
         snackPosition: SnackPosition.BOTTOM,
       );
       return;
+    } else if (otpExpiration.value <= 0) {
+      otpError.value = 'otp_expired_message'.tr;
+      Get.snackbar(
+        'otp_expired'.tr,
+        otpError.value,
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
     } else {
       otpError.value = '';
     }
@@ -293,7 +301,11 @@ class AuthController extends GetxController {
         String errorMessage = 'failed_to_verify_otp'.tr;
 
         if (e.code == 400 || e.code == 404) {
-          errorMessage = 'incorrect_otp_message'.tr;
+          if (otpExpiration.value <= 0) {
+            errorMessage = 'otp_expired_message'.tr;
+          } else {
+            errorMessage = 'incorrect_otp_message'.tr;
+          }
         } else if (e.code == 401) {
           errorMessage = 'unauthorized'.tr;
         } else if (e.code == 500) {


### PR DESCRIPTION
## Summary
- refine OTP verification logic to differentiate between incorrect and expired OTPs
- show OTP expired errors immediately when user tries an expired code
- update translations for clearer messaging

## Testing
- `flutter test ./test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684422be3d28832d9e5374f5e22ef0ea