### PR TITLE
Add chat rooms feature

### DIFF
--- a/lib/bindings/auth_binding.dart
+++ b/lib/bindings/auth_binding.dart
@@ -1,5 +1,6 @@
 import 'package:get/get.dart';
 import '../controllers/auth_controller.dart';
+import '../controllers/chat_controller.dart';
 
 class AuthBinding extends Bindings {
   @override
@@ -8,5 +9,8 @@ class AuthBinding extends Bindings {
     // entire application lifecycle to preserve state such as
     // the `justLoggedOut` flag during navigation.
     Get.put<AuthController>(AuthController(), permanent: true);
+    if (!Get.isRegistered<ChatController>()) {
+      Get.put(ChatController(), permanent: true);
+    }
   }
 }

--- a/lib/controllers/chat_controller.dart
+++ b/lib/controllers/chat_controller.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:logger/logger.dart';
+
+import '../models/chat_room.dart';
+import 'auth_controller.dart';
+
+class ChatController extends GetxController {
+  final AuthController _auth = Get.find<AuthController>();
+  final logger = Logger();
+
+  final RxList<ChatRoom> rashiRooms = <ChatRoom>[].obs;
+  final RxList<ChatRoom> joinedRooms = <ChatRoom>[].obs;
+  final Rx<ChatRoom?> currentRoom = Rx<ChatRoom?>(null);
+
+  final RxBool isLoading = false.obs;
+  final RxString error = ''.obs;
+
+  @override
+  void onInit() {
+    super.onInit();
+    initializeChatRooms();
+  }
+
+  Future<void> initializeChatRooms() async {
+    isLoading.value = true;
+    error.value = '';
+    try {
+      await _loadRashiRooms();
+      logger.i('Chat rooms loaded: \${rashiRooms.length}');
+    } catch (e) {
+      error.value = e.toString();
+      logger.e('Error loading chat rooms', error: e);
+      _createMockRashiRooms();
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> _loadRashiRooms() async {
+    final dbId = dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB';
+    const collectionId = 'chat_rooms';
+    final result = await _auth.databases.listDocuments(
+      databaseId: dbId,
+      collectionId: collectionId,
+      queries: [
+        Query.equal('type', 'rashi'),
+        Query.equal('is_active', true),
+        Query.orderAsc('order'),
+      ],
+    );
+    final rooms =
+        result.documents.map((doc) => ChatRoom.fromJson(doc.data)).toList();
+    rashiRooms.assignAll(rooms);
+  }
+
+  void _createMockRashiRooms() {
+    rashiRooms.assignAll([
+      ChatRoom(
+        id: '1',
+        name: 'Aries Rashi',
+        type: 'rashi',
+        symbol: '♈',
+        dailyMessages: 142,
+        gradientColors: [Color(0xFFFF6B6B), Color(0xFFFF8E8E)],
+      ),
+      ChatRoom(
+        id: '2',
+        name: 'Taurus Rashi',
+        type: 'rashi',
+        symbol: '♉',
+        dailyMessages: 98,
+        gradientColors: [Color(0xFF4ECDC4), Color(0xFF7EDDD4)],
+      ),
+      ChatRoom(
+        id: '3',
+        name: 'Gemini Rashi',
+        type: 'rashi',
+        symbol: '♊',
+        dailyMessages: 156,
+        gradientColors: [Color(0xFF45B7D1), Color(0xFF75C7E1)],
+      ),
+      ChatRoom(
+        id: '4',
+        name: 'Cancer Rashi',
+        type: 'rashi',
+        symbol: '♋',
+        dailyMessages: 89,
+        gradientColors: [Color(0xFF96CEB4), Color(0xFFB6DEC4)],
+      ),
+      ChatRoom(
+        id: '5',
+        name: 'Leo Rashi',
+        type: 'rashi',
+        symbol: '♌',
+        dailyMessages: 203,
+        gradientColors: [Color(0xFFFFA726), Color(0xFFFFB74D)],
+      ),
+      ChatRoom(
+        id: '6',
+        name: 'Virgo Rashi',
+        type: 'rashi',
+        symbol: '♍',
+        dailyMessages: 76,
+        gradientColors: [Color(0xFF8E24AA), Color(0xFFAB47BC)],
+      ),
+      ChatRoom(
+        id: '7',
+        name: 'Libra Rashi',
+        type: 'rashi',
+        symbol: '♎',
+        dailyMessages: 134,
+        gradientColors: [Color(0xFFE91E63), Color(0xFFF06292)],
+      ),
+      ChatRoom(
+        id: '8',
+        name: 'Scorpio Rashi',
+        type: 'rashi',
+        symbol: '♏',
+        dailyMessages: 167,
+        gradientColors: [Color(0xFF5D4037), Color(0xFF8D6E63)],
+      ),
+      ChatRoom(
+        id: '9',
+        name: 'Sagittarius Rashi',
+        type: 'rashi',
+        symbol: '♐',
+        dailyMessages: 92,
+        gradientColors: [Color(0xFF00ACC1), Color(0xFF26C6DA)],
+      ),
+      ChatRoom(
+        id: '10',
+        name: 'Capricorn Rashi',
+        type: 'rashi',
+        symbol: '♑',
+        dailyMessages: 118,
+        gradientColors: [Color(0xFF6D4C41), Color(0xFF8D6E63)],
+      ),
+      ChatRoom(
+        id: '11',
+        name: 'Aquarius Rashi',
+        type: 'rashi',
+        symbol: '♒',
+        dailyMessages: 145,
+        gradientColors: [Color(0xFF42A5F5), Color(0xFF64B5F6)],
+      ),
+      ChatRoom(
+        id: '12',
+        name: 'Pisces Rashi',
+        type: 'rashi',
+        symbol: '♓',
+        dailyMessages: 101,
+        gradientColors: [Color(0xFF26A69A), Color(0xFF4DB6AC)],
+      ),
+    ]);
+    logger.i('Created mock rashi rooms');
+  }
+
+  ChatRoom? getRoomById(String roomId) {
+    return rashiRooms.firstWhereOrNull((r) => r.id == roomId);
+  }
+
+  Future<void> refreshRooms() async {
+    await initializeChatRooms();
+  }
+
+  Future<void> joinRoom(String roomId) async {
+    final room = getRoomById(roomId);
+    if (room != null && !joinedRooms.contains(room)) {
+      joinedRooms.add(room);
+    }
+  }
+
+  Future<void> leaveRoom(String roomId) async {
+    joinedRooms.removeWhere((r) => r.id == roomId);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -7,6 +7,8 @@ import 'pages/set_username_page.dart';
 import 'pages/profile_page.dart';
 import 'pages/settings_page.dart';
 import 'pages/sliver_sample_page.dart';
+import 'pages/chat_room_page.dart';
+import 'pages/chat_rooms_list_page.dart';
 import 'themes/enhanced_app_theme.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -74,6 +76,18 @@ class MyApp extends StatelessWidget {
             GetPage(
               name: '/sliver',
               page: () => const SliverSamplePage(),
+              binding: AuthBinding(),
+              transition: Transition.rightToLeft,
+            ),
+            GetPage(
+              name: '/chat-room/:roomId',
+              page: () => const ChatRoomPage(),
+              binding: AuthBinding(),
+              transition: Transition.rightToLeft,
+            ),
+            GetPage(
+              name: '/chat-rooms-list',
+              page: () => const ChatRoomsListPage(),
               binding: AuthBinding(),
               transition: Transition.rightToLeft,
             ),

--- a/lib/models/chat_room.dart
+++ b/lib/models/chat_room.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class ChatRoom {
+  final String id;
+  final String name;
+  final String type;
+  final String? rashiId;
+  final String? symbol;
+  final int dailyMessages;
+  final List<Color> gradientColors;
+  final DateTime? lastMessageAt;
+  final bool isActive;
+
+  ChatRoom({
+    required this.id,
+    required this.name,
+    required this.type,
+    this.rashiId,
+    this.symbol,
+    required this.dailyMessages,
+    required this.gradientColors,
+    this.lastMessageAt,
+    this.isActive = true,
+  });
+
+  factory ChatRoom.fromJson(Map<String, dynamic> json) {
+    return ChatRoom(
+      id: json['id'] ?? json['\$id'],
+      name: json['name'],
+      type: json['type'],
+      rashiId: json['rashi_id'],
+      symbol: json['symbol'],
+      dailyMessages: json['daily_messages'] ?? 0,
+      gradientColors: [
+        Color(json['color_primary'] ?? 0xFFFF6B6B),
+        Color(json['color_secondary'] ?? 0xFFFF8E8E),
+      ],
+      lastMessageAt: json['last_message_at'] != null
+          ? DateTime.parse(json['last_message_at'])
+          : null,
+      isActive: json['is_active'] ?? true,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'type': type,
+      'rashi_id': rashiId,
+      'symbol': symbol,
+      'daily_messages': dailyMessages,
+      'color_primary': gradientColors.first.value,
+      'color_secondary': gradientColors.last.value,
+      'last_message_at': lastMessageAt?.toIso8601String(),
+      'is_active': isActive,
+    };
+  }
+}

--- a/lib/pages/chat_room_page.dart
+++ b/lib/pages/chat_room_page.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/chat_controller.dart';
+
+class ChatRoomPage extends GetView<ChatController> {
+  const ChatRoomPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final roomId = Get.parameters['roomId']!;
+    return Scaffold(
+      appBar: AppBar(
+        title: Obx(() {
+          final room = controller.getRoomById(roomId);
+          return Text(
+            room?.name ?? 'Chat Room',
+            style: const TextStyle(fontSize: 18, fontWeight: FontWeight.w600),
+          );
+        }),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.info_outline),
+            onPressed: () {
+              Get.snackbar(
+                'Room Info',
+                'Room details and settings coming soon',
+                snackPosition: SnackPosition.BOTTOM,
+                duration: const Duration(seconds: 2),
+              );
+            },
+          ),
+        ],
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: Container(
+              color:
+                  Theme.of(context).colorScheme.surfaceVariant.withOpacity(0.3),
+              child: Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.chat_bubble_outline,
+                      size: 64,
+                      color: Theme.of(context)
+                          .colorScheme
+                          .onSurfaceVariant
+                          .withOpacity(0.5),
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      'Chat messages will appear here',
+                      style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                            color:
+                                Theme.of(context).colorScheme.onSurfaceVariant,
+                          ),
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      'Start a conversation with other members',
+                      style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                            color: Theme.of(context)
+                                .colorScheme
+                                .onSurfaceVariant
+                                .withOpacity(0.7),
+                          ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ),
+          Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: Theme.of(context).colorScheme.surface,
+              border: Border(
+                top: BorderSide(
+                  color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+                ),
+              ),
+            ),
+            child: Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    decoration: InputDecoration(
+                      hintText: 'Type a message...',
+                      border: OutlineInputBorder(
+                        borderRadius: BorderRadius.circular(24),
+                      ),
+                      contentPadding: const EdgeInsets.symmetric(
+                          horizontal: 16, vertical: 12),
+                    ),
+                    maxLines: null,
+                    textCapitalization: TextCapitalization.sentences,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.primary,
+                    shape: BoxShape.circle,
+                  ),
+                  child: IconButton(
+                    icon: Icon(
+                      Icons.send,
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                    onPressed: () {
+                      Get.snackbar(
+                        'Coming Soon',
+                        'Message sending will be implemented in the next phase',
+                        snackPosition: SnackPosition.BOTTOM,
+                        duration: const Duration(seconds: 2),
+                      );
+                    },
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/pages/chat_rooms_list_page.dart
+++ b/lib/pages/chat_rooms_list_page.dart
@@ -1,0 +1,75 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/chat_controller.dart';
+import '../widgets/chat/chat_room_card.dart';
+
+class ChatRoomsListPage extends GetView<ChatController> {
+  const ChatRoomsListPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('All Chat Rooms'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: controller.refreshRooms,
+          ),
+        ],
+      ),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (controller.rashiRooms.isEmpty) {
+          return Center(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                Icon(
+                  Icons.chat_bubble_outline,
+                  size: 64,
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurfaceVariant
+                      .withOpacity(0.5),
+                ),
+                const SizedBox(height: 16),
+                Text(
+                  'No chat rooms available',
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  'Check back later for active discussions',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              ],
+            ),
+          );
+        }
+        return GridView.builder(
+          padding: const EdgeInsets.all(16),
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: MediaQuery.of(context).size.width > 600 ? 3 : 2,
+            crossAxisSpacing: 16,
+            mainAxisSpacing: 16,
+            childAspectRatio: 1.0,
+          ),
+          itemCount: controller.rashiRooms.length,
+          itemBuilder: (context, index) {
+            final room = controller.rashiRooms[index];
+            return ChatRoomCard(
+              room: room,
+              width: double.infinity,
+              onTap: () => Get.toNamed('/chat-room/${room.id}'),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -6,6 +6,8 @@ import '../widgets/adaptive_navigation.dart';
 import '../widgets/sample_sliver_app_bar.dart';
 import '../widgets/safe_network_image.dart';
 import '../widgets/complete_enhanced_watchlist.dart';
+import '../controllers/chat_controller.dart';
+import '../widgets/chat/chat_room_card.dart';
 import 'empty_page.dart';
 
 class HomePage extends StatefulWidget {
@@ -182,45 +184,49 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   Widget _buildHomeBody(BuildContext context) {
     return DefaultTabController(
       length: 5,
-      child: CustomScrollView(
-        slivers: [
+      child: NestedScrollView(
+        headerSliverBuilder: (context, innerBoxIsScrolled) => [
           const SampleSliverAppBar(),
-          SliverFillRemaining(
-            child: TabBarView(
-              children: [
-                EnhancedResponsiveLayout(
-                  mobile: (context) => _buildContent(
-                      context, MediaQuery.of(context).size.width * 0.95),
-                  tablet: (context) => _buildContent(context, 600),
-                  desktop: (context) => _buildContent(context, 800),
-                ),
-                const Center(child: SizedBox()),
-                const Center(child: SizedBox()),
-                const Center(child: SizedBox()),
-                const Center(child: SizedBox()),
-              ],
-            ),
-          ),
         ],
+        body: TabBarView(
+          children: [
+            EnhancedResponsiveLayout(
+              mobile: (context) => _buildContent(
+                  context, MediaQuery.of(context).size.width * 0.95),
+              tablet: (context) => _buildContent(context, 600),
+              desktop: (context) => _buildContent(context, 800),
+            ),
+            const Center(child: SizedBox()),
+            const Center(child: SizedBox()),
+            const Center(child: SizedBox()),
+            const Center(child: SizedBox()),
+          ],
+        ),
       ),
     );
   }
 
   Widget _buildContent(BuildContext context, double width) {
-    final screenHeight = MediaQuery.of(context).size.height;
-    return Center(
-      child: Container(
-        padding: EdgeInsets.all(_getResponsivePadding(context)),
-        width: width,
-        child: Column(
-          mainAxisSize: MainAxisSize.max,
-          children: [
-            _buildPredictionScoresSection(context),
-            SizedBox(height: _getResponsiveSpacing(context)),
-            Expanded(
-              child: const EnhancedWatchlistWidget(),
-            ),
-          ],
+    return SingleChildScrollView(
+      padding: EdgeInsets.all(_getResponsivePadding(context)),
+      child: Center(
+        child: ConstrainedBox(
+          constraints: BoxConstraints(maxWidth: width),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _buildPredictionScoresSection(context),
+              SizedBox(height: _getResponsiveSpacing(context)),
+              _buildChatRoomsSection(context),
+              SizedBox(height: _getResponsiveSpacing(context)),
+              SizedBox(
+                height: MediaQuery.of(context).size.height * 0.5,
+                child: const EnhancedWatchlistWidget(),
+              ),
+              SizedBox(height: _getResponsiveSpacing(context)),
+            ],
+          ),
         ),
       ),
     );
@@ -228,22 +234,22 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
 
   double _getResponsivePadding(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    if (width >= 1024) return 24.0;
-    if (width >= 600) return 20.0;
-    return 16.0;
+    if (width >= 1024) return 16.0;
+    if (width >= 600) return 14.0;
+    return 12.0;
   }
 
   double _getResponsiveSpacing(BuildContext context) {
     final width = MediaQuery.of(context).size.width;
-    if (width >= 1024) return 32.0;
-    if (width >= 600) return 24.0;
-    return 20.0;
+    if (width >= 1024) return 28.0;
+    if (width >= 600) return 22.0;
+    return 18.0;
   }
 
   double _getResponsiveFontSize(BuildContext context, double baseSize) {
     final width = MediaQuery.of(context).size.width;
-    if (width >= 1024) return baseSize * 1.2;
-    if (width >= 600) return baseSize * 1.1;
+    if (width >= 1024) return baseSize * 1.1;
+    if (width >= 600) return baseSize * 1.05;
     return baseSize;
   }
 
@@ -272,8 +278,9 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               ),
         ),
         SizedBox(height: _getResponsiveSpacing(context) * 0.5),
-        SizedBox(
-          height: _getResponsiveHeight(context, 80),
+        ConstrainedBox(
+          constraints:
+              BoxConstraints(maxHeight: _getResponsiveHeight(context, 80)),
           child: ListView.separated(
             scrollDirection: Axis.horizontal,
             itemCount: names.length,
@@ -349,10 +356,96 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
     );
   }
 
+  Widget _buildChatRoomsSection(BuildContext context) {
+    final chatController = Get.find<ChatController>();
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceBetween,
+          children: [
+            Text(
+              'Chat Rooms',
+              style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                    fontSize: _getResponsiveFontSize(context, 18),
+                    fontWeight: FontWeight.w600,
+                  ),
+            ),
+            TextButton(
+              onPressed: () => Get.toNamed('/chat-rooms-list'),
+              child: Text(
+                'View All',
+                style: TextStyle(
+                  fontSize: _getResponsiveFontSize(context, 14),
+                  color: Theme.of(context).colorScheme.primary,
+                ),
+              ),
+            ),
+          ],
+        ),
+        SizedBox(height: _getResponsiveSpacing(context) * 0.5),
+        ConstrainedBox(
+          constraints:
+              BoxConstraints(maxHeight: _getResponsiveHeight(context, 90)),
+          child: Obx(() {
+            if (chatController.isLoading.value) {
+              return const Center(child: CircularProgressIndicator());
+            }
+            if (chatController.rashiRooms.isEmpty) {
+              return Center(
+                child: Text(
+                  'No chat rooms available',
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: Theme.of(context).colorScheme.onSurfaceVariant,
+                      ),
+                ),
+              );
+            }
+            return ListView.separated(
+              scrollDirection: Axis.horizontal,
+              padding: const EdgeInsets.symmetric(horizontal: 4),
+              itemCount: chatController.rashiRooms.length,
+              separatorBuilder: (_, __) =>
+                  SizedBox(width: _getResponsiveSpacing(context) * 0.6),
+              itemBuilder: (context, index) {
+                final room = chatController.rashiRooms[index];
+                return TweenAnimationBuilder<double>(
+                  tween: Tween(begin: 0.0, end: 1.0),
+                  duration: Duration(milliseconds: 300 + (index * 100)),
+                  curve: Curves.easeOutBack,
+                  builder: (context, value, child) {
+                    return Transform.scale(
+                      scale: 0.8 + (0.2 * value),
+                      child: Opacity(
+                        opacity: value,
+                        child: ChatRoomCard(
+                          room: room,
+                          width: _getResponsiveChatCardWidth(context),
+                          onTap: () => Get.toNamed('/chat-room/${room.id}'),
+                        ),
+                      ),
+                    );
+                  },
+                );
+              },
+            );
+          }),
+        ),
+      ],
+    );
+  }
+
+  double _getResponsiveChatCardWidth(BuildContext context) {
+    final width = MediaQuery.of(context).size.width;
+    if (width >= 1024) return 120.0;
+    if (width >= 600) return 110.0;
+    return 100.0;
+  }
+
   double _getResponsiveHeight(BuildContext context, double baseHeight) {
     final width = MediaQuery.of(context).size.width;
-    if (width >= 1024) return baseHeight * 1.3;
-    if (width >= 600) return baseHeight * 1.15;
+    if (width >= 1024) return baseHeight * 1.1;
+    if (width >= 600) return baseHeight * 1.05;
     return baseHeight;
   }
 }

--- a/lib/widgets/chat/chat_room_card.dart
+++ b/lib/widgets/chat/chat_room_card.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import '../../models/chat_room.dart';
+
+class ChatRoomCard extends StatelessWidget {
+  final ChatRoom room;
+  final double width;
+  final VoidCallback onTap;
+
+  const ChatRoomCard({
+    super.key,
+    required this.room,
+    required this.width,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onTap: onTap,
+      child: Container(
+        width: width,
+        height: 90,
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: room.gradientColors,
+            begin: Alignment.topLeft,
+            end: Alignment.bottomRight,
+          ),
+          borderRadius: BorderRadius.circular(16),
+          boxShadow: [
+            BoxShadow(
+              color: room.gradientColors.first.withOpacity(0.3),
+              blurRadius: 8,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(10),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              Expanded(
+                child: Text(
+                  room.name,
+                  style: const TextStyle(
+                    fontSize: 13,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                  maxLines: 2,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ),
+              Container(
+                padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                decoration: BoxDecoration(
+                  color: Colors.white.withOpacity(0.2),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Text(
+                  '${room.dailyMessages} today',
+                  style: const TextStyle(
+                    fontSize: 11,
+                    fontWeight: FontWeight.w600,
+                    color: Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement `ChatController` with mock fallback
- add `ChatRoom` model and card widget
- integrate chat rooms section on home page with layout fixes
- create pages for chat room and chat room list
- register new routes and bind controller

## Testing
- `dart format lib`
- `flutter test` *(fails: Persistence across restarts)*


------
https://chatgpt.com/codex/tasks/task_e_68471732dd00832d9ae21f13308abc99