### PR TITLE
Fix sign in button stuck in loading state

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -425,6 +425,21 @@ class AuthController extends GetxController {
     cancelTimers();
   }
 
+  /// Reset all sign in related state back to defaults. Useful when navigating
+  /// to the sign in page from the account switcher so leftover values don't
+  /// disable the form.
+  void resetSignInState() {
+    clearControllers();
+    isLoading.value = false;
+    isOTPSent.value = false;
+    emailError.value = '';
+    otpError.value = '';
+    usernameError.value = '';
+    canResendOTP.value = true;
+    resendCooldown.value = resendCooldownDuration;
+    otpExpiration.value = otpExpirationDuration;
+  }
+
   Future<bool> ensureUsername() async {
     logger.i("[Auth] ensureUsername: Called. Current local userId: ${this.userId}, Current local username: ${username.value}");
 

--- a/lib/pages/account_switcher_page.dart
+++ b/lib/pages/account_switcher_page.dart
@@ -40,10 +40,13 @@ class AccountSwitcherPage extends GetView<MultiAccountController> {
               ListTile(
                 leading: const Icon(Icons.add),
                 title: Text('add_account'.tr),
-                onTap: () => Get.offAllNamed(
-                  '/',
-                  arguments: {'fromAddAccount': true},
-                ),
+                onTap: () {
+                  auth.resetSignInState();
+                  Get.offAllNamed(
+                    '/',
+                    arguments: {'fromAddAccount': true},
+                  );
+                },
               )
             ],
           )),


### PR DESCRIPTION
## Summary
- add a `resetSignInState` helper to clear sign-in related values
- call `resetSignInState` before navigating to add a new account

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68445ef36bec832d9707a110b4405174