### PR TITLE
Replace debugPrint with logger

### DIFF
--- a/lib/widgets/safe_network_image.dart
+++ b/lib/widgets/safe_network_image.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
+import '../utils/logger.dart';
 
 class SafeNetworkImage extends StatelessWidget {
   final String? imageUrl;
@@ -34,13 +35,13 @@ class SafeNetworkImage extends StatelessWidget {
       placeholder: (context, url) =>
           placeholder ?? const CircularProgressIndicator(),
       errorWidget: (context, url, error) {
-        debugPrint('SafeNetworkImage error: $error for URL: $url');
+        logger.e('SafeNetworkImage error: $error for URL: $url');
         return errorWidget ?? const Icon(Icons.person);
       },
       fadeInDuration: const Duration(milliseconds: 200),
       fadeOutDuration: const Duration(milliseconds: 200),
       errorListener: (exception) {
-        debugPrint('SafeNetworkImage exception: $exception');
+        logger.e('SafeNetworkImage exception: $exception');
       },
     );
   }


### PR DESCRIPTION
## Summary
- swap `debugPrint` for `logger.e` in `SafeNetworkImage`
- import the shared logger utility

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3f1008dc832d8c87c3382e2535ee