### PR TITLE
Fix invalid dependency url_validator

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,7 +32,7 @@ dependencies:
   flutter_app_badge: ^1.3.0
   flutter_image_compress: ^2.0.4
   share_plus: ^7.0.0
-  url_validator: ^1.0.0
+  validators: ^3.0.0
   html_unescape: ^2.0.0
   flutter_local_notifications: ^15.0.0
   path_provider: ^2.1.2

--- a/social media features implementation_guide.markdown
+++ b/social media features implementation_guide.markdown
@@ -59,7 +59,7 @@ This guide provides detailed instructions  to implement 26 social media features
      flutter_image_compress: ^2.0.4
      cached_network_image: ^3.2.3
      share_plus: ^7.0.0
-     url_validator: ^1.0.0
+     validators: ^3.0.0
      html_unescape: ^2.0.0
      flutter_app_badge: ^0.1.0
      flutter_local_notifications: ^15.0.0
@@ -348,7 +348,7 @@ Below are instructions for implementing the 26 features, mapped to your project 
 
 - **Production Tips**:
 
-  - Validate URLs with `url_validator`.
+  - Validate URLs with `validators`.
   - Cache metadata in Hive.
   - Display previews in `post_card.dart` with clickable links.
   - Use HTTPS-only URLs.


### PR DESCRIPTION
## Summary
- replace nonexistent `url_validator` dependency with `validators`
- update docs referencing the change

## Testing
- `flutter analyze` *(fails: `flutter` not found)*
- `dart pub get` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4e551a30832d958cd1a99c367a16