### PR TITLE
Implement modern chat room UI

### DIFF
--- a/lib/controllers/chat_controller.dart
+++ b/lib/controllers/chat_controller.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
+import 'dart:ui';
 import 'package:get/get.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:logger/logger.dart';
+import '../utils/modern_color_palettes.dart';
 
 import '../models/chat_room.dart';
 import 'auth_controller.dart';
@@ -33,7 +35,7 @@ class ChatController extends GetxController {
     } catch (e) {
       error.value = e.toString();
       logger.e('Error loading chat rooms', error: e);
-      _createMockRashiRooms();
+      _createModernMockRashiRooms();
     } finally {
       isLoading.value = false;
     }
@@ -56,106 +58,78 @@ class ChatController extends GetxController {
     rashiRooms.assignAll(rooms);
   }
 
-  void _createMockRashiRooms() {
-    rashiRooms.assignAll([
-      ChatRoom(
-        id: '1',
-        name: 'Aries Rashi',
-        type: 'rashi',
-        symbol: '♈',
-        dailyMessages: 142,
-        gradientColors: [Color(0xFFFF6B6B), Color(0xFFFF8E8E)],
-      ),
-      ChatRoom(
-        id: '2',
-        name: 'Taurus Rashi',
-        type: 'rashi',
-        symbol: '♉',
-        dailyMessages: 98,
-        gradientColors: [Color(0xFF4ECDC4), Color(0xFF7EDDD4)],
-      ),
-      ChatRoom(
-        id: '3',
-        name: 'Gemini Rashi',
-        type: 'rashi',
-        symbol: '♊',
-        dailyMessages: 156,
-        gradientColors: [Color(0xFF45B7D1), Color(0xFF75C7E1)],
-      ),
-      ChatRoom(
-        id: '4',
-        name: 'Cancer Rashi',
-        type: 'rashi',
-        symbol: '♋',
-        dailyMessages: 89,
-        gradientColors: [Color(0xFF96CEB4), Color(0xFFB6DEC4)],
-      ),
-      ChatRoom(
-        id: '5',
-        name: 'Leo Rashi',
-        type: 'rashi',
-        symbol: '♌',
-        dailyMessages: 203,
-        gradientColors: [Color(0xFFFFA726), Color(0xFFFFB74D)],
-      ),
-      ChatRoom(
-        id: '6',
-        name: 'Virgo Rashi',
-        type: 'rashi',
-        symbol: '♍',
-        dailyMessages: 76,
-        gradientColors: [Color(0xFF8E24AA), Color(0xFFAB47BC)],
-      ),
-      ChatRoom(
-        id: '7',
-        name: 'Libra Rashi',
-        type: 'rashi',
-        symbol: '♎',
-        dailyMessages: 134,
-        gradientColors: [Color(0xFFE91E63), Color(0xFFF06292)],
-      ),
-      ChatRoom(
-        id: '8',
-        name: 'Scorpio Rashi',
-        type: 'rashi',
-        symbol: '♏',
-        dailyMessages: 167,
-        gradientColors: [Color(0xFF5D4037), Color(0xFF8D6E63)],
-      ),
-      ChatRoom(
-        id: '9',
-        name: 'Sagittarius Rashi',
-        type: 'rashi',
-        symbol: '♐',
-        dailyMessages: 92,
-        gradientColors: [Color(0xFF00ACC1), Color(0xFF26C6DA)],
-      ),
-      ChatRoom(
-        id: '10',
-        name: 'Capricorn Rashi',
-        type: 'rashi',
-        symbol: '♑',
-        dailyMessages: 118,
-        gradientColors: [Color(0xFF6D4C41), Color(0xFF8D6E63)],
-      ),
-      ChatRoom(
-        id: '11',
-        name: 'Aquarius Rashi',
-        type: 'rashi',
-        symbol: '♒',
-        dailyMessages: 145,
-        gradientColors: [Color(0xFF42A5F5), Color(0xFF64B5F6)],
-      ),
-      ChatRoom(
-        id: '12',
-        name: 'Pisces Rashi',
-        type: 'rashi',
-        symbol: '♓',
-        dailyMessages: 101,
-        gradientColors: [Color(0xFF26A69A), Color(0xFF4DB6AC)],
-      ),
-    ]);
-    logger.i('Created mock rashi rooms');
+  void _createModernMockRashiRooms() {
+    // Modern, sophisticated color palettes based on 2024-2025 UI trends
+    final modernGradients = [
+      // Aries - Warm coral to soft peach
+      [const Color(0xFFFF9A9E), const Color(0xFFFECFEF)],
+
+      // Taurus - Earth green to sage
+      [const Color(0xFF83A4D4), const Color(0xFFB6FBFF)],
+
+      // Gemini - Sky blue to lavender
+      [const Color(0xFFA8EDEA), const Color(0xFFFED6E3)],
+
+      // Cancer - Soft purple to pink
+      [const Color(0xFFD299C2), const Color(0xFFFED6E3)],
+
+      // Leo - Golden yellow to orange
+      [const Color(0xFFFDC830), const Color(0xFFF37335)],
+
+      // Virgo - Mint to teal
+      [const Color(0xFF4FACFE), const Color(0xFF00F2FE)],
+
+      // Libra - Rose to coral
+      [const Color(0xFFF093FB), const Color(0xFFF5576C)],
+
+      // Scorpio - Deep purple to magenta
+      [const Color(0xFF4E54C8), const Color(0xFF8F94FB)],
+
+      // Sagittarius - Turquoise to blue
+      [const Color(0xFF43E97B), const Color(0xFF38F9D7)],
+
+      // Capricorn - Gray blue to light blue
+      [const Color(0xFF667EEA), const Color(0xFF764BA2)],
+
+      // Aquarius - Electric blue to cyan
+      [const Color(0xFF2196F3), const Color(0xFF21CBF3)],
+
+      // Pisces - Ocean blue to aqua
+      [const Color(0xFF36D1DC), const Color(0xFF5B86E5)],
+    ];
+
+    final rashiData = [
+      {'name': 'Aries Rashi', 'symbol': '♈', 'messages': 142},
+      {'name': 'Taurus Rashi', 'symbol': '♉', 'messages': 98},
+      {'name': 'Gemini Rashi', 'symbol': '♊', 'messages': 156},
+      {'name': 'Cancer Rashi', 'symbol': '♋', 'messages': 89},
+      {'name': 'Leo Rashi', 'symbol': '♌', 'messages': 203},
+      {'name': 'Virgo Rashi', 'symbol': '♍', 'messages': 76},
+      {'name': 'Libra Rashi', 'symbol': '♎', 'messages': 134},
+      {'name': 'Scorpio Rashi', 'symbol': '♏', 'messages': 167},
+      {'name': 'Sagittarius Rashi', 'symbol': '♐', 'messages': 92},
+      {'name': 'Capricorn Rashi', 'symbol': '♑', 'messages': 118},
+      {'name': 'Aquarius Rashi', 'symbol': '♒', 'messages': 145},
+      {'name': 'Pisces Rashi', 'symbol': '♓', 'messages': 101},
+    ];
+
+    rashiRooms.assignAll(
+      rashiData.asMap().entries.map((entry) {
+        final index = entry.key;
+        final data = entry.value;
+        
+        return ChatRoom(
+          id: (index + 1).toString(),
+          name: data['name'] as String,
+          type: 'rashi',
+          symbol: data['symbol'] as String,
+          dailyMessages: data['messages'] as int,
+          gradientColors: modernGradients[index],
+        );
+      }).toList(),
+    );
+    
+    logger.i('Created modern mock rashi rooms with sophisticated color palettes');
   }
 
   ChatRoom? getRoomById(String roomId) {
@@ -175,5 +149,58 @@ class ChatController extends GetxController {
 
   Future<void> leaveRoom(String roomId) async {
     joinedRooms.removeWhere((r) => r.id == roomId);
+  }
+}
+
+/// Modern glassmorphism utility functions
+class GlassmorphismUtils {
+  /// Create a modern glassmorphism container
+  static Widget createGlassContainer({
+    required Widget child,
+    double borderRadius = 20,
+    double blur = 10,
+    List<Color>? gradientColors,
+    bool isDark = false,
+  }) {
+    return ClipRRect(
+      borderRadius: BorderRadius.circular(borderRadius),
+      child: BackdropFilter(
+        filter: ImageFilter.blur(sigmaX: blur, sigmaY: blur),
+        child: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: gradientColors ?? [
+                Colors.white.withOpacity(isDark ? 0.1 : 0.2),
+                Colors.white.withOpacity(isDark ? 0.05 : 0.1),
+              ],
+            ),
+            borderRadius: BorderRadius.circular(borderRadius),
+            border: Border.all(
+              color: Colors.white.withOpacity(0.2),
+              width: 1.5,
+            ),
+          ),
+          child: child,
+        ),
+      ),
+    );
+  }
+
+  /// Create modern elevation shadow
+  static List<BoxShadow> createModernShadow(Color baseColor, double elevation) {
+    return [
+      BoxShadow(
+        color: baseColor.withOpacity(0.2),
+        blurRadius: elevation,
+        offset: Offset(0, elevation / 2),
+      ),
+      BoxShadow(
+        color: Colors.black.withOpacity(0.1),
+        blurRadius: elevation * 2,
+        offset: Offset(0, elevation),
+      ),
+    ];
   }
 }

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -7,7 +7,8 @@ import '../widgets/sample_sliver_app_bar.dart';
 import '../widgets/safe_network_image.dart';
 import '../widgets/complete_enhanced_watchlist.dart';
 import '../controllers/chat_controller.dart';
-import '../widgets/chat/chat_room_card.dart';
+import '../widgets/chat/modern_chat_room_card.dart';
+import '../utils/modern_color_palettes.dart';
 import 'empty_page.dart';
 
 class HomePage extends StatefulWidget {
@@ -420,7 +421,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
                       scale: scale,
                       child: Opacity(
                         opacity: clampedValue,
-                        child: ChatRoomCard(
+                        child: ModernChatRoomCard(
                           room: room,
                           width: _getResponsiveChatCardWidth(context),
                           onTap: () => Get.toNamed('/chat-room/${room.id}'),

--- a/lib/utils/modern_color_palettes.dart
+++ b/lib/utils/modern_color_palettes.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+
+/// Modern, sophisticated color palettes for chat rooms
+/// Based on 2024-2025 UI design trends with glassmorphism in mind
+class ModernColorPalettes {
+  
+  // Sophisticated gradient palettes with better contrast and accessibility
+  static const List<List<Color>> rashiGradients = [
+    // Aries - Warm coral to soft peach
+    [Color(0xFFFF9A9E), Color(0xFFFECFEF)],
+    
+    // Taurus - Earth green to sage
+    [Color(0xFF83A4D4), Color(0xFFB6FBFF)],
+    
+    // Gemini - Sky blue to lavender
+    [Color(0xFFA8EDEA), Color(0xFFFED6E3)],
+    
+    // Cancer - Soft purple to pink
+    [Color(0xFFD299C2), Color(0xFFFED6E3)],
+    
+    // Leo - Golden yellow to orange
+    [Color(0xFFFDC830), Color(0xFFF37335)],
+    
+    // Virgo - Mint to teal
+    [Color(0xFF4FACFE), Color(0xFF00F2FE)],
+    
+    // Libra - Rose to coral
+    [Color(0xFFF093FB), Color(0xFFF5576C)],
+    
+    // Scorpio - Deep purple to magenta
+    [Color(0xFF4E54C8), Color(0xFF8F94FB)],
+    
+    // Sagittarius - Turquoise to blue
+    [Color(0xFF43E97B), Color(0xFF38F9D7)],
+    
+    // Capricorn - Gray blue to light blue
+    [Color(0xFF667EEA), Color(0xFF764BA2)],
+    
+    // Aquarius - Electric blue to cyan
+    [Color(0xFF2196F3), Color(0xFF21CBF3)],
+    
+    // Pisces - Ocean blue to aqua
+    [Color(0xFF36D1DC), Color(0xFF5B86E5)],
+  ];
+
+  // Alternative sophisticated palettes for variety
+  static const List<List<Color>> alternativeGradients = [
+    // Warm sunset
+    [Color(0xFFFA8072), Color(0xFFFFB6C1)],
+    
+    // Cool ocean
+    [Color(0xFF74B9FF), Color(0xFF81ECEC)],
+    
+    // Forest whisper
+    [Color(0xFF6C5CE7), Color(0xFFA29BFE)],
+    
+    // Lavender dream
+    [Color(0xFFE17055), Color(0xFFFDCB6E)],
+    
+    // Golden hour
+    [Color(0xFF00B894), Color(0xFF55EFC4)],
+    
+    // Mystic purple
+    [Color(0xFFF8B500), Color(0xFFFFD93D)],
+    
+    // Cherry blossom
+    [Color(0xFF00CEFF), Color(0xFF0099FF)],
+    
+    // Northern lights
+    [Color(0xFF667EEA), Color(0xFF764BA2)],
+    
+    // Emerald sea
+    [Color(0xFF12C2E9), Color(0xFFC471ED)],
+    
+    // Rose gold
+    [Color(0xFFFE6B8B), Color(0xFFFF8E53)],
+    
+    // Cosmic blue
+    [Color(0xFF667DB6), Color(0xFF0082C8)],
+    
+    // Gentle breeze
+    [Color(0xFF89F7FE), Color(0xFF66A6FF)],
+  ];
+
+  // Glassmorphism-friendly background colors
+  static const List<Color> backgroundColors = [
+    Color(0xFFF8F9FA), // Light gray
+    Color(0xFFF1F3F4), // Cool gray
+    Color(0xFFF5F7FA), // Blue-tinted white
+    Color(0xFFFAFBFC), // Pure light
+    Color(0xFFF0F2F5), // Facebook-style light
+  ];
+
+  // Dark mode friendly backgrounds
+  static const List<Color> darkBackgroundColors = [
+    Color(0xFF1A1A1A), // Rich black
+    Color(0xFF0F1419), // Dark blue
+    Color(0xFF121212), // Material dark
+    Color(0xFF1E1E1E), // VS Code dark
+    Color(0xFF0D1117), // GitHub dark
+  ];
+
+  /// Get a sophisticated gradient pair for a given index
+  static List<Color> getGradientForIndex(int index) {
+    return rashiGradients[index % rashiGradients.length];
+  }
+
+  /// Get an alternative gradient for variety
+  static List<Color> getAlternativeGradient(int index) {
+    return alternativeGradients[index % alternativeGradients.length];
+  }
+
+  /// Create a softer version of a color for better accessibility
+  static Color softenColor(Color color, {double opacity = 0.8}) {
+    return Color.lerp(color, Colors.white, 1 - opacity) ?? color;
+  }
+
+  /// Create a color with better contrast for text
+  static Color getTextColor(List<Color> backgroundGradient, {bool isDark = false}) {
+    // Calculate luminance to determine best text color
+    final avgLuminance = (backgroundGradient.first.computeLuminance() + 
+                         backgroundGradient.last.computeLuminance()) / 2;
+    
+    if (avgLuminance > 0.5) {
+      return isDark ? Colors.white : Colors.black87;
+    } else {
+      return Colors.white;
+    }
+  }
+
+  /// Get glassmorphism overlay colors
+  static List<Color> getGlassmorphismOverlay({bool isDark = false}) {
+    if (isDark) {
+      return [
+        Colors.white.withOpacity(0.1),
+        Colors.white.withOpacity(0.05),
+      ];
+    } else {
+      return [
+        Colors.white.withOpacity(0.25),
+        Colors.white.withOpacity(0.15),
+      ];
+    }
+  }
+
+  /// Generate a modern shadow color from a base color
+  static BoxShadow createModernShadow(Color baseColor, {double elevation = 4}) {
+    return BoxShadow(
+      color: baseColor.withOpacity(0.2),
+      blurRadius: elevation * 2,
+      offset: Offset(0, elevation / 2),
+      spreadRadius: 0,
+    );
+  }
+
+  /// Create a glassmorphism border color
+  static Color getGlassmorphismBorder({bool isDark = false}) {
+    return Colors.white.withOpacity(isDark ? 0.15 : 0.25);
+  }
+}
+
+/// Extension to add modern color utilities
+extension ModernColorExtensions on Color {
+  /// Create a lighter version of the color for glassmorphism
+  Color get glassy => withOpacity(0.7);
+  
+  /// Create a muted version of the color
+  Color get muted => Color.lerp(this, Colors.grey, 0.3) ?? this;
+  
+  /// Create a softer version by blending with white
+  Color soft([double amount = 0.3]) => Color.lerp(this, Colors.white, amount) ?? this;
+  
+  /// Create a darker version by blending with black
+  Color deep([double amount = 0.2]) => Color.lerp(this, Colors.black, amount) ?? this;
+}

--- a/lib/widgets/chat/modern_chat_room_card.dart
+++ b/lib/widgets/chat/modern_chat_room_card.dart
@@ -1,0 +1,326 @@
+import 'package:flutter/material.dart';
+import 'dart:ui';
+import '../../models/chat_room.dart';
+
+class ModernChatRoomCard extends StatefulWidget {
+  final ChatRoom room;
+  final double width;
+  final VoidCallback onTap;
+
+  const ModernChatRoomCard({
+    super.key,
+    required this.room,
+    required this.width,
+    required this.onTap,
+  });
+
+  @override
+  State<ModernChatRoomCard> createState() => _ModernChatRoomCardState();
+}
+
+class _ModernChatRoomCardState extends State<ModernChatRoomCard>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _animationController;
+  late Animation<double> _scaleAnimation;
+  late Animation<double> _elevationAnimation;
+  bool _isHovered = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _animationController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+    _scaleAnimation = Tween<double>(
+      begin: 1.0,
+      end: 1.02,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    ));
+    _elevationAnimation = Tween<double>(
+      begin: 2.0,
+      end: 8.0,
+    ).animate(CurvedAnimation(
+      parent: _animationController,
+      curve: Curves.easeInOut,
+    ));
+  }
+
+  @override
+  void dispose() {
+    _animationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isDark = Theme.of(context).brightness == Brightness.dark;
+    
+    return MouseRegion(
+      onEnter: (_) {
+        setState(() => _isHovered = true);
+        _animationController.forward();
+      },
+      onExit: (_) {
+        setState(() => _isHovered = false);
+        _animationController.reverse();
+      },
+      child: AnimatedBuilder(
+        animation: _animationController,
+        builder: (context, child) {
+          return Transform.scale(
+            scale: _scaleAnimation.value,
+            child: GestureDetector(
+              onTap: widget.onTap,
+              child: Container(
+                width: widget.width,
+                height: 110,
+                margin: const EdgeInsets.all(4),
+                child: Stack(
+                  children: [
+                    // Background gradient
+                    Container(
+                      decoration: BoxDecoration(
+                        gradient: LinearGradient(
+                          begin: Alignment.topLeft,
+                          end: Alignment.bottomRight,
+                          colors: widget.room.gradientColors.map((color) => 
+                            color.withOpacity(0.6)
+                          ).toList(),
+                        ),
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                    ),
+                    
+                    // Glassmorphism effect
+                    ClipRRect(
+                      borderRadius: BorderRadius.circular(20),
+                      child: BackdropFilter(
+                        filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
+                        child: Container(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              begin: Alignment.topLeft,
+                              end: Alignment.bottomRight,
+                              colors: [
+                                Colors.white.withOpacity(isDark ? 0.1 : 0.2),
+                                Colors.white.withOpacity(isDark ? 0.05 : 0.1),
+                              ],
+                            ),
+                            borderRadius: BorderRadius.circular(20),
+                            border: Border.all(
+                              color: Colors.white.withOpacity(0.2),
+                              width: 1.5,
+                            ),
+                          ),
+                          child: Container(
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(20),
+                              boxShadow: [
+                                BoxShadow(
+                                  color: widget.room.gradientColors.first
+                                      .withOpacity(0.2),
+                                  blurRadius: _elevationAnimation.value,
+                                  offset: Offset(0, _elevationAnimation.value / 2),
+                                ),
+                                BoxShadow(
+                                  color: Colors.black.withOpacity(isDark ? 0.3 : 0.1),
+                                  blurRadius: _elevationAnimation.value * 2,
+                                  offset: Offset(0, _elevationAnimation.value),
+                                ),
+                              ],
+                            ),
+                            child: _buildCardContent(context, isDark),
+                          ),
+                        ),
+                      ),
+                    ),
+                    
+                    // Floating message count badge
+                    Positioned(
+                      top: 8,
+                      right: 8,
+                      child: _buildMessageBadge(context, isDark),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildCardContent(BuildContext context, bool isDark) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Room symbol and name
+          Row(
+            children: [
+              Container(
+                width: 40,
+                height: 40,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: widget.room.gradientColors,
+                    begin: Alignment.topLeft,
+                    end: Alignment.bottomRight,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                  boxShadow: [
+                    BoxShadow(
+                      color: widget.room.gradientColors.first.withOpacity(0.4),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Center(
+                  child: Text(
+                    widget.room.symbol ?? '⭐',
+                    style: const TextStyle(
+                      fontSize: 20,
+                      fontWeight: FontWeight.bold,
+                      color: Colors.white,
+                    ),
+                  ),
+                ),
+              ),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      widget.room.name,
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w700,
+                        color: isDark ? Colors.white : Colors.black87,
+                        letterSpacing: 0.5,
+                      ),
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 2),
+                    Text(
+                      'Rashi Discussion',
+                      style: TextStyle(
+                        fontSize: 12,
+                        fontWeight: FontWeight.w500,
+                        color: isDark 
+                            ? Colors.white.withOpacity(0.7)
+                            : Colors.black54,
+                        letterSpacing: 0.3,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          
+          const Spacer(),
+          
+          // Activity indicator
+          Row(
+            children: [
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  color: _getActivityColor(),
+                  shape: BoxShape.circle,
+                  boxShadow: [
+                    BoxShadow(
+                      color: _getActivityColor().withOpacity(0.6),
+                      blurRadius: 4,
+                      spreadRadius: 1,
+                    ),
+                  ],
+                ),
+              ),
+              const SizedBox(width: 8),
+              Text(
+                _getActivityText(),
+                style: TextStyle(
+                  fontSize: 11,
+                  fontWeight: FontWeight.w600,
+                  color: isDark 
+                      ? Colors.white.withOpacity(0.8)
+                      : Colors.black54,
+                  letterSpacing: 0.2,
+                ),
+              ),
+              const Spacer(),
+              Icon(
+                Icons.arrow_forward_ios,
+                size: 12,
+                color: isDark 
+                    ? Colors.white.withOpacity(0.6)
+                    : Colors.black38,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageBadge(BuildContext context, bool isDark) {
+    return AnimatedScale(
+      scale: _isHovered ? 1.1 : 1.0,
+      duration: const Duration(milliseconds: 200),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+        decoration: BoxDecoration(
+          gradient: LinearGradient(
+            colors: [
+              Colors.white.withOpacity(isDark ? 0.2 : 0.9),
+              Colors.white.withOpacity(isDark ? 0.1 : 0.8),
+            ],
+          ),
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(
+            color: Colors.white.withOpacity(0.3),
+            width: 1,
+          ),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 4,
+              offset: const Offset(0, 2),
+            ),
+          ],
+        ),
+        child: Text(
+          '${widget.room.dailyMessages}',
+          style: TextStyle(
+            fontSize: 11,
+            fontWeight: FontWeight.w700,
+            color: isDark ? Colors.white : Colors.black87,
+            letterSpacing: 0.2,
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getActivityColor() {
+    if (widget.room.dailyMessages > 150) return Colors.green;
+    if (widget.room.dailyMessages > 100) return Colors.orange;
+    return Colors.red;
+  }
+
+  String _getActivityText() {
+    if (widget.room.dailyMessages > 150) return 'Very Active';
+    if (widget.room.dailyMessages > 100) return 'Active';
+    return 'Quiet';
+  }
+}


### PR DESCRIPTION
## Summary
- add modern color palette utilities
- implement `ModernChatRoomCard` widget with glassmorphism effects
- update `ChatController` to use modern mock rooms and provide glassmorphism helpers
- switch home page to the new card design

## Testing
- `flutter test` *(fails: Some tests did not pass)*

------
https://chatgpt.com/codex/tasks/task_e_68472a79a1c0832daac24096e25ea345