### PR TITLE
Add account flag for sign-in cancel

### DIFF
--- a/lib/pages/account_switcher_page.dart
+++ b/lib/pages/account_switcher_page.dart
@@ -1,9 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/multi_account_controller.dart';
-import '../controllers/auth_controller.dart';
-
-class AccountSwitcherPage extends GetView<MultiAccountController> {
   const AccountSwitcherPage({super.key});
 
   @override
@@ -40,7 +37,10 @@ class AccountSwitcherPage extends GetView<MultiAccountController> {
               ListTile(
                 leading: const Icon(Icons.add),
                 title: Text('add_account'.tr),
-                onTap: () => Get.offAllNamed('/'),
+                onTap: () => Get.offAllNamed(
+                  '/',
+                  arguments: {'fromAddAccount': true},
+                ),
               )
             ],
           )),

--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -8,8 +8,16 @@ class SignInPage extends GetView<AuthController> {
 
   @override
   Widget build(BuildContext context) {
+    final fromAddAccount = Get.arguments?["fromAddAccount"] ?? false;
     return Scaffold(
       appBar: AppBar(
+        leading: fromAddAccount
+            ? IconButton(
+                icon: const Icon(Icons.close),
+                tooltip: 'cancel'.tr,
+                onPressed: () => Get.offAllNamed('/accounts'),
+              )
+            : null,
         title: Text('email_sign_in'.tr),
       ),
       body: ResponsiveLayout(


### PR DESCRIPTION
## Summary
- pass `fromAddAccount` flag from the account switcher
- show cancel button in sign-in when arriving from add account

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684454a6dc30832db69d0edd005ce790