### PR TITLE
Add user type sync with server

### DIFF
--- a/lib/controllers/user_type_controller.dart
+++ b/lib/controllers/user_type_controller.dart
@@ -31,6 +31,9 @@ class UserTypeController extends GetxController {
   static const String _defaultUserType = 'General User';
   static const List<String> _validUserTypes = ['General User', 'Astrologer'];
 
+  /// Expose the storage key for other classes (e.g. [AuthController])
+  static String get storageKey => _userTypeKey;
+
   final Logger _logger = Logger();
 
   @override
@@ -102,6 +105,15 @@ class UserTypeController extends GetxController {
     } finally {
       _isLoading.value = false;
     }
+  }
+
+  /// Sets the user type without any UI notifications. Intended for
+  /// synchronization with server values (e.g. during login).
+  Future<void> applyUserType(String type) async {
+    if (!_validUserTypes.contains(type)) {
+      type = _defaultUserType;
+    }
+    await _setUserTypeInternal(type, saveToStorage: true);
   }
 
   /// Convenience method to toggle between the two known types.

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -7,6 +7,7 @@ import 'package:image_cropper/image_cropper.dart';
 
 import '../controllers/auth_controller.dart';
 import '../widgets/safe_network_image.dart';
+import '../controllers/user_type_controller.dart';
 
 class ProfilePage extends GetView<AuthController> {
   const ProfilePage({super.key});
@@ -22,6 +23,7 @@ class ProfilePage extends GetView<AuthController> {
 
   @override
   Widget build(BuildContext context) {
+    final userTypeController = Get.find<UserTypeController>();
     return Scaffold(
       appBar: AppBar(
         title: Text('profile'.tr),
@@ -64,6 +66,32 @@ class ProfilePage extends GetView<AuthController> {
                 onPressed: _changePicture,
                 child: Text('change_picture'.tr),
               ),
+              const SizedBox(height: 16),
+              Obx(() => Row(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      const Text('User Type:'),
+                      const SizedBox(width: 8),
+                      DropdownButton<String>(
+                        value: userTypeController.userTypeRx.value,
+                        items: const [
+                          DropdownMenuItem(
+                            value: 'General User',
+                            child: Text('General User'),
+                          ),
+                          DropdownMenuItem(
+                            value: 'Astrologer',
+                            child: Text('Astrologer'),
+                          ),
+                        ],
+                        onChanged: (value) {
+                          if (value != null) {
+                            controller.updateUserType(value);
+                          }
+                        },
+                      ),
+                    ],
+                  )),
             ],
           ),
         ),


### PR DESCRIPTION
## Summary
- add storage key & silent setter in `UserTypeController`
- sync user type from backend when ensuring username
- clear user type on logout and reset locally
- allow updating user type on server
- expose dropdown on profile page to change type

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849b5cd2acc832db31bb97fa32e8ebf