### PR TITLE
Fix OTP session verification

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -282,7 +282,7 @@ class AuthController extends GetxController {
         return;
       }
       try {
-        await account.updateMagicURLSession(
+        await account.createSession(
           userId: userId!,
           secret: otp,
         );


### PR DESCRIPTION
## Summary
- correct OTP verification by using `createSession` instead of `updateMagicURLSession`

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68442715f8b4832db727a65902ca1bd9