### PR TITLE
Improve splash screen UI

### DIFF
--- a/lib/pages/splash_screen.dart
+++ b/lib/pages/splash_screen.dart
@@ -16,10 +16,10 @@ class SplashScreen extends GetView<SplashController> {
             fit: BoxFit.cover,
           ),
         ),
-        alignment: Alignment.center,
+        padding: const EdgeInsets.all(16),
         child: Column(
-          mainAxisSize: MainAxisSize.min,
           children: [
+            const Spacer(),
             Text(
               'app_name'.tr,
               style: const TextStyle(
@@ -28,7 +28,7 @@ class SplashScreen extends GetView<SplashController> {
                 color: Colors.white,
               ),
             ),
-            const SizedBox(height: 16),
+            const Spacer(),
             Obx(() {
               if (controller.isLoading.value) {
                 return const CircularProgressIndicator(
@@ -36,10 +36,16 @@ class SplashScreen extends GetView<SplashController> {
                 );
               }
               return ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  padding:
+                      const EdgeInsets.symmetric(horizontal: 32, vertical: 20),
+                  textStyle: const TextStyle(fontSize: 18),
+                ),
                 onPressed: () => Get.offAllNamed('/'),
                 child: Text('lets_go'.tr),
               );
             }),
+            const SizedBox(height: 32),
           ],
         ),
       ),


### PR DESCRIPTION
## Summary
- move the "Let's go" button to the bottom of the splash screen
- enlarge the button so it is more prominent

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_684a9a7c8e00832db44388adce94ed6a