### PR TITLE
Add navigation for account manager

### DIFF
--- a/lib/pages/account_switcher_page.dart
+++ b/lib/pages/account_switcher_page.dart
@@ -10,7 +10,18 @@ class AccountSwitcherPage extends GetView<MultiAccountController> {
   Widget build(BuildContext context) {
     final auth = Get.find<AuthController>();
     return Scaffold(
-      appBar: AppBar(title: Text('manage_accounts'.tr)),
+      appBar: AppBar(
+        leading: Navigator.canPop(context)
+            ? IconButton(
+                icon: const Icon(Icons.arrow_back),
+                onPressed: () => Get.back(),
+              )
+            : IconButton(
+                icon: const Icon(Icons.close),
+                onPressed: () => Get.offAllNamed('/home'),
+              ),
+        title: Text('manage_accounts'.tr),
+      ),
       body: Obx(() => ListView(
             children: [
               ...controller.accounts.map(
@@ -31,6 +42,7 @@ class AccountSwitcherPage extends GetView<MultiAccountController> {
                   onTap: () async {
                     await controller.switchAccount(a.userId);
                     await auth.checkExistingSession();
+                    await Get.offAllNamed('/home');
                   },
                   onLongPress: () async {
                     await controller.removeAccount(a.userId);


### PR DESCRIPTION
## Summary
- add close/back button to account switcher page
- return to home after selecting an account

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68445ea1ded4832dbb43965326305d85