### PR TITLE
Fix account switcher to update username

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -878,6 +878,14 @@ class AuthController extends GetxController {
     }
   }
 
+  Future<void> applyAccount(AccountInfo account) async {
+    username.value = account.username;
+    profilePictureUrl.value = account.profilePictureUrl;
+    userId = account.userId;
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('username', account.username);
+  }
+
   Future<void> logout() async {
     isLoading.value = true;
     try {

--- a/lib/pages/account_switcher_page.dart
+++ b/lib/pages/account_switcher_page.dart
@@ -41,7 +41,7 @@ class AccountSwitcherPage extends GetView<MultiAccountController> {
                       : null,
                   onTap: () async {
                     await controller.switchAccount(a.userId);
-                    await auth.checkExistingSession();
+                    await auth.applyAccount(a);
                     await Get.offAllNamed('/home');
                   },
                   onLongPress: () async {


### PR DESCRIPTION
## Summary
- implement `applyAccount` in `AuthController`
- update account switcher to apply selected account

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684493ef7b04832da057b35781f95946