### PR TITLE
Improve Sign-In Form UI and Add Responsive Navigation

### DIFF
--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/auth_controller.dart';
 import '../widgets/responsive_layout.dart';
+import '../widgets/animated_form_field.dart';
 
 class SignInPage extends StatefulWidget {
   const SignInPage({super.key});
@@ -66,24 +67,16 @@ class _SignInPageState extends State<SignInPage> {
           textAlign: TextAlign.center,
         ),
         const SizedBox(height: 20),
-        TextField(
+        AnimatedFormField(
           controller: controller.emailController,
-          decoration: InputDecoration(
-            labelText: 'email'.tr,
-            border: const OutlineInputBorder(),
-          ),
+          label: 'email'.tr,
+          prefixIcon: Icons.email_outlined,
           keyboardType: TextInputType.emailAddress,
+          errorText: controller.emailError.value.isEmpty
+              ? null
+              : controller.emailError.value,
           onChanged: (_) => controller.emailError.value = '',
         ),
-        Obx(() => controller.emailError.value.isEmpty
-            ? const SizedBox.shrink()
-            : Padding(
-                padding: const EdgeInsets.only(top: 8),
-                child: Text(
-                  controller.emailError.value,
-                  style: const TextStyle(color: Colors.red),
-                ),
-              )),
         const SizedBox(height: 20),
         SizedBox(
           width: double.infinity,
@@ -142,24 +135,16 @@ class _SignInPageState extends State<SignInPage> {
                 style: const TextStyle(color: Colors.red),
               )),
           const SizedBox(height: 10),
-          TextField(
+          AnimatedFormField(
             controller: controller.otpController,
-            decoration: InputDecoration(
-              labelText: 'otp'.tr,
-              border: const OutlineInputBorder(),
-            ),
+            label: 'otp'.tr,
+            prefixIcon: Icons.lock_outlined,
             keyboardType: TextInputType.number,
+            errorText: controller.otpError.value.isEmpty
+                ? null
+                : controller.otpError.value,
             onChanged: (_) => controller.otpError.value = '',
           ),
-          Obx(() => controller.otpError.value.isEmpty
-              ? const SizedBox.shrink()
-              : Padding(
-                  padding: const EdgeInsets.only(top: 8),
-                  child: Text(
-                    controller.otpError.value,
-                    style: const TextStyle(color: Colors.red),
-                  ),
-                )),
           const SizedBox(height: 20),
           SizedBox(
             width: double.infinity,

--- a/lib/widgets/adaptive_navigation.dart
+++ b/lib/widgets/adaptive_navigation.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'responsive_layout.dart';
+
+class AdaptiveNavigation extends StatelessWidget {
+  final int selectedIndex;
+  final Function(int) onDestinationSelected;
+  final Widget body;
+
+  const AdaptiveNavigation({
+    super.key,
+    required this.selectedIndex,
+    required this.onDestinationSelected,
+    required this.body,
+  });
+
+  static const destinations = [
+    NavigationDestination(
+        icon: Icon(Icons.home_outlined),
+        selectedIcon: Icon(Icons.home),
+        label: 'Home'),
+    NavigationDestination(
+        icon: Icon(Icons.dashboard_outlined),
+        selectedIcon: Icon(Icons.dashboard),
+        label: 'Dashboard'),
+    NavigationDestination(
+        icon: Icon(Icons.search_outlined),
+        selectedIcon: Icon(Icons.search),
+        label: 'Search'),
+    NavigationDestination(
+        icon: Icon(Icons.favorite_outline),
+        selectedIcon: Icon(Icons.favorite),
+        label: 'Match'),
+    NavigationDestination(
+        icon: Icon(Icons.notifications_none),
+        selectedIcon: Icon(Icons.notifications),
+        label: 'Notifications'),
+    NavigationDestination(
+        icon: Icon(Icons.storefront_outlined),
+        selectedIcon: Icon(Icons.storefront),
+        label: 'Marketplace'),
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return ResponsiveLayout(
+      mobile: (_) => _buildMobileLayout(context),
+      tablet: (_) => _buildTabletLayout(context),
+      desktop: (_) => _buildDesktopLayout(context),
+    );
+  }
+
+  Widget _buildMobileLayout(BuildContext context) {
+    return Scaffold(
+      body: body,
+      bottomNavigationBar: NavigationBar(
+        selectedIndex: selectedIndex,
+        onDestinationSelected: onDestinationSelected,
+        destinations: destinations,
+        animationDuration: const Duration(milliseconds: 300),
+        labelBehavior: NavigationDestinationLabelBehavior.onlyShowSelected,
+      ),
+    );
+  }
+
+  Widget _buildTabletLayout(BuildContext context) {
+    return Scaffold(
+      body: Row(
+        children: [
+          NavigationRail(
+            selectedIndex: selectedIndex,
+            onDestinationSelected: onDestinationSelected,
+            extended: MediaQuery.of(context).size.width > 800,
+            minWidth: 72,
+            minExtendedWidth: 200,
+            destinations: destinations
+                .map((dest) => NavigationRailDestination(
+                      icon: dest.icon,
+                      selectedIcon: dest.selectedIcon,
+                      label: Text(dest.label),
+                    ))
+                .toList(),
+          ),
+          const VerticalDivider(thickness: 1, width: 1),
+          Expanded(child: body),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDesktopLayout(BuildContext context) {
+    return Scaffold(
+      body: Row(
+        children: [
+          Container(
+            width: 280,
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              border: Border(
+                  right: BorderSide(color: Theme.of(context).dividerColor)),
+            ),
+            child: Column(
+              children: [
+                Container(
+                  padding: const EdgeInsets.all(24),
+                  child: Row(
+                    children: [
+                      Icon(Icons.star,
+                          size: 32,
+                          color: Theme.of(context).colorScheme.primary),
+                      const SizedBox(width: 12),
+                      Text('StarChat',
+                          style: Theme.of(context).textTheme.headlineSmall),
+                    ],
+                  ),
+                ),
+                const Divider(),
+                Expanded(
+                  child: ListView.builder(
+                    itemCount: destinations.length,
+                    itemBuilder: (context, index) {
+                      final dest = destinations[index];
+                      final isSelected = index == selectedIndex;
+                      return Container(
+                        margin: const EdgeInsets.symmetric(
+                            horizontal: 12, vertical: 4),
+                        child: ListTile(
+                          leading: isSelected ? dest.selectedIcon : dest.icon,
+                          title: Text(dest.label),
+                          selected: isSelected,
+                          shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(12)),
+                          onTap: () => onDestinationSelected(index),
+                        ),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Expanded(child: body),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/widgets/animated_form_field.dart
+++ b/lib/widgets/animated_form_field.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+
+class AnimatedFormField extends StatefulWidget {
+  final TextEditingController controller;
+  final String label;
+  final String? hint;
+  final IconData? prefixIcon;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+  final String? Function(String?)? validator;
+  final void Function(String)? onChanged;
+  final String? errorText;
+
+  const AnimatedFormField({
+    super.key,
+    required this.controller,
+    required this.label,
+    this.hint,
+    this.prefixIcon,
+    this.obscureText = false,
+    this.keyboardType,
+    this.validator,
+    this.onChanged,
+    this.errorText,
+  });
+
+  @override
+  State<AnimatedFormField> createState() => _AnimatedFormFieldState();
+}
+
+class _AnimatedFormFieldState extends State<AnimatedFormField>
+    with TickerProviderStateMixin {
+  late AnimationController _focusController;
+  late AnimationController _errorController;
+  late Animation<double> _focusAnimation;
+  late Animation<double> _errorShakeAnimation;
+
+  final FocusNode _focusNode = FocusNode();
+  bool _isFocused = false;
+  bool _hasError = false;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _focusController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+
+    _errorController = AnimationController(
+      duration: const Duration(milliseconds: 500),
+      vsync: this,
+    );
+
+    _focusAnimation = Tween<double>(begin: 1.0, end: 1.02).animate(
+      CurvedAnimation(parent: _focusController, curve: Curves.easeInOut),
+    );
+
+    _errorShakeAnimation = Tween<double>(begin: 0.0, end: 1.0).animate(
+      CurvedAnimation(parent: _errorController, curve: Curves.elasticIn),
+    );
+
+    _focusNode.addListener(() {
+      setState(() {
+        _isFocused = _focusNode.hasFocus;
+        if (_isFocused) {
+          _focusController.forward();
+        } else {
+          _focusController.reverse();
+        }
+      });
+    });
+  }
+
+  @override
+  void didUpdateWidget(AnimatedFormField oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.errorText != null && oldWidget.errorText == null) {
+      _showError();
+    } else if (widget.errorText == null && oldWidget.errorText != null) {
+      _hideError();
+    }
+  }
+
+  void _showError() {
+    setState(() => _hasError = true);
+    _errorController.forward().then((_) {
+      _errorController.reverse();
+    });
+  }
+
+  void _hideError() {
+    setState(() => _hasError = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedBuilder(
+      animation: Listenable.merge([_focusAnimation, _errorShakeAnimation]),
+      builder: (context, child) {
+        return Transform.scale(
+          scale: _focusAnimation.value,
+          child: Transform.translate(
+            offset: _hasError
+                ? Offset(
+                    _errorShakeAnimation.value *
+                        10 *
+                        (1 - _errorShakeAnimation.value),
+                    0)
+                : Offset.zero,
+            child: Container(
+              margin: const EdgeInsets.only(bottom: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  AnimatedContainer(
+                    duration: const Duration(milliseconds: 200),
+                    decoration: BoxDecoration(
+                      borderRadius: BorderRadius.circular(12),
+                      boxShadow: _isFocused
+                          ? [
+                              BoxShadow(
+                                color: Theme.of(context)
+                                    .colorScheme
+                                    .primary
+                                    .withOpacity(0.3),
+                                blurRadius: 8,
+                                offset: const Offset(0, 2),
+                              ),
+                            ]
+                          : [],
+                    ),
+                    child: TextFormField(
+                      controller: widget.controller,
+                      focusNode: _focusNode,
+                      obscureText: widget.obscureText,
+                      keyboardType: widget.keyboardType,
+                      onChanged: widget.onChanged,
+                      decoration: InputDecoration(
+                        labelText: widget.label,
+                        hintText: widget.hint,
+                        prefixIcon: widget.prefixIcon != null
+                            ? AnimatedSwitcher(
+                                duration: const Duration(milliseconds: 200),
+                                child: Icon(
+                                  widget.prefixIcon,
+                                  color: _isFocused
+                                      ? Theme.of(context).colorScheme.primary
+                                      : Theme.of(context)
+                                          .colorScheme
+                                          .onSurfaceVariant,
+                                ),
+                              )
+                            : null,
+                        border: OutlineInputBorder(
+                          borderRadius: BorderRadius.circular(12),
+                          borderSide: BorderSide.none,
+                        ),
+                        filled: true,
+                        fillColor: _isFocused
+                            ? Theme.of(context)
+                                .colorScheme
+                                .primaryContainer
+                                .withOpacity(0.3)
+                            : Theme.of(context)
+                                .colorScheme
+                                .surfaceVariant
+                                .withOpacity(0.5),
+                        errorText: null,
+                      ),
+                    ),
+                  ),
+                  AnimatedSize(
+                    duration: const Duration(milliseconds: 200),
+                    child: widget.errorText != null
+                        ? Container(
+                            margin: const EdgeInsets.only(top: 8, left: 12),
+                            child: Row(
+                              children: [
+                                Icon(
+                                  Icons.error_outline,
+                                  size: 16,
+                                  color: Theme.of(context).colorScheme.error,
+                                ),
+                                const SizedBox(width: 8),
+                                Expanded(
+                                  child: Text(
+                                    widget.errorText!,
+                                    style: Theme.of(context)
+                                        .textTheme
+                                        .bodySmall
+                                        ?.copyWith(
+                                          color: Theme.of(context)
+                                              .colorScheme
+                                              .error,
+                                        ),
+                                  ),
+                                ),
+                              ],
+                            ),
+                          )
+                        : const SizedBox.shrink(),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _focusController.dispose();
+    _errorController.dispose();
+    _focusNode.dispose();
+    super.dispose();
+  }
+}


### PR DESCRIPTION
## Summary
- add AnimatedFormField widget for subtle field focus and error animations
- create AdaptiveNavigation widget for mobile/desktop/tablet layouts
- update SignInPage to use AnimatedFormField for email and OTP inputs

## Testing
- `dart format lib/widgets/animated_form_field.dart lib/widgets/adaptive_navigation.dart lib/pages/sign_in_page.dart`
- `flutter test` *(fails: Resolving dependencies...)*

------
https://chatgpt.com/codex/tasks/task_e_6845ccafc294832db00b3d0e7d51bd68