### PR TITLE
Add sliver app bar demo

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,7 @@ import 'pages/set_username_page.dart';
 import 'pages/profile_page.dart';
 import 'pages/settings_page.dart';
 import 'pages/account_switcher_page.dart';
+import 'pages/sliver_sample_page.dart';
 import 'themes/app_theme.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -65,6 +66,11 @@ class MyApp extends StatelessWidget {
             GetPage(
               name: '/accounts',
               page: () => const AccountSwitcherPage(),
+              binding: AuthBinding(),
+            ),
+            GetPage(
+              name: '/sliver',
+              page: () => const SliverSamplePage(),
               binding: AuthBinding(),
             ),
           ],

--- a/lib/pages/sliver_sample_page.dart
+++ b/lib/pages/sliver_sample_page.dart
@@ -1,0 +1,28 @@
+import 'package:flutter/material.dart';
+import '../widgets/sample_sliver_app_bar.dart';
+
+class SliverSamplePage extends StatelessWidget {
+  const SliverSamplePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return DefaultTabController(
+      length: 5,
+      child: Scaffold(
+        drawer: const Drawer(child: Center(child: Text('Menu'))),
+        body: CustomScrollView(
+          slivers: [
+            const SampleSliverAppBar(),
+            SliverFillRemaining(
+              child: Container(
+                color: Theme.of(context).colorScheme.secondaryContainer,
+                alignment: Alignment.center,
+                child: const Text('Scroll to see sticky header'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/widgets/sample_sliver_app_bar.dart
+++ b/lib/widgets/sample_sliver_app_bar.dart
@@ -1,0 +1,99 @@
+import 'package:flutter/material.dart';
+
+class SampleSliverAppBar extends StatelessWidget {
+  const SampleSliverAppBar({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final iconColor = colorScheme.primary.withOpacity(0.6);
+
+    return SliverAppBar(
+      pinned: true,
+      expandedHeight: 200,
+      collapsedHeight: kToolbarHeight,
+      automaticallyImplyLeading: false,
+      leading: Builder(
+        builder: (context) => IconButton(
+          icon: const Icon(Icons.menu),
+          onPressed: () => Scaffold.of(context).openDrawer(),
+        ),
+      ),
+      flexibleSpace: FlexibleSpaceBar(
+        background: Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+          alignment: Alignment.bottomCenter,
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  GestureDetector(
+                    onTap: () => ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Profile')),
+                    ),
+                    child: const CircleAvatar(radius: 18),
+                  ),
+                  Container(
+                    width: 56,
+                    height: 24,
+                    decoration: BoxDecoration(
+                      color: colorScheme.primary.withOpacity(0.2),
+                      borderRadius: BorderRadius.circular(12),
+                    ),
+                    alignment: Alignment.center,
+                    child: Icon(Icons.all_inclusive, color: iconColor),
+                  ),
+                  IconButton(
+                    icon: Icon(Icons.settings, color: iconColor),
+                    onPressed: () => ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Settings')),
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 8),
+              SizedBox(
+                height: 48,
+                child: ListView.builder(
+                  scrollDirection: Axis.horizontal,
+                  itemCount: 9,
+                  itemBuilder: (context, index) => Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: IconButton(
+                      icon: Icon(
+                        index.isEven ? Icons.circle : Icons.star,
+                        color: iconColor,
+                      ),
+                      tooltip: 'Details',
+                      onPressed: () =>
+                          ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('Item tapped')),
+                      ),
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(height: 8),
+              Material(
+                elevation: 1,
+                color: colorScheme.surface,
+                child: const TabBar(
+                  isScrollable: false,
+                  tabs: [
+                    Tab(text: 'Home'),
+                    Tab(text: 'Feed'),
+                    Tab(text: 'Events'),
+                    Tab(text: 'Preds'),
+                    Tab(text: 'Msgs'),
+                  ],
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- demonstrate a sliver app bar with three rows in a `SampleSliverAppBar` widget
- create `SliverSamplePage` that shows the pinned sliver header
- register a new `/sliver` route

## Testing
- `flutter analyze`
- `flutter test` *(fails: NotInitializedError)*

------
https://chatgpt.com/codex/tasks/task_e_68449c4cc9e0832d956f79b2cbd3d8b8