### PR TITLE
Implement Watchlist persistence and tests

### DIFF
--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -934,7 +934,10 @@ class AuthController extends GetxController {
 
   Future<void> logout() async {
     isLoading.value = true;
+    String? uid;
     try {
+      final session = await account.get();
+      uid = session.$id;
       await account.deleteSessions();
     } catch (e) {
       logger.e('Error deleting Appwrite session(s)', error: e);
@@ -942,6 +945,9 @@ class AuthController extends GetxController {
       try {
         final prefs = await SharedPreferences.getInstance();
         await prefs.remove('username');
+        if (uid != null) {
+          await prefs.remove('watchlist_items_$uid');
+        }
       } catch (e) {
         logger.e('Error clearing cached username from SharedPreferences',
             error: e);

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -25,6 +25,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   @override
   void initState() {
     super.initState();
+    Get.put(WatchlistController(), permanent: true);
     _initializeAnimations();
   }
 

--- a/test/watchlist_widget_test.dart
+++ b/test/watchlist_widget_test.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:myapp/widgets/complete_enhanced_watchlist.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+
+class TestAuthController extends AuthController {
+  final String uid;
+  TestAuthController(this.uid);
+  @override
+  void onInit() {
+    userId = uid;
+  }
+  @override
+  Future<void> checkExistingSession() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    Get.testMode = true;
+  });
+
+  testWidgets('Adding an item', (tester) async {
+    Get.put<AuthController>(TestAuthController('user1'));
+    final controller = Get.put(WatchlistController(testing: true));
+    await tester.pump();
+
+    await controller.addItem(WatchlistItem(
+      id: '1',
+      name: 'Test Item',
+      count: 0,
+      color: Colors.red,
+      icon: Icons.star,
+    ));
+
+    expect(controller.items.length, 1);
+  });
+
+  testWidgets('Remove and restore via Undo', (tester) async {
+    Get.put<AuthController>(TestAuthController('user1'));
+    final controller = Get.put(WatchlistController(testing: true));
+
+    final item = WatchlistItem(
+      id: '1',
+      name: 'Undo Item',
+      count: 0,
+      color: Colors.blue,
+      icon: Icons.star,
+    );
+    await controller.addItem(item);
+    expect(controller.items.length, 1);
+
+    await controller.removeItem(item.id);
+    expect(controller.items.isEmpty, true);
+
+    // Simulate undo by adding item back
+    await controller.addItem(item);
+    expect(controller.items.length, 1);
+  });
+
+  testWidgets('Persistence across restarts', (tester) async {
+    Get.put<AuthController>(TestAuthController('user1'));
+    var controller = Get.put(WatchlistController(testing: true));
+
+    final item = WatchlistItem(
+      id: '1',
+      name: 'Persisted',
+      count: 0,
+      color: Colors.green,
+      icon: Icons.star,
+    );
+    await controller.addItem(item);
+
+    // Recreate controller to simulate restart
+    Get.delete<WatchlistController>();
+    controller = Get.put(WatchlistController(testing: true));
+    await tester.pump();
+
+    expect(controller.items.length, 1);
+    expect(controller.items.first.name, 'Persisted');
+  });
+}

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -11,20 +11,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:myapp/main.dart';
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-    // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
-
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
-
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
-    await tester.pump();
-
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
-  }, skip: true);
+  testWidgets('basic widget test', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SizedBox()));
+    expect(find.byType(SizedBox), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- manage `WatchlistController` lifecycle from `HomePage`
- move controller lookup to `Get.find`
- store watchlist data per-user in SharedPreferences
- clear watchlist data on logout
- show errors for CRUD failures
- add widget tests for controller functionality

## Testing
- `flutter test -j 1` *(fails: Multiple exceptions)*

------
https://chatgpt.com/codex/tasks/task_e_6846c0a42238832d96cf315d049e9eca