### PR TITLE
Support Rashi & Nakshatra watchlist

### DIFF
--- a/test/watchlist_widget_test.dart
+++ b/test/watchlist_widget_test.dart
@@ -13,6 +13,7 @@ class TestAuthController extends AuthController {
   void onInit() {
     userId = uid;
   }
+
   @override
   Future<void> checkExistingSession() async {}
 }
@@ -35,6 +36,7 @@ void main() {
       name: 'Test Item',
       count: 0,
       color: Colors.red,
+      watchlistKey: 'k1',
     ));
 
     expect(controller.items.length, 1);
@@ -49,6 +51,7 @@ void main() {
       name: 'Undo Item',
       count: 0,
       color: Colors.blue,
+      watchlistKey: 'k2',
     );
     await controller.addItem(item);
     expect(controller.items.length, 1);
@@ -70,6 +73,7 @@ void main() {
       name: 'Persisted',
       count: 0,
       color: Colors.green,
+      watchlistKey: 'k3',
     );
     await controller.addItem(item);
 


### PR DESCRIPTION
## Summary
- query `rasi_master` and `nakshatra_master` collections for dropdowns
- generate a watchlist key per item and save it
- add helper to create three watchlist entries at once
- adjust UI to show watchlist key and call new method
- update widget tests for new parameter

## Testing
- `dart format lib/widgets/complete_enhanced_watchlist.dart test/watchlist_widget_test.dart`
- `flutter test` *(fails: MissingPluginException & type errors)*

------
https://chatgpt.com/codex/tasks/task_e_684944172bd0832d856e6217eb79014f