### PR TITLE
Handle OTP verification rate limit

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -312,6 +312,8 @@ class AuthController extends GetxController {
           } else {
             errorMessage = 'incorrect_otp_message'.tr;
           }
+        } else if (e.code == 429) {
+          errorMessage = 'too_many_requests'.tr;
         } else if (e.code == 500) {
           errorMessage = 'server_error'.tr;
         }


### PR DESCRIPTION
## Summary
- show 'too many requests' error when verifying OTP

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844299f17d0832dbc53c1212597e0de