### PR TITLE
Implement dropdown-based watchlist

### DIFF
--- a/test/watchlist_widget_test.dart
+++ b/test/watchlist_widget_test.dart
@@ -35,7 +35,6 @@ void main() {
       name: 'Test Item',
       count: 0,
       color: Colors.red,
-      icon: Icons.star,
     ));
 
     expect(controller.items.length, 1);
@@ -50,7 +49,6 @@ void main() {
       name: 'Undo Item',
       count: 0,
       color: Colors.blue,
-      icon: Icons.star,
     );
     await controller.addItem(item);
     expect(controller.items.length, 1);
@@ -72,7 +70,6 @@ void main() {
       name: 'Persisted',
       count: 0,
       color: Colors.green,
-      icon: Icons.star,
     );
     await controller.addItem(item);
 


### PR DESCRIPTION
## Summary
- update watchlist widget to use Rashi/Nakshatra dropdowns
- fetch options from `chat_rooms` and auto-refresh counts
- remove icon fields and update persistence model
- adjust tests for new watchlist item shape

## Testing
- `flutter test -r compact` *(fails: ChatRoom model expected color mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68485d3bde44832db11af1241b2b6ad3