### PR TITLE
Add bottom navigation bar

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -1,11 +1,18 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/auth_controller.dart';
-import '../controllers/theme_controller.dart';  // Import the ThemeController
+import '../controllers/theme_controller.dart'; // Import the ThemeController
 import '../widgets/responsive_layout.dart';
 
-class HomePage extends StatelessWidget {
+class HomePage extends StatefulWidget {
   const HomePage({super.key});
+
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  int _selectedIndex = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -22,9 +29,10 @@ class HomePage extends StatelessWidget {
             Obx(
               () => UserAccountsDrawerHeader(
                 currentAccountPicture: CircleAvatar(
-                  backgroundImage: authController.profilePictureUrl.value.isNotEmpty
-                      ? NetworkImage(authController.profilePictureUrl.value)
-                      : null,
+                  backgroundImage:
+                      authController.profilePictureUrl.value.isNotEmpty
+                          ? NetworkImage(authController.profilePictureUrl.value)
+                          : null,
                   child: authController.profilePictureUrl.value.isEmpty
                       ? const Icon(Icons.person, size: 40)
                       : null,
@@ -68,14 +76,57 @@ class HomePage extends StatelessWidget {
                 icon: Icon(themeController.isDarkMode.value
                     ? Icons.light_mode
                     : Icons.dark_mode),
-                onPressed: themeController.toggleTheme, // Toggle the theme on press
+                onPressed:
+                    themeController.toggleTheme, // Toggle the theme on press
               )),
         ],
       ),
       body: ResponsiveLayout(
-        mobile: (_) => _buildContent(context, MediaQuery.of(context).size.width * 0.9),
+        mobile: (_) =>
+            _buildContent(context, MediaQuery.of(context).size.width * 0.9),
         tablet: (_) => _buildContent(context, 500),
         desktop: (_) => _buildContent(context, 600),
+      ),
+      bottomNavigationBar: BottomNavigationBar(
+        currentIndex: _selectedIndex,
+        type: BottomNavigationBarType.fixed,
+        onTap: (index) {
+          setState(() {
+            _selectedIndex = index;
+          });
+        },
+        items: const [
+          BottomNavigationBarItem(
+            icon: Icon(Icons.home_outlined),
+            activeIcon: Icon(Icons.home),
+            label: 'Home',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.dashboard_outlined),
+            activeIcon: Icon(Icons.dashboard),
+            label: 'Dashboard',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.search_outlined),
+            activeIcon: Icon(Icons.search),
+            label: 'Search',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.favorite_outline),
+            activeIcon: Icon(Icons.favorite),
+            label: 'Match',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.notifications_none),
+            activeIcon: Icon(Icons.notifications),
+            label: 'Notifications',
+          ),
+          BottomNavigationBarItem(
+            icon: Icon(Icons.storefront_outlined),
+            activeIcon: Icon(Icons.storefront),
+            label: 'Marketplace',
+          ),
+        ],
       ),
     );
   }
@@ -89,19 +140,22 @@ class HomePage extends StatelessWidget {
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-          Obx(() => Text(
-                'signed_in_as'.trParams({'username': authController.username.value}),
-                style: const TextStyle(fontSize: 24),
-                textAlign: TextAlign.center,
-              )),
-          const SizedBox(height: 20),
-          ElevatedButton(
-            onPressed: () async {
-              Get.closeAllSnackbars();
-              await Get.find<AuthController>().logout();
-            },
-            child: Text('logout'.tr),
-          ),
+            Obx(() => Text(
+                  'signed_in_as'
+                      .trParams({'username': authController.username.value}),
+                  style: const TextStyle(fontSize: 24),
+                  textAlign: TextAlign.center,
+                )),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () async {
+                Get.closeAllSnackbars();
+                await Get.find<AuthController>().logout();
+              },
+              child: Text('logout'.tr),
+            ),
+            const SizedBox(height: 8),
+            Text('Tab $_selectedIndex'),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- convert `HomePage` to a `StatefulWidget`
- track the active bottom navigation index
- render a `BottomNavigationBar` with six destinations
- show the current tab index in the body

## Testing
- `flutter test` *(fails: Counter increments smoke test)*

------
https://chatgpt.com/codex/tasks/task_e_68449e45c73c832dbef8e2aada028a12