### PR TITLE
Fix duplicate dependencies in pubspec

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,8 +29,6 @@ dependencies:
   image_picker: ^1.1.1
   image_cropper: ^5.0.1
   package_info_plus: ^8.0.2
-  hive: ^2.2.3
-  hive_flutter: ^1.1.0
   flutter_app_badge: ^1.3.0
   flutter_image_compress: ^2.0.4
   share_plus: ^7.0.0


### PR DESCRIPTION
## Summary
- remove duplicated `hive` and `hive_flutter` dependency declarations from `pubspec.yaml`

## Testing
- `dart pub get --no-example` *(fails: dart not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c4d3b4f44832d8cd5fc469cdf5146