### PR TITLE
Add unit tests

### DIFF
--- a/test/controllers/auth_validation_test.dart
+++ b/test/controllers/auth_validation_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:myapp/controllers/auth_controller.dart';
+
+void main() {
+  group('AuthController validations', () {
+    final controller = AuthController();
+
+    test('validates email format', () {
+      expect(controller.isValidEmail('test@example.com'), isTrue);
+      expect(controller.isValidEmail('invalid'), isFalse);
+    });
+
+    test('validates OTP format', () {
+      expect(controller.isValidOTP('123456'), isTrue);
+      expect(controller.isValidOTP('abc123'), isFalse);
+    });
+
+    test('validates username format', () {
+      expect(controller.isValidUsername('user_1'), isTrue);
+      expect(controller.isValidUsername('x'), isFalse);
+    });
+  });
+}

--- a/test/controllers/chat_controller_test.dart
+++ b/test/controllers/chat_controller_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:myapp/controllers/chat_controller.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+
+class FakeDatabases {
+  Future<dynamic> listDocuments({
+    String? databaseId,
+    String? collectionId,
+    List<dynamic>? queries,
+  }) async {
+    throw Exception('db unavailable');
+  }
+}
+
+class TestAuthController extends AuthController {
+  @override
+  void onInit() {
+    databases = FakeDatabases() as dynamic;
+  }
+
+  @override
+  Future<void> checkExistingSession() async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    Get.testMode = true;
+  });
+
+  test('falls back to mock rooms when load fails', () async {
+    Get.put<AuthController>(TestAuthController());
+    final controller = Get.put(ChatController());
+    await Future.delayed(const Duration(milliseconds: 100));
+    expect(controller.rashiRooms.length, 12);
+  });
+
+  test('join and leave rooms', () async {
+    final auth = Get.find<AuthController>();
+    final controller = Get.find<ChatController>();
+    await controller.joinRoom('1');
+    expect(controller.joinedRooms.length, 1);
+    await controller.leaveRoom('1');
+    expect(controller.joinedRooms.isEmpty, true);
+    Get.delete<ChatController>();
+    Get.delete<AuthController>();
+  });
+}

--- a/test/controllers/theme_controller_test.dart
+++ b/test/controllers/theme_controller_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:myapp/controllers/theme_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    Get.testMode = true;
+  });
+
+  test('toggleTheme changes value', () async {
+    final controller = ThemeController();
+    controller.onInit();
+    await Future.delayed(const Duration(milliseconds: 10));
+    final initial = controller.isDarkMode.value;
+    await controller.toggleTheme();
+    expect(controller.isDarkMode.value, isNot(initial));
+  });
+}

--- a/test/models/chat_room_model_test.dart
+++ b/test/models/chat_room_model_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:myapp/models/chat_room.dart';
+
+void main() {
+  group('ChatRoom model', () {
+    test('fromJson and toJson maintain values', () {
+      final json = {
+        'id': '123',
+        'name': 'Test Room',
+        'type': 'rashi',
+        'rashi_id': 'r1',
+        'symbol': '♈',
+        'daily_messages': 5,
+        'color_primary': Colors.red.value,
+        'color_secondary': Colors.blue.value,
+        'last_message_at': DateTime.parse('2024-01-01').toIso8601String(),
+        'is_active': true,
+      };
+
+      final room = ChatRoom.fromJson(json);
+
+      expect(room.id, '123');
+      expect(room.name, 'Test Room');
+      expect(room.type, 'rashi');
+      expect(room.rashiId, 'r1');
+      expect(room.symbol, '♈');
+      expect(room.dailyMessages, 5);
+      expect(room.gradientColors.first, const Color(0xFFFF0000));
+      expect(room.gradientColors.last, const Color(0xFF0000FF));
+      expect(room.lastMessageAt, DateTime.parse('2024-01-01'));
+      expect(room.isActive, true);
+
+      final encoded = room.toJson();
+      expect(encoded['id'], json['id']);
+      expect(encoded['name'], json['name']);
+      expect(encoded['type'], json['type']);
+      expect(encoded['rashi_id'], json['rashi_id']);
+      expect(encoded['symbol'], json['symbol']);
+      expect(encoded['daily_messages'], json['daily_messages']);
+      expect(encoded['color_primary'], json['color_primary']);
+      expect(encoded['color_secondary'], json['color_secondary']);
+      expect(encoded['last_message_at'], json['last_message_at']);
+      expect(encoded['is_active'], json['is_active']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add tests for ChatRoom model
- add validation tests for AuthController
- add ChatController tests for fallback and join/leave
- add ThemeController toggle test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684723940c30832d8a615456aedf893e