### PR TITLE
Fix social feed interactions

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import '../../../controllers/auth_controller.dart';
 import '../models/feed_post.dart';
 import '../services/feed_service.dart';
 
@@ -29,10 +30,23 @@ class FeedController extends GetxController {
   }
 
   Future<void> likePost(String postId) async {
-    await service.createLike({'item_id': postId, 'item_type': 'post'});
+    final auth = Get.find<AuthController>();
+    final uid = auth.userId;
+    if (uid == null) return;
+    await service.createLike({
+      'item_id': postId,
+      'item_type': 'post',
+      'user_id': uid,
+    });
   }
 
   Future<void> repostPost(String postId) async {
-    await service.createRepost({'post_id': postId});
+    final auth = Get.find<AuthController>();
+    final uid = auth.userId;
+    if (uid == null) return;
+    await service.createRepost({
+      'post_id': postId,
+      'user_id': uid,
+    });
   }
 }

--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -1,22 +1,85 @@
 import 'package:flutter/material.dart';
 import '../../../design_system/modern_ui_system.dart';
+import 'package:get/get.dart';
 import '../widgets/comment_card.dart';
 import '../models/post_comment.dart';
+import '../controllers/comments_controller.dart';
+import '../../../controllers/auth_controller.dart';
 
-class CommentThreadPage extends StatelessWidget {
+class CommentThreadPage extends StatefulWidget {
   final List<PostComment> thread;
   const CommentThreadPage({super.key, required this.thread});
 
   @override
+  State<CommentThreadPage> createState() => _CommentThreadPageState();
+}
+
+class _CommentThreadPageState extends State<CommentThreadPage> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
+    final commentsController = Get.find<CommentsController>();
+    final auth = Get.find<AuthController>();
+
     return Scaffold(
       appBar: AppBar(title: const Text('Thread')),
-      body: OptimizedListView(
+      body: Padding(
         padding: EdgeInsets.all(DesignTokens.md(context)),
-        itemCount: thread.length,
-        itemBuilder: (context, index) => Padding(
-          padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
-          child: CommentCard(comment: thread[index]),
+        child: Column(
+          children: [
+            Expanded(
+              child: OptimizedListView(
+                itemCount: widget.thread.length,
+                itemBuilder: (context, index) => Padding(
+                  padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                  child: CommentCard(comment: widget.thread[index]),
+                ),
+              ),
+            ),
+            SizedBox(height: DesignTokens.sm(context)),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _controller,
+                    decoration:
+                        const InputDecoration(hintText: 'Reply to thread'),
+                  ),
+                ),
+                SizedBox(width: DesignTokens.sm(context)),
+                AnimatedButton(
+                  onPressed: () {
+                    final root = widget.thread.first;
+                    final uid = auth.userId ?? '';
+                    final uname = auth.username.value.isNotEmpty
+                        ? auth.username.value
+                        : 'You';
+                    final comment = PostComment(
+                      id: DateTime.now().toIso8601String(),
+                      postId: root.postId,
+                      userId: uid,
+                      username: uname,
+                      parentId: root.id,
+                      content: _controller.text,
+                    );
+                    commentsController.addComment(comment);
+                    setState(() {
+                      widget.thread.add(comment);
+                    });
+                    _controller.clear();
+                  },
+                  child: const Text('Send'),
+                ),
+              ],
+            ),
+          ],
         ),
       ),
     );

--- a/lib/features/social_feed/screens/compose_post_page.dart
+++ b/lib/features/social_feed/screens/compose_post_page.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import '../../../design_system/modern_ui_system.dart';
 import '../controllers/feed_controller.dart';
 import '../models/feed_post.dart';
+import '../../../controllers/auth_controller.dart';
 
 class ComposePostPage extends StatefulWidget {
   final String roomId;
@@ -18,6 +19,7 @@ class _ComposePostPageState extends State<ComposePostPage> {
   @override
   Widget build(BuildContext context) {
     final feedController = Get.find<FeedController>();
+    final auth = Get.find<AuthController>();
     return Scaffold(
       appBar: AppBar(title: const Text('Compose Post')),
       body: Padding(
@@ -32,11 +34,15 @@ class _ComposePostPageState extends State<ComposePostPage> {
             SizedBox(height: DesignTokens.md(context)),
             AnimatedButton(
               onPressed: () {
+                final uid = auth.userId ?? '';
+                final uname = auth.username.value.isNotEmpty
+                    ? auth.username.value
+                    : 'You';
                 final post = FeedPost(
                   id: DateTime.now().toIso8601String(),
                   roomId: widget.roomId,
-                  userId: 'me',
-                  username: 'You',
+                  userId: uid,
+                  username: uname,
                   content: _controller.text,
                 );
                 feedController.createPost(post);

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -3,30 +3,86 @@ import 'package:get/get.dart';
 import '../../../design_system/modern_ui_system.dart';
 import '../controllers/comments_controller.dart';
 import '../models/feed_post.dart';
+import '../models/post_comment.dart';
+import '../../../controllers/auth_controller.dart';
 import '../widgets/comment_card.dart';
 import '../widgets/post_card.dart';
 
-class PostDetailPage extends StatelessWidget {
+class PostDetailPage extends StatefulWidget {
   final FeedPost post;
   const PostDetailPage({super.key, required this.post});
 
   @override
+  State<PostDetailPage> createState() => _PostDetailPageState();
+}
+
+class _PostDetailPageState extends State<PostDetailPage> {
+  final _textController = TextEditingController();
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final controller = Get.find<CommentsController>();
-    controller.loadComments(post.id);
+    final commentsController = Get.find<CommentsController>();
+    commentsController.loadComments(widget.post.id);
+    final auth = Get.find<AuthController>();
+
     return Scaffold(
       appBar: AppBar(title: const Text('Post')),
-      body: OptimizedListView(
+      body: Padding(
         padding: EdgeInsets.all(DesignTokens.md(context)),
-        itemCount: controller.comments.length + 1,
-        itemBuilder: (context, index) {
-          if (index == 0) return PostCard(post: post);
-          final comment = controller.comments[index - 1];
-          return Padding(
-            padding: EdgeInsets.only(top: DesignTokens.sm(context)),
-            child: CommentCard(comment: comment),
-          );
-        },
+        child: Column(
+          children: [
+            Expanded(
+              child: OptimizedListView(
+                itemCount: commentsController.comments.length + 1,
+                itemBuilder: (context, index) {
+                  if (index == 0) return PostCard(post: widget.post);
+                  final comment = commentsController.comments[index - 1];
+                  return Padding(
+                    padding: EdgeInsets.only(top: DesignTokens.sm(context)),
+                    child: CommentCard(comment: comment),
+                  );
+                },
+              ),
+            ),
+            SizedBox(height: DesignTokens.sm(context)),
+            Row(
+              children: [
+                Expanded(
+                  child: TextField(
+                    controller: _textController,
+                    decoration:
+                        const InputDecoration(hintText: 'Add a comment'),
+                  ),
+                ),
+                SizedBox(width: DesignTokens.sm(context)),
+                AnimatedButton(
+                  onPressed: () {
+                    final uid = auth.userId ?? '';
+                    final uname = auth.username.value.isNotEmpty
+                        ? auth.username.value
+                        : 'You';
+                    final comment = PostComment(
+                      id: DateTime.now().toIso8601String(),
+                      postId: widget.post.id,
+                      userId: uid,
+                      username: uname,
+                      content: _textController.text,
+                    );
+                    commentsController.addComment(comment);
+                    _textController.clear();
+                  },
+                  child: const Text('Send'),
+                ),
+              ],
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -23,7 +23,12 @@ class ReactionBar extends StatelessWidget {
           isButton: true,
           child: AnimatedButton(
             onPressed: onLike,
-            child: Icon(isLiked ? Icons.favorite : Icons.favorite_border),
+            child: Icon(
+              isLiked ? Icons.favorite : Icons.favorite_border,
+              color: isLiked
+                  ? context.colorScheme.primary
+                  : context.iconTheme.color,
+            ),
           ),
         ),
         SizedBox(width: DesignTokens.sm(context)),


### PR DESCRIPTION
## Summary
- pass `user_id` when liking or reposting so Appwrite accepts the document
- use authenticated user info when composing posts
- color the like icon based on state
- add a comment field to post detail page
- allow replying from comment thread page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b354a514c832d8ca511325310e699