### PR TITLE
Add rasi & nakshatra profile options

### DIFF
--- a/lib/bindings/auth_binding.dart
+++ b/lib/bindings/auth_binding.dart
@@ -13,8 +13,5 @@ class AuthBinding extends Bindings {
     if (!Get.isRegistered<ChatController>()) {
       Get.put(ChatController(), permanent: true);
     }
-    if (!Get.isRegistered<EnhancedPlanetHouseController>()) {
-      Get.put(EnhancedPlanetHouseController(), permanent: true);
-    }
   }
 }

--- a/lib/controllers/auth_controller.dart
+++ b/lib/controllers/auth_controller.dart
@@ -38,6 +38,9 @@ class AuthController extends GetxController {
   late TextEditingController emailController;
   late TextEditingController otpController;
 
+  final birthRashiId = ''.obs;
+  final birthNakshatraId = ''.obs;
+
   String? userId;
 
   // Timers and related variables
@@ -89,6 +92,8 @@ class AuthController extends GetxController {
     emailError.value = '';
     otpError.value = '';
     usernameError.value = '';
+    birthRashiId.value = '';
+    birthNakshatraId.value = '';
     cancelTimers();
     super.onClose();
   }
@@ -487,6 +492,8 @@ class AuthController extends GetxController {
         final data = result.documents.first.data;
         final fetchedUsername = data['username'];
         final fetchedTypeRaw = data['userType'];
+        birthRashiId.value = data['birth_rashi'] ?? '';
+        birthNakshatraId.value = data['birth_nakshatra'] ?? '';
         logger.i(
             "[Auth] ensureUsername: Document found. Username from DB: '$fetchedUsername'. Profile Pic URL: '${data['profilePicture']}'");
         if (fetchedUsername != null && fetchedUsername != '') {
@@ -519,6 +526,8 @@ class AuthController extends GetxController {
       await prefs.remove('username');
       username.value = '';
       profilePictureUrl.value = '';
+      birthRashiId.value = '';
+      birthNakshatraId.value = '';
       logger.i(
           "[Auth] ensureUsername: Returning false (no username found on server for this session/UID, or it was empty).");
       return false;
@@ -787,8 +796,16 @@ class AuthController extends GetxController {
     }
   }
 
-  Future<void> _saveUsername(String dbId, String collectionId, String uid,
-      String name, SharedPreferences prefs) async {
+  Future<void> _saveUsername(
+      String dbId,
+      String collectionId,
+      String uid,
+      String name,
+      SharedPreferences prefs,
+      {
+      String? rashiId,
+      String? nakshatraId,
+      }) async {
     logger.i(
         "[Auth] _saveUsername: Starting save process for username '$name' and user '$uid'");
     logger.i(
@@ -822,6 +839,8 @@ class AuthController extends GetxController {
           documentId: docId,
           data: {
             'username': name,
+            'birth_rashi': rashiId ?? '',
+            'birth_nakshatra': nakshatraId ?? '',
             'UpdateAt': now,
           },
         );
@@ -837,6 +856,8 @@ class AuthController extends GetxController {
           'userType': 'General User',
           'firstName': '',
           'lastName': '',
+          'birth_rashi': rashiId ?? '',
+          'birth_nakshatra': nakshatraId ?? '',
           'createdAt': now,
           'UpdateAt': now,
         };
@@ -862,6 +883,8 @@ class AuthController extends GetxController {
       logger.i("[Auth] _saveUsername: STEP 4 - Updating local state and cache");
       username.value = name;
       await prefs.setString('username', name);
+      birthRashiId.value = rashiId ?? '';
+      birthNakshatraId.value = nakshatraId ?? '';
 
       logger.i(
           "[Auth] _saveUsername: Successfully completed save process for username '$name'");
@@ -1024,7 +1047,15 @@ class AuthController extends GetxController {
 
       logger.i(
           "[Auth] submitUsername: Calling _saveUsername for user '$uid' with username '$name'");
-      await _saveUsername(dbId, collectionId, uid, name, prefs);
+      await _saveUsername(
+        dbId,
+        collectionId,
+        uid,
+        name,
+        prefs,
+        rashiId: birthRashiId.value,
+        nakshatraId: birthNakshatraId.value,
+      );
 
       isLoading.value = false;
       logger.i("[Auth] submitUsername: Successfully saved username '$name'");

--- a/lib/controllers/master_data_controller.dart
+++ b/lib/controllers/master_data_controller.dart
@@ -1,0 +1,104 @@
+import 'dart:convert';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../utils/logger.dart';
+import '../controllers/auth_controller.dart';
+import '../widgets/complete_enhanced_watchlist.dart';
+
+class MasterDataController extends GetxController {
+  final AuthController _auth = Get.find<AuthController>();
+
+  final RxList<RashiOption> _rashiOptions = <RashiOption>[].obs;
+  final RxList<NakshatraOption> _nakshatraOptions = <NakshatraOption>[].obs;
+  final RxBool _isLoading = false.obs;
+
+  List<RashiOption> get rashiOptions => _rashiOptions;
+  List<NakshatraOption> get nakshatraOptions => _nakshatraOptions;
+  bool get isLoading => _isLoading.value;
+
+  static const String _rashiCacheKey = 'cached_rashi_options_v2';
+  static const String _nakshatraCacheKey = 'cached_nakshatra_options_v2';
+
+  @override
+  void onInit() {
+    super.onInit();
+    _loadMasterData();
+  }
+
+  Future<void> _loadMasterData() async {
+    _isLoading.value = true;
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final cachedRashi = prefs.getStringList(_rashiCacheKey);
+      final cachedNakshatra = prefs.getStringList(_nakshatraCacheKey);
+      if (cachedRashi != null && cachedNakshatra != null) {
+        _rashiOptions.assignAll(
+          cachedRashi.map((e) => RashiOption.fromJson(jsonDecode(e))).toList(),
+        );
+        _nakshatraOptions.assignAll(
+          cachedNakshatra
+              .map((e) => NakshatraOption.fromJson(jsonDecode(e)))
+              .toList(),
+        );
+      }
+      await _fetchMasterDataFromDatabase();
+    } catch (e, st) {
+      logger.e('Error loading master data', error: e, stackTrace: st);
+    } finally {
+      _isLoading.value = false;
+    }
+  }
+
+  Future<void> _fetchMasterDataFromDatabase() async {
+    final dbId = dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB';
+    try {
+      final rashiResult = await _auth.databases.listDocuments(
+        databaseId: dbId,
+        collectionId: 'rasi_master',
+        queries: [Query.orderAsc('name'), Query.limit(50)],
+      );
+      final rashiList =
+          rashiResult.documents.map((e) => RashiOption.fromJson(e.data)).toList();
+      if (rashiList.isNotEmpty) {
+        _rashiOptions.assignAll(rashiList);
+      }
+      final nakshatraResult = await _auth.databases.listDocuments(
+        databaseId: dbId,
+        collectionId: 'nakshatra_master',
+        queries: [Query.orderAsc('name'), Query.limit(100)],
+      );
+      final nakshatraList = nakshatraResult.documents
+          .map((e) => NakshatraOption.fromJson(e.data))
+          .toList();
+      if (nakshatraList.isNotEmpty) {
+        _nakshatraOptions.assignAll(nakshatraList);
+      }
+      await _cacheMasterData();
+    } catch (e, st) {
+      logger.e('Error fetching master data', error: e, stackTrace: st);
+    }
+  }
+
+  Future<void> _cacheMasterData() async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final rashiJson =
+          _rashiOptions.map((e) => jsonEncode(e.toJson())).toList();
+      final nakJson =
+          _nakshatraOptions.map((e) => jsonEncode(e.toJson())).toList();
+      await prefs.setStringList(_rashiCacheKey, rashiJson);
+      await prefs.setStringList(_nakshatraCacheKey, nakJson);
+    } catch (e) {
+      logger.e('Error caching master data', error: e);
+    }
+  }
+
+  List<NakshatraOption> getNakshatraForRashi(String? rashiId) {
+    if (rashiId == null || rashiId.isEmpty) return [];
+    return _nakshatraOptions
+        .where((n) => n.rashiId == rashiId)
+        .toList();
+  }
+}

--- a/lib/models/planet_house_models.dart
+++ b/lib/models/planet_house_models.dart
@@ -10,6 +10,7 @@ class PlanetHousePosition {
   final String ascendantSign;
   final String ascendantSymbol;
   final int ascendantIndex;
+  final String rashiId;
   final String planet;
   final String planetSign;
   final String planetSignSymbol;
@@ -31,6 +32,7 @@ class PlanetHousePosition {
     required this.ascendantSign,
     required this.ascendantSymbol,
     required this.ascendantIndex,
+    required this.rashiId,
     required this.planet,
     required this.planetSign,
     required this.planetSignSymbol,
@@ -54,6 +56,7 @@ class PlanetHousePosition {
       ascendantSign: json['ascendant_sign'] ?? '',
       ascendantSymbol: json['ascendant_symbol'] ?? '',
       ascendantIndex: ParsingUtils.parseInt(json['ascendant_index']),
+      rashiId: json['rashi_id'] ?? '',
       planet: json['planet'] ?? '',
       planetSign: json['planet_sign'] ?? '',
       planetSignSymbol: json['planet_sign_symbol'] ?? '',
@@ -78,6 +81,7 @@ class PlanetHousePosition {
       'ascendant_sign': ascendantSign,
       'ascendant_symbol': ascendantSymbol,
       'ascendant_index': ascendantIndex,
+      'rashi_id': rashiId,
       'planet': planet,
       'planet_sign': planetSign,
       'planet_sign_symbol': planetSignSymbol,

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -58,7 +58,8 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   void initState() {
     super.initState();
     Get.put(WatchlistController(), permanent: true);
-    Get.put(EnhancedPlanetHouseController(), permanent: true);
+    final phc = Get.put(EnhancedPlanetHouseController(), permanent: true);
+    phc.initialize();
     _initializeAnimations();
   }
 

--- a/lib/pages/set_username_page.dart
+++ b/lib/pages/set_username_page.dart
@@ -2,12 +2,19 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/auth_controller.dart';
 import '../widgets/responsive_layout.dart';
+import '../controllers/master_data_controller.dart';
+import '../widgets/complete_enhanced_watchlist.dart';
 
 class SetUsernamePage extends GetView<AuthController> {
   const SetUsernamePage({super.key});
 
+  MasterDataController get dataController => Get.find<MasterDataController>();
+
   @override
   Widget build(BuildContext context) {
+    if (!Get.isRegistered<MasterDataController>()) {
+      Get.put(MasterDataController(), permanent: true);
+    }
     return Scaffold(
       appBar: AppBar(title: Text('enter_username'.tr)),
       body: ResponsiveLayout(
@@ -39,6 +46,50 @@ class SetUsernamePage extends GetView<AuthController> {
                 ),
                 onChanged: controller.onUsernameChanged,
               ),
+              const SizedBox(height: 16),
+              Obx(() => DropdownButtonFormField<RashiOption>(
+                    value: dataController.rashiOptions.firstWhereOrNull(
+                        (r) => r.rashiId == controller.birthRashiId.value),
+                    decoration: const InputDecoration(
+                      border: OutlineInputBorder(),
+                      hintText: 'Select Rasi',
+                    ),
+                    items: dataController.rashiOptions
+                        .map((r) => DropdownMenuItem(
+                              value: r,
+                              child: Text('${r.symbol} ${r.name}'),
+                            ))
+                        .toList(),
+                    onChanged: (r) {
+                      controller.birthRashiId.value = r?.rashiId ?? '';
+                      controller.birthNakshatraId.value = '';
+                    },
+                  )),
+              const SizedBox(height: 16),
+              Obx(() {
+                final options = dataController
+                    .getNakshatraForRashi(controller.birthRashiId.value);
+                return DropdownButtonFormField<NakshatraOption>(
+                  value: options.firstWhereOrNull(
+                      (n) => n.nakshatraId == controller.birthNakshatraId.value),
+                  decoration: const InputDecoration(
+                    border: OutlineInputBorder(),
+                    hintText: 'Select Nakshatra',
+                  ),
+                  items: options
+                      .map((n) => DropdownMenuItem(
+                            value: n,
+                            child: Text('${n.symbol} ${n.name}'),
+                          ))
+                      .toList(),
+                  onChanged: controller.birthRashiId.value.isEmpty
+                      ? null
+                      : (n) {
+                          controller.birthNakshatraId.value =
+                              n?.nakshatraId ?? '';
+                        },
+                );
+              }),
               Obx(() => controller.usernameError.value.isEmpty
                   ? const SizedBox.shrink()
                   : Padding(

--- a/lib/widgets/enhanced_sliver_app_bar.dart
+++ b/lib/widgets/enhanced_sliver_app_bar.dart
@@ -3,6 +3,8 @@ import 'package:get/get.dart';
 import '../controllers/enhanced_planet_house_controller.dart';
 import '../widgets/enhanced_planet_house_widgets.dart';
 import 'simple_dynamic_tabs.dart';
+import '../controllers/master_data_controller.dart';
+import 'complete_enhanced_watchlist.dart';
 
 class EnhancedSliverAppBar extends StatelessWidget {
   const EnhancedSliverAppBar({super.key});
@@ -12,6 +14,9 @@ class EnhancedSliverAppBar extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     final iconColor = colorScheme.primary.withOpacity(0.6);
     Get.put(EnhancedPlanetHouseController(), permanent: true);
+    if (!Get.isRegistered<MasterDataController>()) {
+      Get.put(MasterDataController(), permanent: true);
+    }
     return SliverAppBar(
       pinned: true,
       expandedHeight: 200,
@@ -84,11 +89,33 @@ class EnhancedSliverAppBar extends StatelessWidget {
                 ),
               ),
               const SizedBox(height: 8),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: Obx(() {
+                  final controller = Get.find<EnhancedPlanetHouseController>();
+                  final data = Get.find<MasterDataController>();
+                  final selected = data.rashiOptions.firstWhereOrNull(
+                      (r) => r.rashiId == controller.currentRashiId);
+                  return DropdownButton<RashiOption>(
+                    value: selected,
+                    underline: const SizedBox(),
+                    items: data.rashiOptions
+                        .map((r) => DropdownMenuItem<RashiOption>(
+                              value: r,
+                              child: Text('${r.symbol} ${r.name}'),
+                            ))
+                        .toList(),
+                    onChanged: (RashiOption? r) =>
+                        controller.selectRashi(r?.rashiId ?? 'r1'),
+                  );
+                }),
+              ),
               const Padding(
                 padding: EdgeInsets.symmetric(horizontal: 16),
-                child: Text('Current Planetary Positions',
-                    style:
-                        TextStyle(fontSize: 12, fontWeight: FontWeight.w600)),
+                child: Text(
+                  'Current Planetary Positions',
+                  style: TextStyle(fontSize: 12, fontWeight: FontWeight.w600),
+                ),
               ),
               const SizedBox(height: 8),
               const EnhancedPlanetHouseList(),


### PR DESCRIPTION
## Summary
- create MasterDataController to load Rasi/Nakshatra master data
- extend AuthController with birth details and save them
- update SetUsernamePage with dropdowns for Rasi and Nakshatra
- fetch planetary houses by rashi id and cache per-user
- allow rasi selection in sliver app bar
- initialize planet house controller on home page
- fix dropdown generic types and remove invalid field

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_684ad9a00b84832d91f2169e9f49f755