### PR TITLE
Improve cleanup and add account deletion option

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -82,9 +82,9 @@ class AuthController extends GetxController {
 
   @override
   void onClose() {
-    emailController.clear();
-    otpController.clear();
-    usernameController.clear();
+    emailController.dispose();
+    otpController.dispose();
+    usernameController.dispose();
     usernameText.value = '';
     emailError.value = '';
     otpError.value = '';
@@ -270,6 +270,17 @@ class AuthController extends GetxController {
       return;
     } else {
       otpError.value = '';
+    }
+
+    // Check network connectivity
+    var connectivityResult = await Connectivity().checkConnectivity();
+    if (connectivityResult == ConnectivityResult.none) {
+      Get.snackbar(
+        'no_internet'.tr,
+        'check_internet'.tr,
+        snackPosition: SnackPosition.BOTTOM,
+      );
+      return;
     }
 
     isLoading.value = true;
@@ -573,6 +584,7 @@ class AuthController extends GetxController {
       ),
       barrierDismissible: false,
     );
+    textController.dispose();
   }
 
   Future<bool> _checkUsernameAvailability(String name) async {

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -50,6 +50,32 @@ class _SettingsPageState extends State<SettingsPage> {
             subtitle: Text(version),
           ),
           ListTile(
+            title: Text('delete_account'.tr),
+            onTap: () async {
+              final confirm = await showDialog<bool>(
+                context: context,
+                builder: (context) => AlertDialog(
+                  title: Text('delete_account'.tr),
+                  content: Text('delete_account_confirmation'.tr),
+                  actions: [
+                    TextButton(
+                      onPressed: () => Navigator.pop(context, false),
+                      child: Text('cancel'.tr),
+                    ),
+                    ElevatedButton(
+                      onPressed: () => Navigator.pop(context, true),
+                      child: Text('delete'.tr),
+                    )
+                  ],
+                ),
+              );
+              if (confirm ?? false) {
+                Get.closeAllSnackbars();
+                await Get.find<AuthController>().deleteUserAccount();
+              }
+            },
+          ),
+          ListTile(
             title: Text('logout'.tr),
             onTap: () async {
               final confirm = await showDialog<bool>(


### PR DESCRIPTION
## Summary
- dispose text controllers in `AuthController`
- validate connectivity before verifying OTP
- dispose temporary username dialog controller
- add a delete account option in settings

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445b78e450832dbe11d9934c700ff8