### PR TITLE
Clamp opacity values in animations

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -169,7 +169,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
         return Transform.translate(
           offset: Offset(50 * (1 - value), 0),
           child: Opacity(
-            opacity: value,
+            opacity: value.clamp(0.0, 1.0),
             child: ListTile(
               leading: Icon(icon),
               title: Text(title),
@@ -294,7 +294,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                 curve: Curves.easeOutBack,
                 builder: (context, value, child) {
                   return Transform.scale(
-                    scale: value,
+                    scale: value.clamp(0.0, 1.0),
                     child: _buildPredictionCard(
                         context, names[index], index + 1, color),
                   );
@@ -414,10 +414,12 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                   duration: Duration(milliseconds: 300 + (index * 100)),
                   curve: Curves.easeOutBack,
                   builder: (context, value, child) {
+                    final clampedValue = value.clamp(0.0, 1.0);
+                    final scale = 0.8 + (0.2 * clampedValue);
                     return Transform.scale(
-                      scale: 0.8 + (0.2 * value),
+                      scale: scale,
                       child: Opacity(
-                        opacity: value,
+                        opacity: clampedValue,
                         child: ChatRoomCard(
                           room: room,
                           width: _getResponsiveChatCardWidth(context),

--- a/lib/widgets/complete_enhanced_watchlist.dart
+++ b/lib/widgets/complete_enhanced_watchlist.dart
@@ -312,7 +312,8 @@ class WatchlistController extends GetxController {
           documentId: id,
         );
       } catch (e, st) {
-        logger.e('Error removing item from watchlist', error: e, stackTrace: st);
+        logger.e('Error removing item from watchlist',
+            error: e, stackTrace: st);
         _showErrorSnackbar('Error', 'Failed to remove item');
       }
     }
@@ -540,7 +541,7 @@ class WatchlistAnimations {
         return Transform.translate(
           offset: Offset(30 * (1 - value), 0),
           child: Opacity(
-            opacity: value,
+            opacity: value.clamp(0.0, 1.0),
             child: child,
           ),
         );
@@ -558,10 +559,12 @@ class WatchlistAnimations {
       duration: duration ?? Duration(milliseconds: 400 + (index * 100)),
       curve: Curves.easeOutBack,
       builder: (context, value, _) {
+        final clampedOpacity = value.clamp(0.0, 1.0);
+        final scale = (0.8 + (0.2 * value)).clamp(0.0, double.infinity);
         return Transform.scale(
-          scale: 0.8 + (0.2 * value),
+          scale: scale,
           child: Opacity(
-            opacity: value,
+            opacity: clampedOpacity,
             child: child,
           ),
         );
@@ -984,7 +987,7 @@ class EnhancedWatchlistWidget extends StatelessWidget {
         curve: Curves.easeOut,
         builder: (context, value, child) {
           return Opacity(
-            opacity: value,
+            opacity: value.clamp(0.0, 1.0),
             child: Transform.translate(
               offset: Offset(0, 30 * (1 - value)),
               child: SingleChildScrollView(


### PR DESCRIPTION
## Summary
- prevent invalid opacity values on HomePage animations
- clamp opacity and scale values for watchlist animations

## Testing
- `flutter analyze` *(fails: analysis server exited)*
- `flutter test --no-pub` *(fails: Broken pipe)*


------
https://chatgpt.com/codex/tasks/task_e_6847248a4a38832da156d6ec183f2ce1