### PR TITLE
Replace spinners with skeleton loaders

### DIFF
--- a/lib/pages/chat_rooms_list_page.dart
+++ b/lib/pages/chat_rooms_list_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../controllers/chat_controller.dart';
 import '../widgets/chat/chat_room_card.dart';
+import '../design_system/modern_ui_system.dart';
 
 class ChatRoomsListPage extends GetView<ChatController> {
   const ChatRoomsListPage({super.key});
@@ -20,7 +21,12 @@ class ChatRoomsListPage extends GetView<ChatController> {
       ),
       body: Obx(() {
         if (controller.isLoading.value) {
-          return const Center(child: CircularProgressIndicator());
+          return Center(
+            child: SkeletonLoader(
+              height: DesignTokens.xl(context),
+              width: DesignTokens.xl(context),
+            ),
+          );
         }
         if (controller.rashiRooms.isEmpty) {
           return Center(

--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import '../controllers/auth_controller.dart';
 import '../widgets/responsive_layout.dart';
 import '../widgets/animated_form_field.dart';
+import '../design_system/modern_ui_system.dart';
 
 class SignInPage extends StatefulWidget {
   const SignInPage({super.key});
@@ -84,7 +85,10 @@ class _SignInPageState extends State<SignInPage> {
                 onPressed:
                     controller.isLoading.value ? null : controller.sendOTP,
                 child: controller.isLoading.value
-                    ? const CircularProgressIndicator()
+                    ? SkeletonLoader(
+                        height: DesignTokens.lg(context),
+                        width: DesignTokens.lg(context),
+                      )
                     : Text('send_otp'.tr),
               )),
         ),
@@ -152,7 +156,10 @@ class _SignInPageState extends State<SignInPage> {
                   onPressed:
                       controller.isLoading.value ? null : controller.verifyOTP,
                   child: controller.isLoading.value
-                      ? const CircularProgressIndicator()
+                      ? SkeletonLoader(
+                          height: DesignTokens.lg(context),
+                          width: DesignTokens.lg(context),
+                        )
                       : Text('verify_otp'.tr),
                 )),
           ),

--- a/lib/pages/splash_screen.dart
+++ b/lib/pages/splash_screen.dart
@@ -32,8 +32,9 @@ class SplashScreen extends GetView<SplashController> {
               SizedBox(height: DesignTokens.lg(context)),
               Obx(() {
                 if (controller.isLoading.value) {
-                  return const CircularProgressIndicator(
-                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  return SkeletonLoader(
+                    height: DesignTokens.xl(context),
+                    width: DesignTokens.xl(context),
                   );
                 }
                 return Padding(

--- a/lib/widgets/safe_network_image.dart
+++ b/lib/widgets/safe_network_image.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../design_system/modern_ui_system.dart';
 
 class SafeNetworkImage extends StatelessWidget {
   final String? imageUrl;
@@ -31,8 +32,11 @@ class SafeNetworkImage extends StatelessWidget {
       width: width,
       height: height,
       fit: fit,
-      placeholder: (context, url) =>
-          placeholder ?? const CircularProgressIndicator(),
+      placeholder: (context, url) => placeholder ??
+          SkeletonLoader(
+            height: DesignTokens.xl(context),
+            width: DesignTokens.xl(context),
+          ),
       errorWidget: (context, url, error) {
         debugPrint('SafeNetworkImage error: $error for URL: $url');
         return errorWidget ?? const Icon(Icons.person);


### PR DESCRIPTION
## Summary
- use `SkeletonLoader` placeholder in `SafeNetworkImage`
- show skeleton loaders in Sign In page buttons
- replace spinner in chat rooms list page
- replace spinner in splash screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3f0ccd7c832da4408d87d395e992