### PR TITLE
Add image posting with offline queue

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -1,4 +1,5 @@
 import 'package:get/get.dart';
+import 'dart:io';
 import '../../../controllers/auth_controller.dart';
 import '../models/feed_post.dart';
 import '../services/feed_service.dart';
@@ -44,6 +45,27 @@ class FeedController extends GetxController {
   Future<void> createPost(FeedPost post) async {
     await service.createPost(post);
     _posts.insert(0, post);
+  }
+
+  Future<void> createPostWithImage(
+    String userId,
+    String username,
+    String content,
+    String roomId,
+    File image,
+  ) async {
+    await service.createPostWithImage(userId, username, content, roomId, image);
+    _posts.insert(
+      0,
+      FeedPost(
+        id: DateTime.now().toIso8601String(),
+        roomId: roomId,
+        userId: userId,
+        username: username,
+        content: content,
+        mediaUrls: [image.path],
+      ),
+    );
   }
 
   Future<void> toggleLikePost(String postId) async {

--- a/lib/features/social_feed/widgets/media_gallery.dart
+++ b/lib/features/social_feed/widgets/media_gallery.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../design_system/modern_ui_system.dart';
-import '../../../widgets/safe_network_image.dart';
+import 'package:cached_network_image/cached_network_image.dart';
 
 class MediaGallery extends StatelessWidget {
   final List<String> urls;
@@ -19,11 +19,18 @@ class MediaGallery extends StatelessWidget {
           final url = urls[index];
           return ClipRRect(
             borderRadius: BorderRadius.circular(DesignTokens.radiusMd(context)),
-            child: SafeNetworkImage(
+            child: CachedNetworkImage(
               imageUrl: url,
               width: 200,
               height: 200,
               fit: BoxFit.cover,
+              placeholder: (context, url) => SkeletonLoader(
+                width: 200,
+                height: 200,
+                borderRadius:
+                    BorderRadius.circular(DesignTokens.radiusMd(context)),
+              ),
+              errorWidget: (context, url, error) => const Icon(Icons.error),
             ),
           );
         },

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -39,6 +39,7 @@ Future<void> main() async {
   await Hive.openBox('posts');
   await Hive.openBox('comments');
   await Hive.openBox('action_queue');
+  await Hive.openBox('post_queue');
   await Hive.openBox('profiles');
   await Hive.openBox('notifications');
   await Hive.openBox('follows');
@@ -48,6 +49,7 @@ Future<void> main() async {
   final auth = Get.find<AuthController>();
   final feedService = FeedService(
     databases: auth.databases,
+    storage: auth.storage,
     databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
     postsCollectionId:
         dotenv.env['FEED_POSTS_COLLECTION_ID'] ?? 'feed_posts',


### PR DESCRIPTION
## Summary
- support selecting images when composing posts
- upload images and queue offline posts
- add image upload helpers to FeedService
- display post images with `CachedNetworkImage`
- queue image posts in Hive `post_queue`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5ae67b74832db3f4a0f3d9efc77b