### PR TITLE
Fix account switcher page

### DIFF
--- a/lib/pages/account_switcher_page.dart
+++ b/lib/pages/account_switcher_page.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/multi_account_controller.dart';
+import '../controllers/auth_controller.dart';
+
+class AccountSwitcherPage extends GetView<MultiAccountController> {
   const AccountSwitcherPage({super.key});
 
   @override


### PR DESCRIPTION
## Summary
- restore missing `AccountSwitcherPage` class definition and import

## Testing
- `dart format lib/pages/account_switcher_page.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684456db0e0c832d9d85c9b65e9ab764