### PR TITLE
Integrate modern UI pages

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,39 +1,40 @@
+// lib/main.dart - Updated to use modern UI system
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'bindings/auth_binding.dart';
-import 'pages/sign_in_page.dart';
-import 'pages/home_page.dart';
-import 'pages/set_username_page.dart';
-import 'pages/profile_page.dart';
+import 'pages/modern_sign_in_page.dart';
+import 'pages/modern_home_page.dart';
+import 'pages/modern_set_username_page.dart';
+import 'pages/modern_profile_page.dart';
+import 'pages/modern_chat_room_page.dart';
+import 'pages/modern_chat_rooms_list_page.dart';
 import 'pages/settings_page.dart';
 import 'pages/sliver_sample_page.dart';
-import 'pages/chat_room_page.dart';
-import 'pages/chat_rooms_list_page.dart';
 import 'design_system/modern_ui_system.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
-import 'controllers/theme_controller.dart'; // Import the ThemeController
+import 'controllers/theme_controller.dart';
 import 'controllers/user_type_controller.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env');
-  runApp(const MyApp());
+  runApp(const ModernStarChatApp());
 }
 
-class MyApp extends StatelessWidget {
-  const MyApp({super.key});
+class ModernStarChatApp extends StatelessWidget {
+  const ModernStarChatApp({super.key});
 
   @override
   Widget build(BuildContext context) {
-    // Initialize the ThemeController
+    // Initialize controllers
     final themeController = Get.put(ThemeController());
-    // Make UserTypeController globally available
     Get.put(UserTypeController(), permanent: true);
 
     return Obx(() => GetMaterialApp(
           title: 'StarChat',
+          // Use the modern design system themes
           theme: MD3ThemeSystem.createTheme(
             seedColor: Colors.deepPurple,
             brightness: Brightness.light,
@@ -44,61 +45,67 @@ class MyApp extends StatelessWidget {
           ),
           themeMode: themeController.isDarkMode.value
               ? ThemeMode.dark
-              : ThemeMode.light, // Reactive theme
+              : ThemeMode.light,
           initialBinding: AuthBinding(),
           initialRoute: '/',
           defaultTransition: Transition.cupertino,
-          transitionDuration: const Duration(milliseconds: 300),
+          transitionDuration: DesignTokens.durationNormal,
           getPages: [
             GetPage(
               name: '/',
-              page: () => const SignInPage(),
+              page: () => const ModernSignInPage(),
               binding: AuthBinding(),
               transition: Transition.fadeIn,
-              transitionDuration: const Duration(milliseconds: 400),
+              transitionDuration: DesignTokens.durationSlow,
             ),
             GetPage(
               name: '/set_username',
-              page: () => const SetUsernamePage(),
+              page: () => const ModernSetUsernamePage(),
               binding: AuthBinding(),
               transition: Transition.rightToLeft,
+              transitionDuration: DesignTokens.durationNormal,
             ),
             GetPage(
               name: '/home',
-              page: () => const HomePage(),
+              page: () => const ModernHomePage(),
               binding: AuthBinding(),
               transition: Transition.fadeIn,
-              transitionDuration: const Duration(milliseconds: 500),
+              transitionDuration: DesignTokens.durationSlow,
             ),
             GetPage(
               name: '/profile',
-              page: () => const ProfilePage(),
+              page: () => const ModernProfilePage(),
               binding: AuthBinding(),
               transition: Transition.rightToLeft,
+              transitionDuration: DesignTokens.durationNormal,
             ),
             GetPage(
               name: '/settings',
-              page: () => const SettingsPage(),
+              page: () => const SettingsPage(), // Keep existing or modernize
               binding: AuthBinding(),
               transition: Transition.rightToLeft,
+              transitionDuration: DesignTokens.durationNormal,
             ),
             GetPage(
               name: '/sliver',
               page: () => const SliverSamplePage(),
               binding: AuthBinding(),
               transition: Transition.rightToLeft,
+              transitionDuration: DesignTokens.durationNormal,
             ),
             GetPage(
               name: '/chat-room/:roomId',
-              page: () => const ChatRoomPage(),
+              page: () => const ModernChatRoomPage(),
               binding: AuthBinding(),
               transition: Transition.rightToLeft,
+              transitionDuration: DesignTokens.durationNormal,
             ),
             GetPage(
               name: '/chat-rooms-list',
-              page: () => const ChatRoomsListPage(),
+              page: () => const ModernChatRoomsListPage(),
               binding: AuthBinding(),
               transition: Transition.rightToLeft,
+              transitionDuration: DesignTokens.durationNormal,
             ),
           ],
           locale: Get.deviceLocale,
@@ -107,7 +114,6 @@ class MyApp extends StatelessWidget {
           supportedLocales: const [
             Locale('en', 'US'),
             Locale('es', 'ES'),
-            // Add other supported locales here
           ],
           localizationsDelegates: const [
             GlobalMaterialLocalizations.delegate,
@@ -117,8 +123,51 @@ class MyApp extends StatelessWidget {
           unknownRoute: GetPage(
             name: '/notfound',
             page: () => Scaffold(
-              appBar: AppBar(title: const Text('Page Not Found')),
-              body: const Center(child: Text('404 - Page Not Found')),
+              body: Center(
+                child: GlassmorphicCard(
+                  padding: DesignTokens.xl(context).all,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.error_outline_rounded,
+                        size: 64,
+                        color: Theme.of(context).colorScheme.error,
+                      ),
+                      SizedBox(height: DesignTokens.lg(context)),
+                      Text(
+                        '404 - Page Not Found',
+                        style: Theme.of(context).textTheme.headlineSmall,
+                      ),
+                      SizedBox(height: DesignTokens.md(context)),
+                      AnimatedButton(
+                        onPressed: () => Get.offAllNamed('/'),
+                        child: Container(
+                          padding: DesignTokens.md(context).all,
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [
+                                Theme.of(context).colorScheme.primary,
+                                Theme.of(context).colorScheme.secondary,
+                              ],
+                            ),
+                            borderRadius: BorderRadius.circular(
+                              DesignTokens.radiusLg(context),
+                            ),
+                          ),
+                          child: Text(
+                            'Go Home',
+                            style: TextStyle(
+                              color: Theme.of(context).colorScheme.onPrimary,
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
             ),
           ),
         ));

--- a/lib/pages/modern_chat_room_page.dart
+++ b/lib/pages/modern_chat_room_page.dart
@@ -1,0 +1,659 @@
+// lib/pages/modern_chat_room_page.dart
+// Modern chat room with glassmorphism and advanced animations
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/chat_controller.dart';
+import '../design_system/modern_ui_system.dart';
+import '../utils/modern_color_palettes.dart';
+import 'dart:ui';
+
+class ModernChatRoomPage extends StatefulWidget {
+  const ModernChatRoomPage({super.key});
+
+  @override
+  State<ModernChatRoomPage> createState() => _ModernChatRoomPageState();
+}
+
+class _ModernChatRoomPageState extends State<ModernChatRoomPage>
+    with TickerProviderStateMixin {
+  final ChatController controller = Get.find<ChatController>();
+  final TextEditingController _messageController = TextEditingController();
+  late AnimationController _slideController;
+  late AnimationController _bubbleController;
+  late Animation<Offset> _slideAnimation;
+  late Animation<double> _fadeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeAnimations();
+  }
+
+  void _initializeAnimations() {
+    _slideController = AnimationController(
+      duration: DesignTokens.durationNormal,
+      vsync: this,
+    );
+    _bubbleController = AnimationController(
+      duration: const Duration(seconds: 2),
+      vsync: this,
+    );
+
+    _slideAnimation = Tween<Offset>(
+      begin: const Offset(0, 0.1),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: _slideController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _fadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _slideController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _slideController.forward();
+    _bubbleController.repeat();
+  }
+
+  @override
+  void dispose() {
+    _slideController.dispose();
+    _bubbleController.dispose();
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final roomId = Get.parameters['roomId']!;
+
+    return Scaffold(
+      body: Obx(() {
+        final room = controller.getRoomById(roomId);
+        if (room == null) {
+          return _buildErrorState(context);
+        }
+
+        return AnimatedBuilder(
+          animation: _slideController,
+          builder: (context, child) {
+            return SlideTransition(
+              position: _slideAnimation,
+              child: FadeTransition(
+                opacity: _fadeAnimation,
+                child: _buildChatInterface(context, room),
+              ),
+            );
+          },
+        );
+      }),
+    );
+  }
+
+  Widget _buildErrorState(BuildContext context) {
+    return Center(
+      child: GlassmorphicCard(
+        padding: DesignTokens.xl(context).all,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.error_outline_rounded,
+              size: 64,
+              color: context.colorScheme.error,
+            ),
+            SizedBox(height: DesignTokens.lg(context)),
+            Text(
+              'Room Not Found',
+              style: context.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            SizedBox(height: DesignTokens.sm(context)),
+            Text(
+              'The chat room you\'re looking for doesn\'t exist.',
+              style: context.textTheme.bodyMedium?.copyWith(
+                color: context.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: DesignTokens.lg(context)),
+            AnimatedButton(
+              onPressed: () => Get.back(),
+              child: Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: DesignTokens.lg(context),
+                  vertical: DesignTokens.md(context),
+                ),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      context.colorScheme.primary,
+                      context.colorScheme.secondary,
+                    ],
+                  ),
+                  borderRadius: BorderRadius.circular(
+                    DesignTokens.radiusLg(context),
+                  ),
+                ),
+                child: Text(
+                  'Go Back',
+                  style: context.textTheme.bodyMedium?.copyWith(
+                    color: context.colorScheme.onPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChatInterface(BuildContext context, dynamic room) {
+    return Column(
+      children: [
+        _buildModernAppBar(context, room),
+        Expanded(
+          child: _buildChatArea(context, room),
+        ),
+        _buildMessageInput(context),
+      ],
+    );
+  }
+
+  Widget _buildModernAppBar(BuildContext context, dynamic room) {
+    return Container(
+      padding: EdgeInsets.only(
+        top: MediaQuery.of(context).padding.top + DesignTokens.sm(context),
+        bottom: DesignTokens.md(context),
+        left: DesignTokens.md(context),
+        right: DesignTokens.md(context),
+      ),
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topLeft,
+          end: Alignment.bottomRight,
+          colors: room.gradientColors.map((c) => c.withOpacity(0.1)).toList(),
+        ),
+      ),
+      child: Row(
+        children: [
+          AnimatedButton(
+            onPressed: () => Get.back(),
+            child: GlassmorphicContainer(
+              width: 40,
+              height: 40,
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusMd(context)),
+              child: Icon(
+                Icons.arrow_back_rounded,
+                color: context.colorScheme.primary,
+                size: 20,
+              ),
+            ),
+          ),
+          SizedBox(width: DesignTokens.md(context)),
+          // Room icon
+          Container(
+            width: 50,
+            height: 50,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(colors: room.gradientColors),
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusMd(context)),
+              boxShadow: [
+                BoxShadow(
+                  color: room.gradientColors[0].withOpacity(0.3),
+                  blurRadius: 8,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Center(
+              child: Text(
+                room.symbol ?? '⭐',
+                style: const TextStyle(
+                  fontSize: 24,
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+          SizedBox(width: DesignTokens.md(context)),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  room.name,
+                  style: context.textTheme.titleMedium?.copyWith(
+                    fontWeight: FontWeight.w700,
+                  ),
+                ),
+                Text(
+                  '${room.dailyMessages} messages today',
+                  style: context.textTheme.bodySmall?.copyWith(
+                    color: context.colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          AnimatedButton(
+            onPressed: () => _showRoomInfo(context, room),
+            child: GlassmorphicContainer(
+              width: 40,
+              height: 40,
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusMd(context)),
+              child: Icon(
+                Icons.info_outline_rounded,
+                color: context.colorScheme.primary,
+                size: 20,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChatArea(BuildContext context, dynamic room) {
+    return Container(
+      decoration: BoxDecoration(
+        gradient: LinearGradient(
+          begin: Alignment.topCenter,
+          end: Alignment.bottomCenter,
+          colors: [
+            context.colorScheme.surface,
+            context.colorScheme.surfaceVariant.withOpacity(0.3),
+          ],
+        ),
+      ),
+      child: AnimatedBuilder(
+        animation: _bubbleController,
+        builder: (context, child) {
+          return Stack(
+            children: [
+              // Floating background elements
+              ...List.generate(5, (index) {
+                final offset = (_bubbleController.value * 100) + (index * 50);
+                return Positioned(
+                  top: 100 + (index * 80.0) + (offset % 200),
+                  left: 20 + (index * 60.0) + (offset % 150),
+                  child: Container(
+                    width: 30 + (index * 5.0),
+                    height: 30 + (index * 5.0),
+                    decoration: BoxDecoration(
+                      color: room.gradientColors[0].withOpacity(0.05),
+                      shape: BoxShape.circle,
+                    ),
+                  ),
+                );
+              }),
+              Center(
+                child: _buildEmptyState(context, room),
+              ),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context, dynamic room) {
+    return GlassmorphicCard(
+      padding: DesignTokens.xl(context).all,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 80,
+            height: 80,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(colors: room.gradientColors),
+              shape: BoxShape.circle,
+              boxShadow: [
+                BoxShadow(
+                  color: room.gradientColors[0].withOpacity(0.4),
+                  blurRadius: 20,
+                  offset: const Offset(0, 8),
+                ),
+              ],
+            ),
+            child: Icon(
+              Icons.chat_bubble_rounded,
+              size: 40,
+              color: Colors.white,
+            ),
+          ),
+          SizedBox(height: DesignTokens.lg(context)),
+          Text(
+            'Welcome to ${room.name}',
+            style: context.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          SizedBox(height: DesignTokens.sm(context)),
+          Text(
+            'Start a conversation with other members of this rashi community',
+            style: context.textTheme.bodyMedium?.copyWith(
+              color: context.colorScheme.onSurfaceVariant,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          SizedBox(height: DesignTokens.lg(context)),
+          Container(
+            padding: DesignTokens.md(context).all,
+            decoration: BoxDecoration(
+              color: context.colorScheme.primaryContainer.withOpacity(0.5),
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusMd(context)),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.lightbulb_outline_rounded,
+                  size: 16,
+                  color: context.colorScheme.onPrimaryContainer,
+                ),
+                SizedBox(width: DesignTokens.sm(context)),
+                Text(
+                  'Real-time messaging coming soon!',
+                  style: context.textTheme.bodySmall?.copyWith(
+                    color: context.colorScheme.onPrimaryContainer,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMessageInput(BuildContext context) {
+    return Container(
+      padding: EdgeInsets.all(DesignTokens.md(context)),
+      decoration: BoxDecoration(
+        color: context.colorScheme.surface,
+        border: Border(
+          top: BorderSide(
+            color: context.colorScheme.outline.withOpacity(0.2),
+            width: 1,
+          ),
+        ),
+      ),
+      child: SafeArea(
+        top: false,
+        child: Row(
+          children: [
+            Expanded(
+              child: GlassmorphicContainer(
+                padding: const EdgeInsets.all(4),
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusXl(context)),
+                child: TextField(
+                  controller: _messageController,
+                  decoration: InputDecoration(
+                    hintText: 'Type a message...',
+                    hintStyle: TextStyle(
+                      color:
+                          context.colorScheme.onSurfaceVariant.withOpacity(0.6),
+                    ),
+                    border: OutlineInputBorder(
+                      borderRadius:
+                          BorderRadius.circular(DesignTokens.radiusXl(context)),
+                      borderSide: BorderSide.none,
+                    ),
+                    filled: true,
+                    fillColor:
+                        context.colorScheme.surfaceVariant.withOpacity(0.5),
+                    contentPadding: EdgeInsets.symmetric(
+                      horizontal: DesignTokens.lg(context),
+                      vertical: DesignTokens.md(context),
+                    ),
+                    prefixIcon: AnimatedButton(
+                      onPressed: () => _showEmojiPicker(context),
+                      child: Icon(
+                        Icons.emoji_emotions_outlined,
+                        color: context.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ),
+                  maxLines: null,
+                  textCapitalization: TextCapitalization.sentences,
+                  style: context.textTheme.bodyMedium,
+                ),
+              ),
+            ),
+            SizedBox(width: DesignTokens.sm(context)),
+            AnimatedButton(
+              onPressed: () => _sendMessage(context),
+              child: Container(
+                width: 48,
+                height: 48,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      context.colorScheme.primary,
+                      context.colorScheme.secondary,
+                    ],
+                  ),
+                  shape: BoxShape.circle,
+                  boxShadow: [
+                    BoxShadow(
+                      color: context.colorScheme.primary.withOpacity(0.3),
+                      blurRadius: 8,
+                      offset: const Offset(0, 2),
+                    ),
+                  ],
+                ),
+                child: Icon(
+                  Icons.send_rounded,
+                  color: context.colorScheme.onPrimary,
+                  size: 20,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showRoomInfo(BuildContext context, dynamic room) {
+    Get.bottomSheet(
+      Container(
+        padding: DesignTokens.xl(context).all,
+        decoration: BoxDecoration(
+          color: context.colorScheme.surface,
+          borderRadius: BorderRadius.vertical(
+            top: Radius.circular(DesignTokens.radiusXl(context)),
+          ),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              width: 40,
+              height: 4,
+              decoration: BoxDecoration(
+                color: context.colorScheme.onSurfaceVariant.withOpacity(0.3),
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            SizedBox(height: DesignTokens.lg(context)),
+            Container(
+              width: 80,
+              height: 80,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(colors: room.gradientColors),
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusLg(context)),
+                boxShadow: [
+                  BoxShadow(
+                    color: room.gradientColors[0].withOpacity(0.4),
+                    blurRadius: 12,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Center(
+                child: Text(
+                  room.symbol ?? '⭐',
+                  style: const TextStyle(
+                    fontSize: 32,
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+            SizedBox(height: DesignTokens.lg(context)),
+            Text(
+              room.name,
+              style: context.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            SizedBox(height: DesignTokens.sm(context)),
+            Text(
+              'Rashi Discussion Room',
+              style: context.textTheme.bodyMedium?.copyWith(
+                color: context.colorScheme.onSurfaceVariant,
+              ),
+            ),
+            SizedBox(height: DesignTokens.lg(context)),
+            Container(
+              padding: DesignTokens.md(context).all,
+              decoration: BoxDecoration(
+                color: context.colorScheme.primaryContainer.withOpacity(0.3),
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusMd(context)),
+              ),
+              child: Row(
+                mainAxisAlignment: MainAxisAlignment.spaceAround,
+                children: [
+                  _buildInfoItem(
+                    context,
+                    'Messages Today',
+                    '${room.dailyMessages}',
+                    Icons.chat_bubble_outline_rounded,
+                  ),
+                  _buildInfoItem(
+                    context,
+                    'Members',
+                    '1.2k',
+                    Icons.people_outline_rounded,
+                  ),
+                  _buildInfoItem(
+                    context,
+                    'Activity',
+                    'High',
+                    Icons.trending_up_rounded,
+                  ),
+                ],
+              ),
+            ),
+            SizedBox(height: DesignTokens.lg(context)),
+            AnimatedButton(
+              onPressed: () => Get.back(),
+              child: Container(
+                width: double.infinity,
+                height: 48,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      context.colorScheme.primary,
+                      context.colorScheme.secondary,
+                    ],
+                  ),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusLg(context)),
+                ),
+                child: Center(
+                  child: Text(
+                    'Close',
+                    style: context.textTheme.titleSmall?.copyWith(
+                      color: context.colorScheme.onPrimary,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInfoItem(
+    BuildContext context,
+    String label,
+    String value,
+    IconData icon,
+  ) {
+    return Column(
+      children: [
+        Icon(
+          icon,
+          color: context.colorScheme.primary,
+          size: 20,
+        ),
+        SizedBox(height: DesignTokens.xs(context)),
+        Text(
+          value,
+          style: context.textTheme.titleMedium?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colorScheme.primary,
+          ),
+        ),
+        Text(
+          label,
+          style: context.textTheme.bodySmall?.copyWith(
+            color: context.colorScheme.onSurfaceVariant,
+          ),
+        ),
+      ],
+    );
+  }
+
+  void _showEmojiPicker(BuildContext context) {
+    Get.snackbar(
+      'Coming Soon',
+      'Emoji picker will be available in the next update',
+      snackPosition: SnackPosition.BOTTOM,
+      duration: const Duration(seconds: 2),
+    );
+  }
+
+  void _sendMessage(BuildContext context) {
+    final message = _messageController.text.trim();
+    if (message.isEmpty) return;
+
+    MicroInteractions.lightHaptic();
+    _messageController.clear();
+
+    Get.snackbar(
+      'Message Sent',
+      'Real-time messaging will be implemented in the next phase',
+      snackPosition: SnackPosition.BOTTOM,
+      duration: const Duration(seconds: 2),
+      backgroundColor: context.colorScheme.primaryContainer,
+      colorText: context.colorScheme.onPrimaryContainer,
+    );
+  }
+}

--- a/lib/pages/modern_chat_rooms_list_page.dart
+++ b/lib/pages/modern_chat_rooms_list_page.dart
@@ -1,0 +1,314 @@
+// lib/pages/modern_chat_rooms_list_page.dart
+// Modern chat rooms list with grid layout and animations
+
+class ModernChatRoomsListPage extends StatefulWidget {
+  const ModernChatRoomsListPage({super.key});
+
+  @override
+  State<ModernChatRoomsListPage> createState() =>
+      _ModernChatRoomsListPageState();
+}
+
+class _ModernChatRoomsListPageState extends State<ModernChatRoomsListPage>
+    with TickerProviderStateMixin {
+  final ChatController controller = Get.find<ChatController>();
+  late AnimationController _listController;
+  late Animation<double> _listAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeAnimations();
+  }
+
+  void _initializeAnimations() {
+    _listController = AnimationController(
+      duration: DesignTokens.durationNormal,
+      vsync: this,
+    );
+
+    _listAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _listController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _listController.forward();
+  }
+
+  @override
+  void dispose() {
+    _listController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: AnimatedBuilder(
+        animation: _listController,
+        builder: (context, child) {
+          return FadeTransition(
+            opacity: _listAnimation,
+            child: CustomScrollView(
+              slivers: [
+                _buildModernAppBar(context),
+                _buildRoomsList(context),
+              ],
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildModernAppBar(BuildContext context) {
+    return SliverAppBar(
+      expandedHeight: 120,
+      floating: true,
+      pinned: true,
+      elevation: 0,
+      backgroundColor: Colors.transparent,
+      leading: AnimatedButton(
+        onPressed: () => Get.back(),
+        child: Icon(
+          Icons.arrow_back_rounded,
+          color: context.colorScheme.primary,
+        ),
+      ),
+      actions: [
+        AnimatedButton(
+          onPressed: controller.refreshRooms,
+          child: Icon(
+            Icons.refresh_rounded,
+            color: context.colorScheme.primary,
+          ),
+        ),
+        SizedBox(width: DesignTokens.md(context)),
+      ],
+      flexibleSpace: FlexibleSpaceBar(
+        centerTitle: false,
+        title: Text(
+          'All Chat Rooms',
+          style: context.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colorScheme.primary,
+          ),
+        ),
+        titlePadding: EdgeInsets.only(
+          left: DesignTokens.md(context),
+          bottom: DesignTokens.md(context),
+        ),
+        background: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                context.colorScheme.primary.withOpacity(0.1),
+                Colors.transparent,
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildRoomsList(BuildContext context) {
+    return Obx(() {
+      if (controller.isLoading.value) {
+        return SliverPadding(
+          padding: DesignTokens.md(context).all,
+          sliver: SliverGrid(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: ResponsiveUtils.adaptiveValue(
+                context,
+                mobile: 2,
+                tablet: 3,
+                desktop: 4,
+              ),
+              crossAxisSpacing: DesignTokens.md(context),
+              mainAxisSpacing: DesignTokens.md(context),
+              childAspectRatio: 1.0,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) => SkeletonLoader(
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusLg(context)),
+              ),
+              childCount: 12,
+            ),
+          ),
+        );
+      }
+
+      if (controller.rashiRooms.isEmpty) {
+        return SliverFillRemaining(
+          child: _buildEmptyState(context),
+        );
+      }
+
+      return SliverPadding(
+        padding: DesignTokens.md(context).all,
+        sliver: SliverGrid(
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: ResponsiveUtils.adaptiveValue(
+              context,
+              mobile: 2,
+              tablet: 3,
+              desktop: 4,
+            ),
+            crossAxisSpacing: DesignTokens.md(context),
+            mainAxisSpacing: DesignTokens.md(context),
+            childAspectRatio: 1.0,
+          ),
+          delegate: SliverChildBuilderDelegate(
+            (context, index) {
+              final room = controller.rashiRooms[index];
+              return StaggeredListItem(
+                index: index,
+                staggerDelay: const Duration(milliseconds: 100),
+                animationDuration: const Duration(milliseconds: 500),
+                child: AnimatedButton(
+                  onPressed: () => Get.toNamed('/chat-room/${room.id}'),
+                  child: _buildRoomCard(context, room, index),
+                ),
+              );
+            },
+            childCount: controller.rashiRooms.length,
+          ),
+        ),
+      );
+    });
+  }
+
+  Widget _buildRoomCard(BuildContext context, dynamic room, int index) {
+    return GlassmorphicContainer(
+      padding: DesignTokens.lg(context).all,
+      borderRadius: BorderRadius.circular(DesignTokens.radiusLg(context)),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 60,
+            height: 60,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(colors: room.gradientColors),
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusMd(context)),
+              boxShadow: [
+                BoxShadow(
+                  color: room.gradientColors[0].withOpacity(0.4),
+                  blurRadius: 12,
+                  offset: const Offset(0, 4),
+                ),
+              ],
+            ),
+            child: Center(
+              child: Text(
+                room.symbol ?? '⭐',
+                style: const TextStyle(
+                  fontSize: 28,
+                  color: Colors.white,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ),
+          ),
+          SizedBox(height: DesignTokens.md(context)),
+          Text(
+            room.name,
+            style: context.textTheme.titleSmall?.copyWith(
+              fontWeight: FontWeight.w700,
+            ),
+            textAlign: TextAlign.center,
+            maxLines: 2,
+            overflow: TextOverflow.ellipsis,
+          ),
+          SizedBox(height: DesignTokens.sm(context)),
+          Container(
+            padding: EdgeInsets.symmetric(
+              horizontal: DesignTokens.sm(context),
+              vertical: DesignTokens.xs(context),
+            ),
+            decoration: BoxDecoration(
+              color: context.colorScheme.primaryContainer.withOpacity(0.5),
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusSm(context)),
+            ),
+            child: Text(
+              '${room.dailyMessages} today',
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.colorScheme.onPrimaryContainer,
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildEmptyState(BuildContext context) {
+    return Center(
+      child: GlassmorphicCard(
+        padding: DesignTokens.xl(context).all,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              Icons.chat_bubble_outline_rounded,
+              size: 80,
+              color: context.colorScheme.onSurfaceVariant.withOpacity(0.5),
+            ),
+            SizedBox(height: DesignTokens.lg(context)),
+            Text(
+              'No Chat Rooms Available',
+              style: context.textTheme.headlineSmall?.copyWith(
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            SizedBox(height: DesignTokens.sm(context)),
+            Text(
+              'Check back later for active discussions',
+              style: context.textTheme.bodyMedium?.copyWith(
+                color: context.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: DesignTokens.lg(context)),
+            AnimatedButton(
+              onPressed: controller.refreshRooms,
+              child: Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: DesignTokens.lg(context),
+                  vertical: DesignTokens.md(context),
+                ),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      context.colorScheme.primary,
+                      context.colorScheme.secondary,
+                    ],
+                  ),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusLg(context)),
+                ),
+                child: Text(
+                  'Refresh',
+                  style: context.textTheme.bodyMedium?.copyWith(
+                    color: context.colorScheme.onPrimary,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/modern_profile_page.dart
+++ b/lib/pages/modern_profile_page.dart
@@ -1,0 +1,866 @@
+// lib/pages/modern_profile_page.dart
+// Modern profile page with glassmorphism and enhanced UX
+
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:image_cropper/image_cropper.dart';
+import '../controllers/auth_controller.dart';
+import '../controllers/user_type_controller.dart';
+import '../controllers/theme_controller.dart';
+import '../design_system/modern_ui_system.dart';
+import '../widgets/safe_network_image.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+class ModernProfilePage extends StatefulWidget {
+  const ModernProfilePage({super.key});
+
+  @override
+  State<ModernProfilePage> createState() => _ModernProfilePageState();
+}
+
+class _ModernProfilePageState extends State<ModernProfilePage>
+    with TickerProviderStateMixin {
+  late AnimationController _slideController;
+  late Animation<Offset> _slideAnimation;
+  late Animation<double> _fadeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeAnimations();
+  }
+
+  void _initializeAnimations() {
+    _slideController = AnimationController(
+      duration: DesignTokens.durationNormal,
+      vsync: this,
+    );
+
+    _slideAnimation = Tween<Offset>(
+      begin: const Offset(0, 0.3),
+      end: Offset.zero,
+    ).animate(CurvedAnimation(
+      parent: _slideController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _fadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _slideController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _slideController.forward();
+  }
+
+  @override
+  void dispose() {
+    _slideController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final authController = Get.find<AuthController>();
+    final userTypeController = Get.find<UserTypeController>();
+
+    return Scaffold(
+      body: AnimatedBuilder(
+        animation: _slideController,
+        builder: (context, child) {
+          return SlideTransition(
+            position: _slideAnimation,
+            child: FadeTransition(
+              opacity: _fadeAnimation,
+              child: CustomScrollView(
+                slivers: [
+                  _buildModernAppBar(context),
+                  SliverPadding(
+                    padding: ResponsiveUtils.getResponsivePadding(context),
+                    sliver: SliverList(
+                      delegate: SliverChildListDelegate([
+                        _buildProfileHeader(
+                            context, authController, userTypeController),
+                        SizedBox(height: DesignTokens.xl(context)),
+                        _buildProfileActions(context, authController),
+                        SizedBox(height: DesignTokens.xl(context)),
+                        _buildUserTypeSection(context, userTypeController),
+                        SizedBox(height: DesignTokens.xl(context)),
+                        _buildSettingsSection(context),
+                        SizedBox(height: DesignTokens.xxl(context)),
+                      ]),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildModernAppBar(BuildContext context) {
+    return SliverAppBar(
+      expandedHeight: 100,
+      floating: true,
+      pinned: true,
+      elevation: 0,
+      backgroundColor: Colors.transparent,
+      leading: AnimatedButton(
+        onPressed: () => Get.back(),
+        child: Icon(
+          Icons.arrow_back_rounded,
+          color: context.colorScheme.primary,
+        ),
+      ),
+      actions: [
+        AnimatedButton(
+          onPressed: () => Get.toNamed('/settings'),
+          child: Icon(
+            Icons.settings_rounded,
+            color: context.colorScheme.primary,
+          ),
+        ),
+        SizedBox(width: DesignTokens.md(context)),
+      ],
+      flexibleSpace: FlexibleSpaceBar(
+        centerTitle: true,
+        title: Text(
+          'profile'.tr,
+          style: context.textTheme.titleLarge?.copyWith(
+            fontWeight: FontWeight.w700,
+            color: context.colorScheme.primary,
+          ),
+        ),
+        background: Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                context.colorScheme.primary.withOpacity(0.1),
+                Colors.transparent,
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildProfileHeader(BuildContext context,
+      AuthController authController, UserTypeController userTypeController) {
+    return GlassmorphicCard(
+      padding: DesignTokens.xl(context).all,
+      child: Obx(() => Column(
+            children: [
+              // Profile Picture with floating effect
+              Stack(
+                alignment: Alignment.center,
+                children: [
+                  // Glow effect
+                  Container(
+                    width: 140,
+                    height: 140,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      gradient: RadialGradient(
+                        colors: [
+                          context.colorScheme.primary.withOpacity(0.3),
+                          Colors.transparent,
+                        ],
+                      ),
+                    ),
+                  ),
+                  // Profile picture
+                  GlassmorphicContainer(
+                    width: 120,
+                    height: 120,
+                    borderRadius: BorderRadius.circular(60),
+                    child: ClipOval(
+                      child: SafeNetworkImage(
+                        imageUrl: authController.profilePictureUrl.value,
+                        width: 120,
+                        height: 120,
+                        fit: BoxFit.cover,
+                        errorWidget: Container(
+                          decoration: BoxDecoration(
+                            gradient: LinearGradient(
+                              colors: [
+                                context.colorScheme.primary,
+                                context.colorScheme.secondary,
+                              ],
+                            ),
+                          ),
+                          child: Icon(
+                            Icons.person_rounded,
+                            size: 60,
+                            color: context.colorScheme.onPrimary,
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  // Edit button
+                  Positioned(
+                    bottom: 0,
+                    right: 0,
+                    child: AnimatedButton(
+                      onPressed: () => _changePicture(authController),
+                      child: Container(
+                        padding: DesignTokens.sm(context).all,
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: [
+                              context.colorScheme.primary,
+                              context.colorScheme.secondary,
+                            ],
+                          ),
+                          shape: BoxShape.circle,
+                          boxShadow: [
+                            BoxShadow(
+                              color:
+                                  context.colorScheme.primary.withOpacity(0.4),
+                              blurRadius: 8,
+                              offset: const Offset(0, 2),
+                            ),
+                          ],
+                        ),
+                        child: Icon(
+                          Icons.camera_alt_rounded,
+                          color: context.colorScheme.onPrimary,
+                          size: 20,
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+              SizedBox(height: DesignTokens.lg(context)),
+              // Username
+              Text(
+                authController.username.value.isNotEmpty
+                    ? authController.username.value
+                    : 'User',
+                style: context.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              SizedBox(height: DesignTokens.sm(context)),
+              // User type badge
+              Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: DesignTokens.md(context),
+                  vertical: DesignTokens.sm(context),
+                ),
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      context.colorScheme.primaryContainer,
+                      context.colorScheme.secondaryContainer,
+                    ],
+                  ),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusLg(context)),
+                ),
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      userTypeController.isAstrologerRx.value
+                          ? Icons.auto_awesome_rounded
+                          : Icons.person_rounded,
+                      size: 16,
+                      color: context.colorScheme.onPrimaryContainer,
+                    ),
+                    SizedBox(width: DesignTokens.sm(context)),
+                    Text(
+                      userTypeController.userTypeRx.value,
+                      style: context.textTheme.bodyMedium?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: context.colorScheme.onPrimaryContainer,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          )),
+    );
+  }
+
+  Widget _buildProfileActions(
+      BuildContext context, AuthController authController) {
+    return Column(
+      children: [
+        Row(
+          children: [
+            Expanded(
+              child: _buildActionCard(
+                context,
+                icon: Icons.edit_rounded,
+                title: 'change_username'.tr,
+                subtitle: 'Update your display name',
+                onTap: () => Get.toNamed('/set_username'),
+                gradient: [
+                  context.colorScheme.primary,
+                  context.colorScheme.secondary,
+                ],
+              ),
+            ),
+            SizedBox(width: DesignTokens.md(context)),
+            Expanded(
+              child: _buildActionCard(
+                context,
+                icon: Icons.photo_camera_rounded,
+                title: 'change_picture'.tr,
+                subtitle: 'Update profile photo',
+                onTap: () => _changePicture(authController),
+                gradient: [
+                  context.colorScheme.tertiary,
+                  context.colorScheme.primary,
+                ],
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildActionCard(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    required VoidCallback onTap,
+    required List<Color> gradient,
+  }) {
+    return AnimatedButton(
+      onPressed: onTap,
+      child: GlassmorphicContainer(
+        height: 120,
+        padding: DesignTokens.lg(context).all,
+        borderRadius: BorderRadius.circular(DesignTokens.radiusLg(context)),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Container(
+              padding: DesignTokens.sm(context).all,
+              decoration: BoxDecoration(
+                gradient: LinearGradient(colors: gradient),
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusMd(context)),
+              ),
+              child: Icon(
+                icon,
+                color: Colors.white,
+                size: 24,
+              ),
+            ),
+            SizedBox(height: DesignTokens.md(context)),
+            Text(
+              title,
+              style: context.textTheme.titleSmall?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+              textAlign: TextAlign.center,
+            ),
+            SizedBox(height: DesignTokens.xs(context)),
+            Text(
+              subtitle,
+              style: context.textTheme.bodySmall?.copyWith(
+                color: context.colorScheme.onSurfaceVariant,
+              ),
+              textAlign: TextAlign.center,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildUserTypeSection(
+      BuildContext context, UserTypeController userTypeController) {
+    return GlassmorphicCard(
+      padding: DesignTokens.lg(context).all,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: DesignTokens.sm(context).all,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      context.colorScheme.secondary,
+                      context.colorScheme.tertiary,
+                    ],
+                  ),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusMd(context)),
+                ),
+                child: Icon(
+                  Icons.swap_horiz_rounded,
+                  color: context.colorScheme.onSecondary,
+                  size: 20,
+                ),
+              ),
+              SizedBox(width: DesignTokens.md(context)),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'User Type',
+                      style: context.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    Text(
+                      'Switch between user types',
+                      style: context.textTheme.bodySmall?.copyWith(
+                        color: context.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: DesignTokens.lg(context)),
+          Obx(() => Column(
+                children: [
+                  _buildUserTypeOption(
+                    context,
+                    'General User',
+                    'Standard user with access to predictions and chat',
+                    Icons.person_rounded,
+                    userTypeController.userTypeRx.value == 'General User',
+                    () => _updateUserType(userTypeController, 'General User'),
+                  ),
+                  SizedBox(height: DesignTokens.md(context)),
+                  _buildUserTypeOption(
+                    context,
+                    'Astrologer',
+                    'Professional astrologer with creation tools',
+                    Icons.auto_awesome_rounded,
+                    userTypeController.userTypeRx.value == 'Astrologer',
+                    () => _updateUserType(userTypeController, 'Astrologer'),
+                  ),
+                ],
+              )),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUserTypeOption(
+    BuildContext context,
+    String type,
+    String description,
+    IconData icon,
+    bool isSelected,
+    VoidCallback onTap,
+  ) {
+    return AnimatedButton(
+      onPressed: onTap,
+      child: Container(
+        padding: DesignTokens.md(context).all,
+        decoration: BoxDecoration(
+          gradient: isSelected
+              ? LinearGradient(
+                  colors: [
+                    context.colorScheme.primary.withOpacity(0.2),
+                    context.colorScheme.secondary.withOpacity(0.1),
+                  ],
+                )
+              : null,
+          borderRadius: BorderRadius.circular(DesignTokens.radiusMd(context)),
+          border: Border.all(
+            color: isSelected
+                ? context.colorScheme.primary
+                : context.colorScheme.outline.withOpacity(0.3),
+            width: isSelected ? 2 : 1,
+          ),
+        ),
+        child: Row(
+          children: [
+            Container(
+              padding: DesignTokens.sm(context).all,
+              decoration: BoxDecoration(
+                color: isSelected
+                    ? context.colorScheme.primary
+                    : context.colorScheme.surfaceVariant,
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusSm(context)),
+              ),
+              child: Icon(
+                icon,
+                color: isSelected
+                    ? context.colorScheme.onPrimary
+                    : context.colorScheme.onSurfaceVariant,
+                size: 20,
+              ),
+            ),
+            SizedBox(width: DesignTokens.md(context)),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    type,
+                    style: context.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: isSelected
+                          ? context.colorScheme.primary
+                          : context.colorScheme.onSurface,
+                    ),
+                  ),
+                  Text(
+                    description,
+                    style: context.textTheme.bodySmall?.copyWith(
+                      color: context.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (isSelected)
+              Icon(
+                Icons.check_circle_rounded,
+                color: context.colorScheme.primary,
+                size: 20,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildSettingsSection(BuildContext context) {
+    final themeController = Get.find<ThemeController>();
+
+    return GlassmorphicCard(
+      padding: DesignTokens.lg(context).all,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Container(
+                padding: DesignTokens.sm(context).all,
+                decoration: BoxDecoration(
+                  gradient: LinearGradient(
+                    colors: [
+                      context.colorScheme.tertiary,
+                      context.colorScheme.primary,
+                    ],
+                  ),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusMd(context)),
+                ),
+                child: Icon(
+                  Icons.settings_rounded,
+                  color: context.colorScheme.onTertiary,
+                  size: 20,
+                ),
+              ),
+              SizedBox(width: DesignTokens.md(context)),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      'Quick Settings',
+                      style: context.textTheme.titleMedium?.copyWith(
+                        fontWeight: FontWeight.w700,
+                      ),
+                    ),
+                    Text(
+                      'Personalize your experience',
+                      style: context.textTheme.bodySmall?.copyWith(
+                        color: context.colorScheme.onSurfaceVariant,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ),
+          SizedBox(height: DesignTokens.lg(context)),
+          Obx(() => _buildSettingsTile(
+                context,
+                icon: themeController.isDarkMode.value
+                    ? Icons.dark_mode_rounded
+                    : Icons.light_mode_rounded,
+                title: 'dark_mode'.tr,
+                subtitle: 'Toggle between light and dark themes',
+                trailing: Switch(
+                  value: themeController.isDarkMode.value,
+                  onChanged: (_) => themeController.toggleTheme(),
+                ),
+              )),
+          _buildSettingsTile(
+            context,
+            icon: Icons.notifications_rounded,
+            title: 'push_notifications'.tr,
+            subtitle: 'Receive updates and alerts',
+            trailing: Switch(
+              value: true,
+              onChanged: (value) {
+                // TODO: Implement notification settings
+                Get.snackbar('Coming Soon',
+                    'Notification settings will be available soon');
+              },
+            ),
+          ),
+          _buildSettingsTile(
+            context,
+            icon: Icons.info_rounded,
+            title: 'version'.tr,
+            subtitle: 'App version information',
+            trailing: FutureBuilder<PackageInfo>(
+              future: PackageInfo.fromPlatform(),
+              builder: (context, snapshot) {
+                return Text(
+                  snapshot.hasData ? snapshot.data!.version : '...',
+                  style: context.textTheme.bodyMedium?.copyWith(
+                    color: context.colorScheme.onSurfaceVariant,
+                  ),
+                );
+              },
+            ),
+            onTap: () {},
+          ),
+          const Divider(),
+          _buildSettingsTile(
+            context,
+            icon: Icons.logout_rounded,
+            title: 'logout'.tr,
+            subtitle: 'Sign out of your account',
+            isDestructive: true,
+            onTap: () => _showLogoutDialog(context),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSettingsTile(
+    BuildContext context, {
+    required IconData icon,
+    required String title,
+    required String subtitle,
+    Widget? trailing,
+    VoidCallback? onTap,
+    bool isDestructive = false,
+  }) {
+    return AnimatedButton(
+      onPressed: onTap,
+      child: Container(
+        padding: DesignTokens.md(context).all,
+        margin: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(DesignTokens.radiusMd(context)),
+        ),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              color: isDestructive
+                  ? context.colorScheme.error
+                  : context.colorScheme.primary,
+              size: 24,
+            ),
+            SizedBox(width: DesignTokens.md(context)),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: context.textTheme.titleSmall?.copyWith(
+                      fontWeight: FontWeight.w600,
+                      color: isDestructive
+                          ? context.colorScheme.error
+                          : context.colorScheme.onSurface,
+                    ),
+                  ),
+                  Text(
+                    subtitle,
+                    style: context.textTheme.bodySmall?.copyWith(
+                      color: context.colorScheme.onSurfaceVariant,
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            if (trailing != null) trailing,
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _changePicture(AuthController authController) async {
+    try {
+      final picker = ImagePicker();
+      final picked = await picker.pickImage(
+        source: ImageSource.gallery,
+        maxWidth: 512,
+        maxHeight: 512,
+        imageQuality: 80,
+      );
+
+      if (picked == null) return;
+
+      final cropped = await ImageCropper().cropImage(
+        sourcePath: picked.path,
+        aspectRatio: const CropAspectRatio(ratioX: 1, ratioY: 1),
+        uiSettings: [
+          AndroidUiSettings(
+            toolbarTitle: 'Crop Profile Picture',
+            toolbarColor: Theme.of(context).colorScheme.primary,
+            toolbarWidgetColor: Theme.of(context).colorScheme.onPrimary,
+            initAspectRatio: CropAspectRatioPreset.square,
+            lockAspectRatio: true,
+          ),
+          IOSUiSettings(
+            title: 'Crop Profile Picture',
+            aspectRatioLockEnabled: true,
+            resetAspectRatioEnabled: false,
+          ),
+        ],
+      );
+
+      if (cropped != null) {
+        final file = File(cropped.path);
+        await authController.updateProfilePicture(file);
+        MicroInteractions.mediumHaptic();
+      }
+    } catch (e) {
+      Get.snackbar(
+        'Error',
+        'Failed to update profile picture. Please try again.',
+        snackPosition: SnackPosition.BOTTOM,
+        backgroundColor: Theme.of(context).colorScheme.errorContainer,
+        colorText: Theme.of(context).colorScheme.onErrorContainer,
+      );
+    }
+  }
+
+  Future<void> _updateUserType(
+      UserTypeController controller, String type) async {
+    if (controller.userTypeRx.value == type) return;
+
+    MicroInteractions.lightHaptic();
+    await Get.find<AuthController>().updateUserType(type);
+  }
+
+  void _showLogoutDialog(BuildContext context) {
+    Get.dialog(
+      Dialog(
+        backgroundColor: Colors.transparent,
+        child: GlassmorphicContainer(
+          padding: DesignTokens.xl(context).all,
+          borderRadius: BorderRadius.circular(DesignTokens.radiusXl(context)),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                Icons.logout_rounded,
+                size: 48,
+                color: context.colorScheme.error,
+              ),
+              SizedBox(height: DesignTokens.lg(context)),
+              Text(
+                'logout'.tr,
+                style: context.textTheme.headlineSmall?.copyWith(
+                  fontWeight: FontWeight.w700,
+                ),
+              ),
+              SizedBox(height: DesignTokens.md(context)),
+              Text(
+                'logout_confirm'.tr,
+                style: context.textTheme.bodyMedium?.copyWith(
+                  color: context.colorScheme.onSurfaceVariant,
+                ),
+                textAlign: TextAlign.center,
+              ),
+              SizedBox(height: DesignTokens.xl(context)),
+              Row(
+                children: [
+                  Expanded(
+                    child: AnimatedButton(
+                      onPressed: () => Get.back(),
+                      child: Container(
+                        height: 48,
+                        decoration: BoxDecoration(
+                          border: Border.all(
+                            color: context.colorScheme.outline,
+                          ),
+                          borderRadius: BorderRadius.circular(
+                            DesignTokens.radiusLg(context),
+                          ),
+                        ),
+                        child: Center(
+                          child: Text(
+                            'cancel'.tr,
+                            style: context.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.w600,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: DesignTokens.md(context)),
+                  Expanded(
+                    child: AnimatedButton(
+                      onPressed: () async {
+                        Get.back();
+                        await Get.find<AuthController>().logout();
+                      },
+                      child: Container(
+                        height: 48,
+                        decoration: BoxDecoration(
+                          gradient: LinearGradient(
+                            colors: [
+                              context.colorScheme.error,
+                              context.colorScheme.error.withOpacity(0.8),
+                            ],
+                          ),
+                          borderRadius: BorderRadius.circular(
+                            DesignTokens.radiusLg(context),
+                          ),
+                        ),
+                        child: Center(
+                          child: Text(
+                            'logout'.tr,
+                            style: context.textTheme.titleSmall?.copyWith(
+                              fontWeight: FontWeight.w600,
+                              color: context.colorScheme.onError,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/pages/modern_set_username_page.dart
+++ b/lib/pages/modern_set_username_page.dart
@@ -1,0 +1,554 @@
+// lib/pages/modern_set_username_page.dart
+// Modern username setup with real-time validation and animations
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/auth_controller.dart';
+import '../design_system/modern_ui_system.dart';
+import 'dart:ui';
+
+class ModernSetUsernamePage extends StatefulWidget {
+  const ModernSetUsernamePage({super.key});
+
+  @override
+  State<ModernSetUsernamePage> createState() => _ModernSetUsernamePageState();
+}
+
+class _ModernSetUsernamePageState extends State<ModernSetUsernamePage>
+    with TickerProviderStateMixin {
+  final AuthController controller = Get.find<AuthController>();
+  late AnimationController _backgroundController;
+  late AnimationController _formController;
+  late AnimationController _validationController;
+  late Animation<double> _backgroundAnimation;
+  late Animation<double> _formSlideAnimation;
+  late Animation<double> _formFadeAnimation;
+  late Animation<double> _validationScaleAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _initializeAnimations();
+  }
+
+  void _initializeAnimations() {
+    _backgroundController = AnimationController(
+      duration: const Duration(seconds: 4),
+      vsync: this,
+    );
+    _formController = AnimationController(
+      duration: DesignTokens.durationNormal,
+      vsync: this,
+    );
+    _validationController = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+
+    _backgroundAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(_backgroundController);
+
+    _formSlideAnimation = Tween<double>(
+      begin: 30.0,
+      end: 0.0,
+    ).animate(CurvedAnimation(
+      parent: _formController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _formFadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _formController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _validationScaleAnimation = Tween<double>(
+      begin: 0.8,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _validationController,
+      curve: Curves.elasticOut,
+    ));
+
+    _backgroundController.repeat();
+    _formController.forward();
+  }
+
+  @override
+  void dispose() {
+    _backgroundController.dispose();
+    _formController.dispose();
+    _validationController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: Stack(
+        children: [
+          _buildAnimatedBackground(context),
+          _buildContent(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAnimatedBackground(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _backgroundAnimation,
+      builder: (context, child) {
+        return Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topCenter,
+              end: Alignment.bottomCenter,
+              colors: [
+                context.colorScheme.primary.withOpacity(0.7),
+                context.colorScheme.secondary.withOpacity(0.5),
+                context.colorScheme.tertiary.withOpacity(0.3),
+              ],
+              transform:
+                  GradientRotation(_backgroundAnimation.value * 2 * 3.14159),
+            ),
+          ),
+          child: Stack(
+            children: [
+              // Animated particles
+              ...List.generate(6, (index) {
+                final offset =
+                    (index * 60.0) + (_backgroundAnimation.value * 40);
+                return Positioned(
+                  top: 150 + (index * 100.0) + (offset % 200),
+                  left: 20 + (index * 50.0) + (offset % 100),
+                  child: _buildParticle(
+                    size: 30 + (index * 10.0),
+                    opacity: 0.1 - (index * 0.01),
+                  ),
+                );
+              }),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildParticle({required double size, required double opacity}) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(opacity),
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return SafeArea(
+      child: AnimatedBuilder(
+        animation: _formController,
+        builder: (context, child) {
+          return Transform.translate(
+            offset: Offset(0, _formSlideAnimation.value),
+            child: Opacity(
+              opacity: _formFadeAnimation.value,
+              child: Column(
+                children: [
+                  _buildHeader(context),
+                  Expanded(
+                    child: Center(
+                      child: SingleChildScrollView(
+                        padding: ResponsiveUtils.adaptiveValue(
+                          context,
+                          mobile: DesignTokens.lg(context).all,
+                          tablet: EdgeInsets.symmetric(
+                            horizontal: MediaQuery.of(context).size.width * 0.2,
+                            vertical: DesignTokens.lg(context),
+                          ),
+                          desktop: EdgeInsets.symmetric(
+                            horizontal: MediaQuery.of(context).size.width * 0.3,
+                            vertical: DesignTokens.xl(context),
+                          ),
+                        ),
+                        child: _buildMainCard(context),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Container(
+      padding: DesignTokens.lg(context).all,
+      child: Column(
+        children: [
+          GlassmorphicContainer(
+            width: 60,
+            height: 60,
+            borderRadius: BorderRadius.circular(DesignTokens.radiusLg(context)),
+            child: Icon(
+              Icons.person_add_rounded,
+              size: 30,
+              color: Colors.white,
+            ),
+          ),
+          SizedBox(height: DesignTokens.md(context)),
+          Text(
+            'enter_username'.tr,
+            style: context.textTheme.headlineMedium?.copyWith(
+              color: Colors.white,
+              fontWeight: FontWeight.w800,
+            ),
+          ),
+          SizedBox(height: DesignTokens.sm(context)),
+          Text(
+            'Choose a unique username to continue',
+            style: context.textTheme.bodyMedium?.copyWith(
+              color: Colors.white.withOpacity(0.8),
+            ),
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMainCard(BuildContext context) {
+    return GlassmorphicContainer(
+      padding: ResponsiveUtils.adaptiveValue(
+        context,
+        mobile: DesignTokens.xl(context).all,
+        tablet: DesignTokens.xxl(context).all,
+        desktop: DesignTokens.xxl(context).all,
+      ),
+      borderRadius: BorderRadius.circular(DesignTokens.radiusXl(context)),
+      blur: 20,
+      opacity: 0.15,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildUsernameField(context),
+          SizedBox(height: DesignTokens.lg(context)),
+          _buildValidationStatus(context),
+          SizedBox(height: DesignTokens.xl(context)),
+          _buildSubmitButton(context),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildUsernameField(BuildContext context) {
+    return Obx(() => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GlassmorphicContainer(
+              padding: const EdgeInsets.all(4),
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusLg(context)),
+              child: TextField(
+                controller: controller.usernameController,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'username'.tr,
+                  hintStyle: TextStyle(
+                    color: Colors.white.withOpacity(0.5),
+                    fontSize: 18,
+                  ),
+                  prefixIcon: Icon(
+                    Icons.alternate_email_rounded,
+                    color: Colors.white.withOpacity(0.8),
+                  ),
+                  suffixIcon: controller.usernameText.value.isNotEmpty
+                      ? AnimatedButton(
+                          onPressed: controller.clearUsernameInput,
+                          child: Icon(
+                            Icons.clear_rounded,
+                            color: Colors.white.withOpacity(0.6),
+                          ),
+                        )
+                      : null,
+                  border: OutlineInputBorder(
+                    borderRadius:
+                        BorderRadius.circular(DesignTokens.radiusLg(context)),
+                    borderSide: BorderSide.none,
+                  ),
+                  filled: true,
+                  fillColor: Colors.white.withOpacity(0.1),
+                  contentPadding: DesignTokens.lg(context).all,
+                ),
+                onChanged: (value) {
+                  controller.onUsernameChanged(value);
+                  if (controller.hasCheckedUsername.value) {
+                    _validationController.forward();
+                  }
+                },
+              ),
+            ),
+            if (controller.usernameError.value.isNotEmpty) ...[
+              SizedBox(height: DesignTokens.sm(context)),
+              Container(
+                padding: DesignTokens.sm(context).all,
+                decoration: BoxDecoration(
+                  color: Colors.red.withOpacity(0.2),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusSm(context)),
+                  border: Border.all(
+                    color: Colors.red.withOpacity(0.3),
+                    width: 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.error_outline_rounded,
+                      color: Colors.red.shade200,
+                      size: 16,
+                    ),
+                    SizedBox(width: DesignTokens.sm(context)),
+                    Expanded(
+                      child: Text(
+                        controller.usernameError.value,
+                        style: context.textTheme.bodySmall?.copyWith(
+                          color: Colors.red.shade200,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ));
+  }
+
+  Widget _buildValidationStatus(BuildContext context) {
+    return Obx(() {
+      if (!controller.hasCheckedUsername.value &&
+          controller.usernameText.value.isEmpty) {
+        return const SizedBox.shrink();
+      }
+
+      return AnimatedBuilder(
+        animation: _validationController,
+        builder: (context, child) {
+          return Transform.scale(
+            scale: _validationScaleAnimation.value,
+            child: _buildValidationContent(context),
+          );
+        },
+      );
+    });
+  }
+
+  Widget _buildValidationContent(BuildContext context) {
+    return Obx(() {
+      if (controller.isCheckingUsername.value) {
+        return _buildValidationCard(
+          context,
+          icon: Container(
+            width: 20,
+            height: 20,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(Colors.blue.shade200),
+            ),
+          ),
+          title: 'Checking availability...',
+          subtitle: 'Please wait while we verify your username',
+          color: Colors.blue,
+        );
+      }
+
+      if (!controller.isUsernameValid.value &&
+          controller.usernameText.value.isNotEmpty) {
+        return _buildValidationCard(
+          context,
+          icon: Icon(Icons.close_rounded, color: Colors.red.shade200, size: 20),
+          title: 'Invalid username',
+          subtitle:
+              'Username must be 3-15 characters with letters, numbers, and underscores only',
+          color: Colors.red,
+        );
+      }
+
+      if (controller.isUsernameValid.value &&
+          !controller.usernameAvailable.value) {
+        return _buildValidationCard(
+          context,
+          icon: Icon(Icons.close_rounded,
+              color: Colors.orange.shade200, size: 20),
+          title: 'Username taken',
+          subtitle: 'This username is already in use. Please try another one.',
+          color: Colors.orange,
+        );
+      }
+
+      if (controller.isUsernameValid.value &&
+          controller.usernameAvailable.value) {
+        return _buildValidationCard(
+          context,
+          icon:
+              Icon(Icons.check_rounded, color: Colors.green.shade200, size: 20),
+          title: 'Username available!',
+          subtitle: 'Great choice! This username is ready to use.',
+          color: Colors.green,
+        );
+      }
+
+      return const SizedBox.shrink();
+    });
+  }
+
+  Widget _buildValidationCard(
+    BuildContext context, {
+    required Widget icon,
+    required String title,
+    required String subtitle,
+    required Color color,
+  }) {
+    return Container(
+      padding: DesignTokens.md(context).all,
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.2),
+        borderRadius: BorderRadius.circular(DesignTokens.radiusMd(context)),
+        border: Border.all(
+          color: color.withOpacity(0.3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        children: [
+          icon,
+          SizedBox(width: DesignTokens.md(context)),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  title,
+                  style: context.textTheme.titleSmall?.copyWith(
+                    color: color.shade200,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+                Text(
+                  subtitle,
+                  style: context.textTheme.bodySmall?.copyWith(
+                    color: color.shade200.withOpacity(0.8),
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildSubmitButton(BuildContext context) {
+    return Obx(() {
+      final isEnabled = controller.isUsernameValid.value &&
+          controller.usernameAvailable.value &&
+          !controller.isLoading.value;
+
+      return SizedBox(
+        width: double.infinity,
+        height: 56,
+        child: AnimatedButton(
+          onPressed: isEnabled ? controller.submitUsername : null,
+          child: Container(
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: isEnabled
+                    ? [
+                        Colors.white.withOpacity(0.9),
+                        Colors.white.withOpacity(0.7),
+                      ]
+                    : [
+                        Colors.grey.withOpacity(0.5),
+                        Colors.grey.withOpacity(0.3),
+                      ],
+              ),
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusLg(context)),
+              boxShadow: isEnabled
+                  ? [
+                      BoxShadow(
+                        color: Colors.black.withOpacity(0.2),
+                        blurRadius: 12,
+                        offset: const Offset(0, 6),
+                      ),
+                    ]
+                  : null,
+            ),
+            child: Center(
+              child: controller.isLoading.value
+                  ? Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        SizedBox(
+                          width: 20,
+                          height: 20,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              context.colorScheme.primary,
+                            ),
+                          ),
+                        ),
+                        SizedBox(width: DesignTokens.sm(context)),
+                        Text(
+                          'Creating account...',
+                          style: context.textTheme.titleMedium?.copyWith(
+                            color: context.colorScheme.primary,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ],
+                    )
+                  : Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Icon(
+                          Icons.check_rounded,
+                          color: isEnabled
+                              ? context.colorScheme.primary
+                              : context.colorScheme.onSurfaceVariant,
+                          size: 20,
+                        ),
+                        SizedBox(width: DesignTokens.sm(context)),
+                        Text(
+                          'save'.tr,
+                          style: context.textTheme.titleMedium?.copyWith(
+                            color: isEnabled
+                                ? context.colorScheme.primary
+                                : context.colorScheme.onSurfaceVariant,
+                            fontWeight: FontWeight.w700,
+                          ),
+                        ),
+                      ],
+                    ),
+            ),
+          ),
+        ),
+      );
+    });
+  }
+}

--- a/lib/pages/modern_sign_in_page.dart
+++ b/lib/pages/modern_sign_in_page.dart
@@ -1,0 +1,681 @@
+// lib/pages/modern_sign_in_page.dart
+// Completely modernized sign-in page with glassmorphism and animations
+
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../controllers/auth_controller.dart';
+import '../design_system/modern_ui_system.dart';
+import 'dart:ui';
+
+class ModernSignInPage extends StatefulWidget {
+  const ModernSignInPage({super.key});
+
+  @override
+  State<ModernSignInPage> createState() => _ModernSignInPageState();
+}
+
+class _ModernSignInPageState extends State<ModernSignInPage>
+    with TickerProviderStateMixin {
+  final AuthController controller = Get.find<AuthController>();
+  late AnimationController _backgroundController;
+  late AnimationController _formController;
+  late Animation<double> _backgroundAnimation;
+  late Animation<double> _formSlideAnimation;
+  late Animation<double> _formFadeAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    controller.resetSignInState();
+    _initializeAnimations();
+  }
+
+  void _initializeAnimations() {
+    _backgroundController = AnimationController(
+      duration: const Duration(seconds: 3),
+      vsync: this,
+    );
+    _formController = AnimationController(
+      duration: DesignTokens.durationNormal,
+      vsync: this,
+    );
+
+    _backgroundAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _backgroundController,
+      curve: Curves.linear,
+    ));
+
+    _formSlideAnimation = Tween<double>(
+      begin: 50.0,
+      end: 0.0,
+    ).animate(CurvedAnimation(
+      parent: _formController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _formFadeAnimation = Tween<double>(
+      begin: 0.0,
+      end: 1.0,
+    ).animate(CurvedAnimation(
+      parent: _formController,
+      curve: DesignTokens.curveEaseOut,
+    ));
+
+    _backgroundController.repeat();
+    _formController.forward();
+  }
+
+  @override
+  void dispose() {
+    _backgroundController.dispose();
+    _formController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final fromAddAccount = Get.arguments?["fromAddAccount"] ?? false;
+
+    return Scaffold(
+      body: Stack(
+        children: [
+          _buildAnimatedBackground(context),
+          _buildContent(context, fromAddAccount),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAnimatedBackground(BuildContext context) {
+    return AnimatedBuilder(
+      animation: _backgroundAnimation,
+      builder: (context, child) {
+        return Container(
+          decoration: BoxDecoration(
+            gradient: LinearGradient(
+              begin: Alignment.topLeft,
+              end: Alignment.bottomRight,
+              colors: [
+                context.colorScheme.primary.withOpacity(0.8),
+                context.colorScheme.secondary.withOpacity(0.6),
+                context.colorScheme.tertiary.withOpacity(0.4),
+              ],
+              transform:
+                  GradientRotation(_backgroundAnimation.value * 2 * 3.14159),
+            ),
+          ),
+          child: Stack(
+            children: [
+              // Floating circles
+              Positioned(
+                top: 100 + (_backgroundAnimation.value * 20),
+                left: 50 + (_backgroundAnimation.value * 30),
+                child: _buildFloatingCircle(80, Colors.white.withOpacity(0.1)),
+              ),
+              Positioned(
+                top: 300 + (_backgroundAnimation.value * -25),
+                right: 30 + (_backgroundAnimation.value * 20),
+                child:
+                    _buildFloatingCircle(120, Colors.white.withOpacity(0.05)),
+              ),
+              Positioned(
+                bottom: 200 + (_backgroundAnimation.value * 15),
+                left: 20 + (_backgroundAnimation.value * -10),
+                child: _buildFloatingCircle(60, Colors.white.withOpacity(0.08)),
+              ),
+              Positioned(
+                bottom: 100 + (_backgroundAnimation.value * 30),
+                right: 80 + (_backgroundAnimation.value * -20),
+                child:
+                    _buildFloatingCircle(100, Colors.white.withOpacity(0.06)),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildFloatingCircle(double size, Color color) {
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: color,
+        shape: BoxShape.circle,
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, bool fromAddAccount) {
+    return SafeArea(
+      child: AnimatedBuilder(
+        animation: _formController,
+        builder: (context, child) {
+          return Transform.translate(
+            offset: Offset(0, _formSlideAnimation.value),
+            child: Opacity(
+              opacity: _formFadeAnimation.value,
+              child: Column(
+                children: [
+                  _buildAppBar(context, fromAddAccount),
+                  Expanded(
+                    child: Center(
+                      child: SingleChildScrollView(
+                        padding: ResponsiveUtils.adaptiveValue(
+                          context,
+                          mobile: DesignTokens.lg(context).all,
+                          tablet: EdgeInsets.symmetric(
+                            horizontal: MediaQuery.of(context).size.width * 0.2,
+                            vertical: DesignTokens.lg(context),
+                          ),
+                          desktop: EdgeInsets.symmetric(
+                            horizontal: MediaQuery.of(context).size.width * 0.3,
+                            vertical: DesignTokens.xl(context),
+                          ),
+                        ),
+                        child: _buildMainCard(context),
+                      ),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildAppBar(BuildContext context, bool fromAddAccount) {
+    if (!fromAddAccount) return const SizedBox.shrink();
+
+    return Padding(
+      padding: DesignTokens.md(context).all,
+      child: Row(
+        children: [
+          AnimatedButton(
+            onPressed: () => Get.offAllNamed('/accounts'),
+            child: GlassmorphicContainer(
+              padding: DesignTokens.sm(context).all,
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusMd(context)),
+              child: Icon(
+                Icons.close_rounded,
+                color: Colors.white,
+                size: 24,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildMainCard(BuildContext context) {
+    return GlassmorphicContainer(
+      padding: ResponsiveUtils.adaptiveValue(
+        context,
+        mobile: DesignTokens.xl(context).all,
+        tablet: DesignTokens.xxl(context).all,
+        desktop: DesignTokens.xxl(context).all,
+      ),
+      borderRadius: BorderRadius.circular(DesignTokens.radiusXl(context)),
+      blur: 20,
+      opacity: 0.15,
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          _buildHeader(context),
+          SizedBox(height: DesignTokens.xxl(context)),
+          Obx(() => controller.isOTPSent.value
+              ? _buildOTPForm(context)
+              : _buildEmailForm(context)),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Column(
+      children: [
+        // App Icon with glassmorphism
+        GlassmorphicContainer(
+          width: 80,
+          height: 80,
+          borderRadius: BorderRadius.circular(DesignTokens.radiusXl(context)),
+          child: Icon(
+            Icons.auto_awesome_rounded,
+            size: 40,
+            color: Colors.white,
+          ),
+        ),
+        SizedBox(height: DesignTokens.lg(context)),
+        Text(
+          'app_name'.tr,
+          style: context.textTheme.headlineLarge?.copyWith(
+            color: Colors.white,
+            fontWeight: FontWeight.w800,
+            letterSpacing: 1.2,
+          ),
+        ),
+        SizedBox(height: DesignTokens.sm(context)),
+        Text(
+          'email_sign_in'.tr,
+          style: context.textTheme.titleMedium?.copyWith(
+            color: Colors.white.withOpacity(0.8),
+            fontWeight: FontWeight.w500,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildEmailForm(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          'enter_email'.tr,
+          style: context.textTheme.bodyLarge?.copyWith(
+            color: Colors.white.withOpacity(0.9),
+            fontWeight: FontWeight.w500,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        SizedBox(height: DesignTokens.xl(context)),
+        _buildEmailField(context),
+        SizedBox(height: DesignTokens.xl(context)),
+        _buildSendOTPButton(context),
+      ],
+    );
+  }
+
+  Widget _buildEmailField(BuildContext context) {
+    return Obx(() => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GlassmorphicContainer(
+              padding: const EdgeInsets.all(4),
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusLg(context)),
+              child: TextField(
+                controller: controller.emailController,
+                keyboardType: TextInputType.emailAddress,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 16,
+                  fontWeight: FontWeight.w500,
+                ),
+                decoration: InputDecoration(
+                  hintText: 'email'.tr,
+                  hintStyle: TextStyle(
+                    color: Colors.white.withOpacity(0.6),
+                    fontSize: 16,
+                  ),
+                  prefixIcon: Icon(
+                    Icons.email_rounded,
+                    color: Colors.white.withOpacity(0.8),
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius:
+                        BorderRadius.circular(DesignTokens.radiusLg(context)),
+                    borderSide: BorderSide.none,
+                  ),
+                  filled: true,
+                  fillColor: Colors.white.withOpacity(0.1),
+                  contentPadding: DesignTokens.lg(context).all,
+                ),
+                onChanged: (_) => controller.emailError.value = '',
+              ),
+            ),
+            if (controller.emailError.value.isNotEmpty) ...[
+              SizedBox(height: DesignTokens.sm(context)),
+              Container(
+                padding: DesignTokens.sm(context).all,
+                decoration: BoxDecoration(
+                  color: Colors.red.withOpacity(0.2),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusSm(context)),
+                  border: Border.all(
+                    color: Colors.red.withOpacity(0.3),
+                    width: 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.error_outline_rounded,
+                      color: Colors.red.shade200,
+                      size: 16,
+                    ),
+                    SizedBox(width: DesignTokens.sm(context)),
+                    Expanded(
+                      child: Text(
+                        controller.emailError.value,
+                        style: context.textTheme.bodySmall?.copyWith(
+                          color: Colors.red.shade200,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ));
+  }
+
+  Widget _buildSendOTPButton(BuildContext context) {
+    return Obx(() => SizedBox(
+          width: double.infinity,
+          height: 56,
+          child: AnimatedButton(
+            onPressed: controller.isLoading.value ? null : controller.sendOTP,
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: controller.isLoading.value
+                      ? [
+                          Colors.grey.withOpacity(0.5),
+                          Colors.grey.withOpacity(0.3),
+                        ]
+                      : [
+                          Colors.white.withOpacity(0.9),
+                          Colors.white.withOpacity(0.7),
+                        ],
+                ),
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusLg(context)),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.2),
+                    blurRadius: 8,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Center(
+                child: controller.isLoading.value
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            context.colorScheme.primary,
+                          ),
+                        ),
+                      )
+                    : Text(
+                        'send_otp'.tr,
+                        style: context.textTheme.titleMedium?.copyWith(
+                          color: context.colorScheme.primary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+              ),
+            ),
+          ),
+        ));
+  }
+
+  Widget _buildOTPForm(BuildContext context) {
+    return Column(
+      children: [
+        Text(
+          'enter_otp'.tr,
+          style: context.textTheme.bodyLarge?.copyWith(
+            color: Colors.white.withOpacity(0.9),
+            fontWeight: FontWeight.w500,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        SizedBox(height: DesignTokens.md(context)),
+        Obx(() => Container(
+              padding: DesignTokens.md(context).all,
+              decoration: BoxDecoration(
+                color: Colors.orange.withOpacity(0.2),
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusMd(context)),
+                border: Border.all(
+                  color: Colors.orange.withOpacity(0.3),
+                  width: 1,
+                ),
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Icon(
+                    Icons.timer_outlined,
+                    color: Colors.orange.shade200,
+                    size: 16,
+                  ),
+                  SizedBox(width: DesignTokens.sm(context)),
+                  Text(
+                    'otp_expires_in'.trParams(
+                        {'seconds': controller.otpExpiration.value.toString()}),
+                    style: context.textTheme.bodySmall?.copyWith(
+                      color: Colors.orange.shade200,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ],
+              ),
+            )),
+        SizedBox(height: DesignTokens.lg(context)),
+        _buildOTPField(context),
+        SizedBox(height: DesignTokens.xl(context)),
+        _buildVerifyButton(context),
+        SizedBox(height: DesignTokens.lg(context)),
+        _buildOTPActions(context),
+      ],
+    );
+  }
+
+  Widget _buildOTPField(BuildContext context) {
+    return Obx(() => Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            GlassmorphicContainer(
+              padding: const EdgeInsets.all(4),
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusLg(context)),
+              child: TextField(
+                controller: controller.otpController,
+                keyboardType: TextInputType.number,
+                textAlign: TextAlign.center,
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 24,
+                  fontWeight: FontWeight.w700,
+                  letterSpacing: 8,
+                ),
+                decoration: InputDecoration(
+                  hintText: '000000',
+                  hintStyle: TextStyle(
+                    color: Colors.white.withOpacity(0.3),
+                    fontSize: 24,
+                    fontWeight: FontWeight.w700,
+                    letterSpacing: 8,
+                  ),
+                  border: OutlineInputBorder(
+                    borderRadius:
+                        BorderRadius.circular(DesignTokens.radiusLg(context)),
+                    borderSide: BorderSide.none,
+                  ),
+                  filled: true,
+                  fillColor: Colors.white.withOpacity(0.1),
+                  contentPadding: DesignTokens.lg(context).all,
+                ),
+                onChanged: (_) => controller.otpError.value = '',
+              ),
+            ),
+            if (controller.otpError.value.isNotEmpty) ...[
+              SizedBox(height: DesignTokens.sm(context)),
+              Container(
+                padding: DesignTokens.sm(context).all,
+                decoration: BoxDecoration(
+                  color: Colors.red.withOpacity(0.2),
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusSm(context)),
+                  border: Border.all(
+                    color: Colors.red.withOpacity(0.3),
+                    width: 1,
+                  ),
+                ),
+                child: Row(
+                  children: [
+                    Icon(
+                      Icons.error_outline_rounded,
+                      color: Colors.red.shade200,
+                      size: 16,
+                    ),
+                    SizedBox(width: DesignTokens.sm(context)),
+                    Expanded(
+                      child: Text(
+                        controller.otpError.value,
+                        style: context.textTheme.bodySmall?.copyWith(
+                          color: Colors.red.shade200,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ],
+          ],
+        ));
+  }
+
+  Widget _buildVerifyButton(BuildContext context) {
+    return Obx(() => SizedBox(
+          width: double.infinity,
+          height: 56,
+          child: AnimatedButton(
+            onPressed: controller.isLoading.value ? null : controller.verifyOTP,
+            child: Container(
+              decoration: BoxDecoration(
+                gradient: LinearGradient(
+                  colors: controller.isLoading.value
+                      ? [
+                          Colors.grey.withOpacity(0.5),
+                          Colors.grey.withOpacity(0.3),
+                        ]
+                      : [
+                          Colors.white.withOpacity(0.9),
+                          Colors.white.withOpacity(0.7),
+                        ],
+                ),
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusLg(context)),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.2),
+                    blurRadius: 8,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Center(
+                child: controller.isLoading.value
+                    ? SizedBox(
+                        width: 20,
+                        height: 20,
+                        child: CircularProgressIndicator(
+                          strokeWidth: 2,
+                          valueColor: AlwaysStoppedAnimation<Color>(
+                            context.colorScheme.primary,
+                          ),
+                        ),
+                      )
+                    : Text(
+                        'verify_otp'.tr,
+                        style: context.textTheme.titleMedium?.copyWith(
+                          color: context.colorScheme.primary,
+                          fontWeight: FontWeight.w700,
+                        ),
+                      ),
+              ),
+            ),
+          ),
+        ));
+  }
+
+  Widget _buildOTPActions(BuildContext context) {
+    return Column(
+      children: [
+        Obx(() => AnimatedButton(
+              onPressed:
+                  controller.canResendOTP.value ? controller.resendOTP : null,
+              child: Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: DesignTokens.lg(context),
+                  vertical: DesignTokens.md(context),
+                ),
+                decoration: BoxDecoration(
+                  color: controller.canResendOTP.value
+                      ? Colors.white.withOpacity(0.1)
+                      : Colors.transparent,
+                  borderRadius:
+                      BorderRadius.circular(DesignTokens.radiusMd(context)),
+                  border: Border.all(
+                    color: Colors.white.withOpacity(0.3),
+                    width: 1,
+                  ),
+                ),
+                child: Text(
+                  controller.canResendOTP.value
+                      ? 'resend_otp'.tr
+                      : 'resend_otp_in'.trParams({
+                          'seconds': controller.resendCooldown.value.toString()
+                        }),
+                  style: context.textTheme.bodyMedium?.copyWith(
+                    color: controller.canResendOTP.value
+                        ? Colors.white
+                        : Colors.white.withOpacity(0.6),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            )),
+        SizedBox(height: DesignTokens.md(context)),
+        AnimatedButton(
+          onPressed: controller.goBackToEmailInput,
+          child: Container(
+            padding: EdgeInsets.symmetric(
+              horizontal: DesignTokens.lg(context),
+              vertical: DesignTokens.md(context),
+            ),
+            decoration: BoxDecoration(
+              borderRadius:
+                  BorderRadius.circular(DesignTokens.radiusMd(context)),
+            ),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.arrow_back_rounded,
+                  color: Colors.white.withOpacity(0.8),
+                  size: 16,
+                ),
+                SizedBox(width: DesignTokens.sm(context)),
+                Text(
+                  'change_email'.tr,
+                  style: context.textTheme.bodyMedium?.copyWith(
+                    color: Colors.white.withOpacity(0.8),
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- upgrade `main.dart` to reference modern pages
- add modernized versions of sign-in, set username, home, profile, chat room, and chat rooms list pages

## Testing
- `dart format lib/main.dart lib/pages/modern_sign_in_page.dart lib/pages/modern_set_username_page.dart lib/pages/modern_home_page.dart lib/pages/modern_profile_page.dart lib/pages/modern_chat_room_page.dart lib/pages/modern_chat_rooms_list_page.dart`
- `dart analyze` *(fails: numerous errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_6849ec0e9640832db6df0f572cf29219