### PR TITLE
Extend social feed interactions

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import '../../../controllers/auth_controller.dart';
 import '../models/post_comment.dart';
 import '../services/feed_service.dart';
 
@@ -10,6 +11,9 @@ class CommentsController extends GetxController {
   final _comments = <PostComment>[].obs;
   List<PostComment> get comments => _comments;
 
+  final _likedIds = <String, String>{}.obs; // commentId -> likeId
+  final _likeCounts = <String, int>{}.obs; // commentId -> likes
+
   final _isLoading = false.obs;
   bool get isLoading => _isLoading.value;
 
@@ -18,6 +22,15 @@ class CommentsController extends GetxController {
     try {
       final data = await service.getComments(postId);
       _comments.assignAll(data);
+      _likeCounts.assignAll({for (final c in data) c.id: c.likeCount});
+      final auth = Get.find<AuthController>();
+      final uid = auth.userId;
+      if (uid != null) {
+        for (final c in data) {
+          final like = await service.getUserLike(c.id, uid);
+          if (like != null) _likedIds[c.id] = like.id;
+        }
+      }
     } finally {
       _isLoading.value = false;
     }
@@ -26,5 +39,33 @@ class CommentsController extends GetxController {
   Future<void> addComment(PostComment comment) async {
     await service.createComment(comment);
     _comments.add(comment);
+    _likeCounts[comment.id] = comment.likeCount;
   }
+
+  Future<void> replyToComment(PostComment comment) async {
+    await addComment(comment);
+  }
+
+  Future<void> toggleLikeComment(String commentId) async {
+    final auth = Get.find<AuthController>();
+    final uid = auth.userId;
+    if (uid == null) return;
+    if (_likedIds.containsKey(commentId)) {
+      final likeId = _likedIds.remove(commentId)!;
+      await service.deleteLike(likeId);
+      _likeCounts[commentId] = (_likeCounts[commentId] ?? 1) - 1;
+    } else {
+      await service.createLike({
+        'item_id': commentId,
+        'item_type': 'comment',
+        'user_id': uid,
+      });
+      final like = await service.getUserLike(commentId, uid);
+      if (like != null) _likedIds[commentId] = like.id;
+      _likeCounts[commentId] = (_likeCounts[commentId] ?? 0) + 1;
+    }
+  }
+
+  bool isCommentLiked(String id) => _likedIds.containsKey(id);
+  int commentLikeCount(String id) => _likeCounts[id] ?? 0;
 }

--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -35,12 +35,21 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
         child: Column(
           children: [
             Expanded(
-              child: OptimizedListView(
-                itemCount: widget.thread.length,
-                itemBuilder: (context, index) => Padding(
-                  padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
-                  child: CommentCard(comment: widget.thread[index]),
-                ),
+              child: Obx(
+                () {
+                  final root = widget.thread.first;
+                  final items = commentsController.comments
+                      .where((c) => c.id == root.id || c.parentId == root.id)
+                      .toList();
+                  return OptimizedListView(
+                    itemCount: items.length,
+                    itemBuilder: (context, index) => Padding(
+                      padding:
+                          EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                      child: CommentCard(comment: items[index]),
+                    ),
+                  );
+                },
               ),
             ),
             SizedBox(height: DesignTokens.sm(context)),
@@ -69,10 +78,7 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                       parentId: root.id,
                       content: _controller.text,
                     );
-                    commentsController.addComment(comment);
-                    setState(() {
-                      widget.thread.add(comment);
-                    });
+                    commentsController.replyToComment(comment);
                     _controller.clear();
                   },
                   child: const Text('Send'),

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -38,16 +38,18 @@ class _PostDetailPageState extends State<PostDetailPage> {
         child: Column(
           children: [
             Expanded(
-              child: OptimizedListView(
-                itemCount: commentsController.comments.length + 1,
-                itemBuilder: (context, index) {
-                  if (index == 0) return PostCard(post: widget.post);
-                  final comment = commentsController.comments[index - 1];
-                  return Padding(
-                    padding: EdgeInsets.only(top: DesignTokens.sm(context)),
-                    child: CommentCard(comment: comment),
-                  );
-                },
+              child: Obx(
+                () => OptimizedListView(
+                  itemCount: commentsController.comments.length + 1,
+                  itemBuilder: (context, index) {
+                    if (index == 0) return PostCard(post: widget.post);
+                    final comment = commentsController.comments[index - 1];
+                    return Padding(
+                      padding: EdgeInsets.only(top: DesignTokens.sm(context)),
+                      child: CommentCard(comment: comment),
+                    );
+                  },
+                ),
               ),
             ),
             SizedBox(height: DesignTokens.sm(context)),

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -1,6 +1,8 @@
 import 'package:appwrite/appwrite.dart';
 import '../models/feed_post.dart';
 import '../models/post_comment.dart';
+import '../models/post_like.dart';
+import '../models/post_repost.dart';
 
 class FeedService {
   final Databases databases;
@@ -77,5 +79,39 @@ class FeedService {
       documentId: ID.unique(),
       data: repost,
     );
+  }
+
+  Future<PostLike?> getUserLike(String itemId, String userId) async {
+    final res = await databases.listDocuments(
+      databaseId: databaseId,
+      collectionId: likesCollectionId,
+      queries: [
+        Query.equal('item_id', itemId),
+        Query.equal('user_id', userId),
+      ],
+    );
+    if (res.documents.isEmpty) return null;
+    return PostLike.fromJson(res.documents.first.data);
+  }
+
+  Future<void> deleteLike(String likeId) async {
+    await databases.deleteDocument(
+      databaseId: databaseId,
+      collectionId: likesCollectionId,
+      documentId: likeId,
+    );
+  }
+
+  Future<PostRepost?> getUserRepost(String postId, String userId) async {
+    final res = await databases.listDocuments(
+      databaseId: databaseId,
+      collectionId: repostsCollectionId,
+      queries: [
+        Query.equal('post_id', postId),
+        Query.equal('user_id', userId),
+      ],
+    );
+    if (res.documents.isEmpty) return null;
+    return PostRepost.fromJson(res.documents.first.data);
   }
 }

--- a/lib/features/social_feed/widgets/comment_card.dart
+++ b/lib/features/social_feed/widgets/comment_card.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
 import '../../../design_system/modern_ui_system.dart';
 import '../models/post_comment.dart';
+import '../controllers/comments_controller.dart';
+import '../screens/comment_thread_page.dart';
+import 'reaction_bar.dart';
 
 class CommentCard extends StatelessWidget {
   final PostComment comment;
@@ -8,18 +12,38 @@ class CommentCard extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return GlassmorphicCard(
-      padding: DesignTokens.sm(context).all,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            comment.username,
-            style: Theme.of(context).textTheme.bodyMedium,
-          ),
-          SizedBox(height: DesignTokens.xs(context)),
-          Text(comment.content),
-        ],
+    final controller = Get.find<CommentsController>();
+    void handleLike() => controller.toggleLikeComment(comment.id);
+    void handleReply() {
+      final thread = controller.comments
+          .where((c) => c.id == comment.id || c.parentId == comment.id)
+          .toList();
+      Get.to(() => CommentThreadPage(thread: thread));
+    }
+
+    return Obx(
+      () => GlassmorphicCard(
+        padding: DesignTokens.sm(context).all,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              comment.username,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            SizedBox(height: DesignTokens.xs(context)),
+            Text(comment.content),
+            SizedBox(height: DesignTokens.xs(context)),
+            ReactionBar(
+              onLike: handleLike,
+              onComment: handleReply,
+              isLiked: controller.isCommentLiked(comment.id),
+              likeCount: controller.commentLikeCount(comment.id),
+              commentCount: comment.replyCount,
+              repostCount: 0,
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -7,58 +7,54 @@ import '../screens/post_detail_page.dart';
 import 'media_gallery.dart';
 import 'reaction_bar.dart';
 
-class PostCard extends StatefulWidget {
+class PostCard extends StatelessWidget {
   final FeedPost post;
   const PostCard({super.key, required this.post});
 
-  @override
-  State<PostCard> createState() => _PostCardState();
-}
-
-class _PostCardState extends State<PostCard> {
-  bool isLiked = false;
-
-  void _handleLike() {
-    final controller = Get.find<FeedController>();
-    controller.likePost(widget.post.id);
-    setState(() => isLiked = !isLiked);
+  void _handleLike(FeedController controller) {
+    controller.toggleLikePost(post.id);
   }
 
   void _handleComment() {
-    Get.to(() => PostDetailPage(post: widget.post));
+    Get.to(() => PostDetailPage(post: post));
   }
 
-  void _handleRepost() {
-    final controller = Get.find<FeedController>();
-    controller.repostPost(widget.post.id);
+  void _handleRepost(FeedController controller) {
+    controller.repostPost(post.id);
   }
 
   @override
   Widget build(BuildContext context) {
-    return GlassmorphicCard(
-      padding: DesignTokens.md(context).all,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            widget.post.username,
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          SizedBox(height: DesignTokens.sm(context)),
-          Text(widget.post.content),
-          if (widget.post.mediaUrls.isNotEmpty)
-            Padding(
-              padding: EdgeInsets.only(top: DesignTokens.sm(context)),
-              child: MediaGallery(urls: widget.post.mediaUrls),
+    final controller = Get.find<FeedController>();
+    return Obx(
+      () => GlassmorphicCard(
+        padding: DesignTokens.md(context).all,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              post.username,
+              style: Theme.of(context).textTheme.titleMedium,
             ),
-          SizedBox(height: DesignTokens.sm(context)),
-          ReactionBar(
-            onLike: _handleLike,
-            onComment: _handleComment,
-            onRepost: _handleRepost,
-            isLiked: isLiked,
-          ),
-        ],
+            SizedBox(height: DesignTokens.sm(context)),
+            Text(post.content),
+            if (post.mediaUrls.isNotEmpty)
+              Padding(
+                padding: EdgeInsets.only(top: DesignTokens.sm(context)),
+                child: MediaGallery(urls: post.mediaUrls),
+              ),
+            SizedBox(height: DesignTokens.sm(context)),
+            ReactionBar(
+              onLike: () => _handleLike(controller),
+              onComment: _handleComment,
+              onRepost: () => _handleRepost(controller),
+              isLiked: controller.isPostLiked(post.id),
+              likeCount: controller.postLikeCount(post.id),
+              commentCount: post.commentCount,
+              repostCount: controller.postRepostCount(post.id),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -6,48 +6,70 @@ class ReactionBar extends StatelessWidget {
   final VoidCallback? onComment;
   final VoidCallback? onRepost;
   final bool isLiked;
+  final int likeCount;
+  final int commentCount;
+  final int repostCount;
   const ReactionBar({
     super.key,
     this.onLike,
     this.onComment,
     this.onRepost,
     this.isLiked = false,
+    this.likeCount = 0,
+    this.commentCount = 0,
+    this.repostCount = 0,
   });
 
   @override
   Widget build(BuildContext context) {
+    Widget buildItem({
+      required Widget icon,
+      required String label,
+      required VoidCallback? onTap,
+      required int count,
+    }) {
+      return AccessibilityWrapper(
+        semanticLabel: label,
+        isButton: true,
+        child: AnimatedButton(
+          onPressed: onTap,
+          child: Row(
+            children: [
+              icon,
+              SizedBox(width: DesignTokens.xs(context)),
+              Text('$count'),
+            ],
+          ),
+        ),
+      );
+    }
+
     return Row(
       children: [
-        AccessibilityWrapper(
-          semanticLabel: isLiked ? 'Unlike post' : 'Like post',
-          isButton: true,
-          child: AnimatedButton(
-            onPressed: onLike,
-            child: Icon(
-              isLiked ? Icons.favorite : Icons.favorite_border,
-              color: isLiked
-                  ? context.colorScheme.primary
-                  : context.theme.iconTheme.color,
-            ),
+        buildItem(
+          icon: Icon(
+            isLiked ? Icons.favorite : Icons.favorite_border,
+            color: isLiked
+                ? context.colorScheme.primary
+                : context.theme.iconTheme.color,
           ),
+          label: isLiked ? 'Unlike post' : 'Like post',
+          onTap: onLike,
+          count: likeCount,
         ),
         SizedBox(width: DesignTokens.sm(context)),
-        AccessibilityWrapper(
-          semanticLabel: 'Comment on post',
-          isButton: true,
-          child: AnimatedButton(
-            onPressed: onComment,
-            child: const Icon(Icons.mode_comment_outlined),
-          ),
+        buildItem(
+          icon: const Icon(Icons.mode_comment_outlined),
+          label: 'Comment on post',
+          onTap: onComment,
+          count: commentCount,
         ),
         SizedBox(width: DesignTokens.sm(context)),
-        AccessibilityWrapper(
-          semanticLabel: 'Repost',
-          isButton: true,
-          child: AnimatedButton(
-            onPressed: onRepost,
-            child: const Icon(Icons.repeat),
-          ),
+        buildItem(
+          icon: const Icon(Icons.repeat),
+          label: 'Repost',
+          onTap: onRepost,
+          count: repostCount,
         ),
       ],
     );

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -2,6 +2,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:myapp/features/social_feed/controllers/feed_controller.dart';
 import 'package:myapp/features/social_feed/models/feed_post.dart';
+import 'package:myapp/features/social_feed/models/post_like.dart';
+import 'package:myapp/features/social_feed/models/post_repost.dart';
 import 'package:myapp/features/social_feed/services/feed_service.dart';
 
 class FakeFeedService extends FeedService {
@@ -15,16 +17,49 @@ class FakeFeedService extends FeedService {
           repostsCollectionId: 'reposts',
         );
 
-  final List<FeedPost> _store = [];
+  final List<FeedPost> store = [];
+  final Map<String, String> likes = {}; // likeId by postId
+  final Map<String, String> reposts = {}; // repostId by postId
 
   @override
   Future<List<FeedPost>> getPosts(String roomId) async {
-    return _store.where((p) => p.roomId == roomId).toList();
+    return store.where((p) => p.roomId == roomId).toList();
   }
 
   @override
   Future<void> createPost(FeedPost post) async {
-    _store.add(post);
+    store.add(post);
+  }
+
+  @override
+  Future<void> createLike(Map<String, dynamic> like) async {
+    likes[like['item_id']] = 'l1';
+  }
+
+  @override
+  Future<PostLike?> getUserLike(String itemId, String userId) async {
+    final id = likes[itemId];
+    return id == null
+        ? null
+        : PostLike(id: id, itemId: itemId, itemType: 'post', userId: userId);
+  }
+
+  @override
+  Future<void> deleteLike(String likeId) async {
+    likes.removeWhere((key, value) => value == likeId);
+  }
+
+  @override
+  Future<void> createRepost(Map<String, dynamic> repost) async {
+    reposts[repost['post_id']] = 'r1';
+  }
+
+  @override
+  Future<PostRepost?> getUserRepost(String postId, String userId) async {
+    final id = reposts[postId];
+    return id == null
+        ? null
+        : PostRepost(id: id, postId: postId, userId: userId);
   }
 }
 
@@ -50,5 +85,42 @@ void main() {
     );
     await controller.createPost(post);
     expect(controller.posts.length, 1);
+  });
+
+  test('toggleLikePost updates maps', () async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    service.store.add(
+      FeedPost(
+        id: '1',
+        roomId: 'room',
+        userId: 'u1',
+        username: 'user',
+        content: 'text',
+      ),
+    );
+    await controller.loadPosts('room');
+    await controller.toggleLikePost('1');
+    expect(controller.isPostLiked('1'), isTrue);
+    expect(controller.postLikeCount('1'), 1);
+    await controller.toggleLikePost('1');
+    expect(controller.isPostLiked('1'), isFalse);
+  });
+
+  test('repostPost increases count', () async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    service.store.add(
+      FeedPost(
+        id: '1',
+        roomId: 'room',
+        userId: 'u1',
+        username: 'user',
+        content: 'hello',
+      ),
+    );
+    await controller.loadPosts('room');
+    await controller.repostPost('1');
+    expect(controller.postRepostCount('1'), 1);
   });
 }


### PR DESCRIPTION
## Summary
- support fetching like/repost objects in `FeedService`
- track like/repost state in `FeedController` and `CommentsController`
- update `PostCard` and `CommentCard` with new `ReactionBar`
- enhance thread and detail pages for replies
- add unit and widget tests for new behaviour

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3c29389c832d8529ac77ca67a2bb