### PR TITLE
Fix OTP error messaging

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -307,7 +307,11 @@ class AuthController extends GetxController {
             errorMessage = 'incorrect_otp_message'.tr;
           }
         } else if (e.code == 401) {
-          errorMessage = 'unauthorized'.tr;
+          if (otpExpiration.value <= 0) {
+            errorMessage = 'otp_expired_message'.tr;
+          } else {
+            errorMessage = 'incorrect_otp_message'.tr;
+          }
         } else if (e.code == 500) {
           errorMessage = 'server_error'.tr;
         }


### PR DESCRIPTION
## Summary
- handle 401 responses when verifying OTPs by showing invalid or expired code

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6844250b3ac8832d909ebc21f702bc07