### PR TITLE
Fix watchlist item data mapping

### DIFF
--- a/lib/widgets/complete_enhanced_watchlist.dart
+++ b/lib/widgets/complete_enhanced_watchlist.dart
@@ -574,12 +574,13 @@ class WatchlistController extends GetxController {
       'name': item.name,
       'count': item.count,
       'colorValue': item.color.value,
-      'combinationKey': item.combinationKey,
-      'chatRoomId': item.chatRoomId,
       'watchlistKey': item.watchlistKey,
       'createdAt': item.createdAt.toIso8601String(),
       'updatedAt': (updatedAt ?? DateTime.now()).toIso8601String(),
       'order': order ?? _items.indexOf(item),
+      // Provide default values for optional schema fields
+      'iconCodePoint': 0xe885,
+      'iconFontFamily': 'MaterialIcons',
     };
   }
 


### PR DESCRIPTION
## Summary
- remove old `combinationKey` and `chatRoomId` fields when saving watchlist items
- add default values for icon fields in `_itemDataForDb`

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_684963337bfc832da7ca9b0f4e0dc099