### PR TITLE
Refactor colors to design tokens

### DIFF
--- a/lib/controllers/chat_controller.dart
+++ b/lib/controllers/chat_controller.dart
@@ -4,9 +4,11 @@ import 'package:get/get.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../utils/logger.dart';
+import '../utils/modern_color_palettes.dart';
 
 import '../models/chat_room.dart';
 import 'auth_controller.dart';
+import '../design_system/modern_ui_system.dart';
 
 class ChatController extends GetxController {
   final AuthController _auth = Get.find<AuthController>();
@@ -171,14 +173,11 @@ class GlassmorphismUtils {
               begin: Alignment.topLeft,
               end: Alignment.bottomRight,
               colors: gradientColors ??
-                  [
-                    Colors.white.withOpacity(isDark ? 0.1 : 0.2),
-                    Colors.white.withOpacity(isDark ? 0.05 : 0.1),
-                  ],
+                  ModernColorPalettes.getGlassmorphismOverlay(isDark: isDark),
             ),
             borderRadius: BorderRadius.circular(borderRadius),
             border: Border.all(
-              color: Colors.white.withOpacity(0.2),
+              color: ModernColorPalettes.getGlassmorphismBorder(isDark: isDark),
               width: 1.5,
             ),
           ),

--- a/lib/design_system/modern_ui_system.dart
+++ b/lib/design_system/modern_ui_system.dart
@@ -1050,6 +1050,23 @@ extension PaddingExtensions on double {
   EdgeInsets get bottom => EdgeInsets.only(bottom: this);
 }
 
+extension ColorTokens on BuildContext {
+  /// Border color used for glassmorphism effects
+  Color get glassBorderColor => colorScheme.onSurface.withOpacity(
+        colorScheme.brightness == Brightness.dark ? 0.15 : 0.25,
+      );
+
+  /// High overlay color for glassmorphism backgrounds
+  Color get glassOverlayHigh => colorScheme.onSurface.withOpacity(
+        colorScheme.brightness == Brightness.dark ? 0.1 : 0.25,
+      );
+
+  /// Low overlay color for glassmorphism backgrounds
+  Color get glassOverlayLow => colorScheme.onSurface.withOpacity(
+        colorScheme.brightness == Brightness.dark ? 0.05 : 0.15,
+      );
+}
+
 // ============================================================================
 // EXAMPLE USAGE DEMONSTRATION
 // ============================================================================

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -4,6 +4,7 @@ import 'package:myapp/design_system/modern_ui_system.dart';
 import '../controllers/auth_controller.dart';
 import '../widgets/enhanced_responsive_layout.dart';
 import '../design_system/modern_ui_system.dart' as ui;
+import '../utils/modern_color_palettes.dart';
 import '../widgets/enhanced_sliver_app_bar.dart';
 import '../widgets/simple_astrologer_fab.dart';
 import '../controllers/user_type_controller.dart';
@@ -343,7 +344,8 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
             separatorBuilder: (_, __) =>
                 SizedBox(width: _getResponsiveSpacing(context) * 0.4),
             itemBuilder: (context, index) {
-              final color = Colors.primaries[index % Colors.primaries.length];
+              final color =
+                  ModernColorPalettes.getGradientForIndex(index).first;
               return TweenAnimationBuilder<double>(
                 tween: Tween(begin: 0.0, end: 1.0),
                 duration: Duration(milliseconds: 200 + (index * 50)),
@@ -378,7 +380,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               child: Text(
                 '$number',
                 style: TextStyle(
-                  color: Colors.white,
+                  color: context.colorScheme.onPrimary,
                   fontSize: _getResponsiveFontSize(context, 16),
                   fontWeight: FontWeight.bold,
                 ),

--- a/lib/pages/splash_screen.dart
+++ b/lib/pages/splash_screen.dart
@@ -25,15 +25,17 @@ class SplashScreen extends GetView<SplashController> {
               Text(
                 'app_name'.tr,
                 style: Theme.of(context).textTheme.headlineLarge?.copyWith(
-                  color: Colors.white,
+                  color: context.colorScheme.onPrimary,
                   fontWeight: FontWeight.bold,
                 ),
               ),
               SizedBox(height: DesignTokens.lg(context)),
               Obx(() {
                 if (controller.isLoading.value) {
-                  return const CircularProgressIndicator(
-                    valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                  return CircularProgressIndicator(
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      context.colorScheme.onPrimary,
+                    ),
                   );
                 }
                 return Padding(

--- a/lib/widgets/chat/chat_room_card.dart
+++ b/lib/widgets/chat/chat_room_card.dart
@@ -44,10 +44,10 @@ class ChatRoomCard extends StatelessWidget {
               Expanded(
                 child: Text(
                   room.name,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 13,
                     fontWeight: FontWeight.w600,
-                    color: Colors.white,
+                    color: context.colorScheme.onPrimary,
                   ),
                   maxLines: 2,
                   overflow: TextOverflow.ellipsis,
@@ -56,15 +56,15 @@ class ChatRoomCard extends StatelessWidget {
               Container(
                 padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
                 decoration: BoxDecoration(
-                  color: Colors.white.withOpacity(0.2),
+                  color: context.colorScheme.onPrimary.withOpacity(0.2),
                   borderRadius: BorderRadius.circular(12),
                 ),
                 child: Text(
                   '${room.dailyMessages} today',
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontSize: 11,
                     fontWeight: FontWeight.w600,
-                    color: Colors.white,
+                    color: context.colorScheme.onPrimary,
                   ),
                 ),
               ),

--- a/lib/widgets/chat/modern_chat_room_card.dart
+++ b/lib/widgets/chat/modern_chat_room_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'dart:ui';
 import '../../models/chat_room.dart';
+import '../../design_system/modern_ui_system.dart';
 
 class ModernChatRoomCard extends StatefulWidget {
   final ChatRoom room;
@@ -105,13 +106,13 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
                               begin: Alignment.topLeft,
                               end: Alignment.bottomRight,
                               colors: [
-                                Colors.white.withOpacity(isDark ? 0.1 : 0.2),
-                                Colors.white.withOpacity(isDark ? 0.05 : 0.1),
+                                context.glassOverlayHigh,
+                                context.glassOverlayLow,
                               ],
                             ),
                             borderRadius: BorderRadius.circular(20),
                             border: Border.all(
-                              color: Colors.white.withOpacity(0.2),
+                              color: context.glassBorderColor,
                               width: 1.5,
                             ),
                           ),
@@ -126,7 +127,8 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
                                   offset: Offset(0, _elevationAnimation.value / 2),
                                 ),
                                 BoxShadow(
-                                  color: Colors.black.withOpacity(isDark ? 0.3 : 0.1),
+                                  color: context.colorScheme.shadow
+                                      .withOpacity(isDark ? 0.3 : 0.1),
                                   blurRadius: _elevationAnimation.value * 2,
                                   offset: Offset(0, _elevationAnimation.value),
                                 ),
@@ -184,10 +186,10 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
                 child: Center(
                   child: Text(
                     widget.room.symbol ?? '⭐',
-                    style: const TextStyle(
+                    style: TextStyle(
                       fontSize: 20,
                       fontWeight: FontWeight.bold,
-                      color: Colors.white,
+                      color: context.colorScheme.onPrimary,
                     ),
                   ),
                 ),
@@ -202,7 +204,7 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
                       style: TextStyle(
                         fontSize: 16,
                         fontWeight: FontWeight.w700,
-                        color: isDark ? Colors.white : Colors.black87,
+                        color: context.colorScheme.onSurface,
                         letterSpacing: 0.5,
                       ),
                       maxLines: 1,
@@ -214,9 +216,7 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
                       style: TextStyle(
                         fontSize: 12,
                         fontWeight: FontWeight.w500,
-                        color: isDark 
-                            ? Colors.white.withOpacity(0.7)
-                            : Colors.black54,
+                        color: context.colorScheme.onSurfaceVariant,
                         letterSpacing: 0.3,
                       ),
                     ),
@@ -252,9 +252,7 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
                 style: TextStyle(
                   fontSize: 11,
                   fontWeight: FontWeight.w600,
-                  color: isDark 
-                      ? Colors.white.withOpacity(0.8)
-                      : Colors.black54,
+                  color: context.colorScheme.onSurface.withOpacity(0.8),
                   letterSpacing: 0.2,
                 ),
               ),
@@ -262,9 +260,7 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
               Icon(
                 Icons.arrow_forward_ios,
                 size: 12,
-                color: isDark 
-                    ? Colors.white.withOpacity(0.6)
-                    : Colors.black38,
+                color: context.colorScheme.onSurfaceVariant,
               ),
             ],
           ),
@@ -282,18 +278,18 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
         decoration: BoxDecoration(
           gradient: LinearGradient(
             colors: [
-              Colors.white.withOpacity(isDark ? 0.2 : 0.9),
-              Colors.white.withOpacity(isDark ? 0.1 : 0.8),
+              context.glassOverlayHigh,
+              context.glassOverlayLow,
             ],
           ),
           borderRadius: BorderRadius.circular(12),
           border: Border.all(
-            color: Colors.white.withOpacity(0.3),
+            color: context.glassBorderColor,
             width: 1,
           ),
           boxShadow: [
             BoxShadow(
-              color: Colors.black.withOpacity(0.1),
+            color: context.colorScheme.shadow.withOpacity(0.1),
               blurRadius: 4,
               offset: const Offset(0, 2),
             ),
@@ -304,7 +300,7 @@ class _ModernChatRoomCardState extends State<ModernChatRoomCard>
           style: TextStyle(
             fontSize: 11,
             fontWeight: FontWeight.w700,
-            color: isDark ? Colors.white : Colors.black87,
+            color: context.colorScheme.onSurface,
             letterSpacing: 0.2,
           ),
         ),

--- a/lib/widgets/complete_enhanced_watchlist.dart
+++ b/lib/widgets/complete_enhanced_watchlist.dart
@@ -8,6 +8,7 @@ import 'dart:convert';
 import 'package:appwrite/appwrite.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../design_system/modern_ui_system.dart';
 import '../utils/logger.dart';
 import '../controllers/auth_controller.dart';
 import '../utils/parsing_utils.dart';
@@ -1203,7 +1204,7 @@ class SwipeableWatchlistCard extends StatelessWidget {
                   padding:
                       const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
                   decoration: BoxDecoration(
-                    color: Colors.white.withOpacity(0.2),
+                    color: context.colorScheme.onPrimary.withOpacity(0.2),
                     borderRadius: BorderRadius.circular(20),
                   ),
                   child: Text(
@@ -1244,12 +1245,12 @@ class SwipeableWatchlistCard extends StatelessWidget {
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Icon(icon, color: Colors.white, size: 24),
+              Icon(icon, color: context.colorScheme.onPrimary, size: 24),
               const SizedBox(height: 4),
               Text(
                 text,
-                style: const TextStyle(
-                  color: Colors.white,
+                style: TextStyle(
+                  color: context.colorScheme.onPrimary,
                   fontSize: 12,
                   fontWeight: FontWeight.w600,
                 ),
@@ -1275,8 +1276,8 @@ class SwipeableWatchlistCard extends StatelessWidget {
               ElevatedButton(
                 onPressed: () => Get.back(result: true),
                 style: ElevatedButton.styleFrom(
-                  backgroundColor: Colors.red,
-                  foregroundColor: Colors.white,
+                  backgroundColor: context.colorScheme.error,
+                  foregroundColor: context.colorScheme.onError,
                 ),
                 child: const Text('Remove'),
               ),
@@ -1714,8 +1715,8 @@ class EnhancedWatchlistWidget extends StatelessWidget {
               Get.back();
             },
             style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.red,
-              foregroundColor: Colors.white,
+              backgroundColor: context.colorScheme.error,
+              foregroundColor: context.colorScheme.onError,
             ),
             child: const Text('Clear All'),
           ),


### PR DESCRIPTION
## Summary
- add `ColorTokens` extension for glassmorphism colors
- switch widgets to use `ColorTokens` and `colorScheme`
- apply palette-based colors instead of `Colors.primaries`

## Testing
- `dart format` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c3f129d98832d88dc0b16cddbea70