### PR TITLE
Fix multi-account session management

### DIFF
--- a/lib/controllers/multi_account_controller.dart
+++ b/lib/controllers/multi_account_controller.dart
@@ -1,6 +1,7 @@
 import 'dart:convert';
 import 'package:get/get.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import 'auth_controller.dart';
 
 class AccountInfo {
   final String userId;
@@ -89,6 +90,9 @@ class MultiAccountController extends GetxController {
     }
     activeAccountId.value = account.userId;
     await _saveActiveAccount();
+    try {
+      Get.find<AuthController>().client.setSession(account.sessionId);
+    } catch (_) {}
   }
 
   Future<void> removeAccount(String userId) async {
@@ -102,9 +106,13 @@ class MultiAccountController extends GetxController {
 
   Future<void> switchAccount(String userId) async {
     if (activeAccountId.value == userId) return;
-    if (_findById(userId) != null) {
+    final account = _findById(userId);
+    if (account != null) {
       activeAccountId.value = userId;
       await _saveActiveAccount();
+      try {
+        Get.find<AuthController>().client.setSession(account.sessionId);
+      } catch (_) {}
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure each account stores its session id
- update client session when adding or switching accounts
- grab current session id when restoring accounts
- create a new session during OTP verification and activate it

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684443dc529c832db45434235506a056