### PR TITLE
Implement offline caching with Hive

### DIFF
--- a/lib/bindings/feed_binding.dart
+++ b/lib/bindings/feed_binding.dart
@@ -2,6 +2,7 @@ import 'package:get/get.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 import '../controllers/auth_controller.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import '../features/social_feed/services/feed_service.dart';
 import '../features/social_feed/controllers/feed_controller.dart';
 import '../features/social_feed/controllers/comments_controller.dart';
@@ -23,6 +24,7 @@ class FeedBinding extends Bindings {
             dotenv.env['POST_LIKES_COLLECTION_ID'] ?? 'post_likes',
         repostsCollectionId:
             dotenv.env['POST_REPOSTS_COLLECTION_ID'] ?? 'post_reposts',
+        connectivity: Get.put(Connectivity()),
       );
       Get.put<FeedController>(FeedController(service: service));
     }

--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -60,8 +60,16 @@ class CommentsController extends GetxController {
         'item_type': 'comment',
         'user_id': uid,
       });
-      final like = await service.getUserLike(commentId, uid);
-      if (like != null) _likedIds[commentId] = like.id;
+      try {
+        final like = await service.getUserLike(commentId, uid);
+        if (like != null) {
+          _likedIds[commentId] = like.id;
+        } else {
+          _likedIds[commentId] = 'offline';
+        }
+      } catch (_) {
+        _likedIds[commentId] = 'offline';
+      }
       _likeCounts[commentId] = (_likeCounts[commentId] ?? 0) + 1;
     }
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'bindings/auth_binding.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'features/social_feed/services/feed_service.dart';
 import 'pages/sign_in_page.dart';
 import 'pages/home_page.dart';
 import 'pages/set_username_page.dart';
@@ -23,6 +27,11 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  final dir = await getApplicationDocumentsDirectory();
+  await Hive.initFlutter(dir.path);
+  await Hive.openBox('posts');
+  await Hive.openBox('comments');
+  await Hive.openBox('action_queue');
   await dotenv.load(fileName: '.env');
   runApp(const MyApp());
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
   appwrite: ^13.0.0
   get: ^4.6.6
   logger: ^2.4.0
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
   connectivity_plus: ^6.0.5
   flutter_localizations:
     sdk: flutter

--- a/test/features/social_feed/offline_comments_controller_test.dart
+++ b/test/features/social_feed/offline_comments_controller_test.dart
@@ -1,0 +1,77 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:get/get.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/features/social_feed/controllers/comments_controller.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+
+class OfflineDatabases extends Databases {
+  OfflineDatabases() : super(Client());
+
+  @override
+  Future listDocuments({
+    required String databaseId,
+    required String collectionId,
+    List<String>? queries,
+  }) {
+    return Future.error('offline');
+  }
+
+  @override
+  Future createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<String, dynamic> data,
+    List<String>? permissions,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+void main() {
+  late Directory dir;
+  late CommentsController controller;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('posts');
+    await Hive.openBox('comments');
+    await Hive.openBox('action_queue');
+    final service = FeedService(
+      databases: OfflineDatabases(),
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      connectivity: Connectivity(),
+    );
+    controller = CommentsController(service: service);
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('loadComments uses cached data when offline', () async {
+    final box = Hive.box('comments');
+    await box.put('comments_post', [
+      {
+        'id': 'c1',
+        'post_id': 'post',
+        'user_id': 'u',
+        'username': 'name',
+        'content': 'hi',
+        '_cachedAt': DateTime.now().toIso8601String(),
+      }
+    ]);
+    await controller.loadComments('post');
+    expect(controller.comments.length, 1);
+  });
+}

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -1,0 +1,80 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+
+class OfflineDatabases extends Databases {
+  OfflineDatabases() : super(Client());
+
+  @override
+  Future listDocuments({
+    required String databaseId,
+    required String collectionId,
+    List<String>? queries,
+  }) {
+    return Future.error('offline');
+  }
+
+  @override
+  Future createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<String, dynamic> data,
+    List<String>? permissions,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+void main() {
+  late Directory dir;
+  late FeedService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('posts');
+    await Hive.openBox('comments');
+    await Hive.openBox('action_queue');
+    service = FeedService(
+      databases: OfflineDatabases(),
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      connectivity: Connectivity(),
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('getPosts returns cached posts when offline', () async {
+    final box = Hive.box('posts');
+    await box.put('posts_room', [
+      {
+        'id': '1',
+        'room_id': 'room',
+        'user_id': 'u',
+        'username': 'name',
+        'content': 'hi',
+        '_cachedAt': DateTime.now().toIso8601String(),
+      }
+    ]);
+    final posts = await service.getPosts('room');
+    expect(posts, isNotEmpty);
+    expect(posts.first.content, 'hi');
+  });
+
+  test('createLike queues when offline', () async {
+    await service.createLike({'item_id': '1', 'item_type': 'post', 'user_id': 'u'});
+    final queue = Hive.box('action_queue');
+    expect(queue.isNotEmpty, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- initialize Hive boxes at startup
- update FeedService for local caching, offline queue, and sync
- adjust CommentsController for offline likes
- pass Connectivity to FeedService via binding
- add offline caching tests

## Testing
- `flutter pub get` *(fails: `flutter: command not found`)*
- `flutter analyze` *(fails: `flutter: command not found`)*
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684c3f168b3c832dbe949676031ccfab