### PR TITLE
Add link preview support in social feed

### DIFF
--- a/lib/bindings/feed_binding.dart
+++ b/lib/bindings/feed_binding.dart
@@ -6,6 +6,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import '../features/social_feed/services/feed_service.dart';
 import '../features/social_feed/controllers/feed_controller.dart';
 import '../features/social_feed/controllers/comments_controller.dart';
+import 'package:appwrite/appwrite.dart';
 
 class FeedBinding extends Bindings {
   @override
@@ -15,6 +16,8 @@ class FeedBinding extends Bindings {
     if (!Get.isRegistered<FeedController>()) {
       final service = FeedService(
         databases: auth.databases,
+        storage: auth.storage,
+        functions: Functions(auth.client),
         databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
         postsCollectionId:
             dotenv.env['FEED_POSTS_COLLECTION_ID'] ?? 'feed_posts',
@@ -25,6 +28,8 @@ class FeedBinding extends Bindings {
         repostsCollectionId:
             dotenv.env['POST_REPOSTS_COLLECTION_ID'] ?? 'post_reposts',
         connectivity: Get.put(Connectivity()),
+        linkMetadataFunctionId:
+            dotenv.env['FETCH_LINK_METADATA_FUNCTION_ID'] ?? 'fetch_link_metadata',
       );
       Get.put<FeedController>(FeedController(service: service));
     }

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -68,6 +68,35 @@ class FeedController extends GetxController {
     );
   }
 
+  Future<void> createPostWithLink(
+    String userId,
+    String username,
+    String content,
+    String roomId,
+    String linkUrl,
+    Map<String, dynamic> metadata,
+  ) async {
+    await service.createPostWithLink(
+      userId,
+      username,
+      content,
+      roomId,
+      linkUrl,
+    );
+    _posts.insert(
+      0,
+      FeedPost(
+        id: DateTime.now().toIso8601String(),
+        roomId: roomId,
+        userId: userId,
+        username: username,
+        content: content,
+        linkUrl: linkUrl,
+        linkMetadata: metadata,
+      ),
+    );
+  }
+
   Future<void> toggleLikePost(String postId) async {
     final auth = Get.find<AuthController>();
     final uid = auth.userId;

--- a/lib/features/social_feed/models/feed_post.dart
+++ b/lib/features/social_feed/models/feed_post.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 class FeedPost {
   final String id;
   final String roomId;
@@ -7,6 +9,8 @@ class FeedPost {
   final String content;
   final List<String> mediaUrls;
   final String? pollId;
+  final String? linkUrl;
+  final Map<String, dynamic>? linkMetadata;
   final int likeCount;
   final int commentCount;
   final int repostCount;
@@ -21,6 +25,8 @@ class FeedPost {
     required this.content,
     this.mediaUrls = const [],
     this.pollId,
+    this.linkUrl,
+    this.linkMetadata,
     this.likeCount = 0,
     this.commentCount = 0,
     this.repostCount = 0,
@@ -37,6 +43,8 @@ class FeedPost {
       content: json['content'] ?? '',
       mediaUrls: (json['media_urls'] as List?)?.cast<String>() ?? const [],
       pollId: json['poll_id'],
+      linkUrl: json['link_url'],
+      linkMetadata: _parseMetadata(json['link_metadata']),
       likeCount: json['like_count'] ?? 0,
       commentCount: json['comment_count'] ?? 0,
       repostCount: json['repost_count'] ?? 0,
@@ -53,10 +61,25 @@ class FeedPost {
       'content': content,
       'media_urls': mediaUrls,
       'poll_id': pollId,
+      'link_url': linkUrl,
+      'link_metadata': linkMetadata,
       'like_count': likeCount,
       'comment_count': commentCount,
       'repost_count': repostCount,
       'share_count': shareCount,
     };
+  }
+
+  static Map<String, dynamic>? _parseMetadata(dynamic raw) {
+    if (raw == null) return null;
+    if (raw is Map<String, dynamic>) return raw;
+    if (raw is String && raw.isNotEmpty) {
+      try {
+        return jsonDecode(raw) as Map<String, dynamic>;
+      } catch (_) {
+        return null;
+      }
+    }
+    return null;
   }
 }

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -6,6 +6,8 @@ import '../controllers/feed_controller.dart';
 import '../screens/post_detail_page.dart';
 import 'media_gallery.dart';
 import 'reaction_bar.dart';
+import 'package:url_launcher/url_launcher.dart';
+import '../../../widgets/safe_network_image.dart';
 
 class PostCard extends StatelessWidget {
   final FeedPost post;
@@ -42,6 +44,50 @@ class PostCard extends StatelessWidget {
               Padding(
                 padding: EdgeInsets.only(top: DesignTokens.sm(context)),
                 child: MediaGallery(urls: post.mediaUrls),
+              ),
+            if (post.linkUrl != null && post.linkMetadata != null)
+              Padding(
+                padding: EdgeInsets.only(top: DesignTokens.sm(context)),
+                child: GlassmorphicCard(
+                  padding: DesignTokens.sm(context).all,
+                  onTap: () {
+                    final uri = Uri.parse(post.linkUrl!);
+                    launchUrl(uri, mode: LaunchMode.externalApplication);
+                  },
+                  child: Row(
+                    children: [
+                      if (post.linkMetadata!['image'] != null)
+                        Padding(
+                          padding: EdgeInsets.only(right: DesignTokens.sm(context)),
+                          child: SafeNetworkImage(
+                            imageUrl: post.linkMetadata!['image'] as String?,
+                            width: 60,
+                            height: 60,
+                            fit: BoxFit.cover,
+                          ),
+                        ),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              post.linkMetadata!['title'] ?? post.linkUrl!,
+                              style: Theme.of(context).textTheme.bodyMedium,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                            if (post.linkMetadata!['description'] != null)
+                              Text(
+                                post.linkMetadata!['description'],
+                                maxLines: 2,
+                                overflow: TextOverflow.ellipsis,
+                              ),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
               ),
             SizedBox(height: DesignTokens.sm(context)),
             ReactionBar(

--- a/test/features/social_feed/comments_controller_test.dart
+++ b/test/features/social_feed/comments_controller_test.dart
@@ -9,12 +9,15 @@ class FakeFeedService extends FeedService {
   FakeFeedService()
       : super(
           databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
           databaseId: 'db',
           postsCollectionId: 'posts',
           commentsCollectionId: 'comments',
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
           connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
         );
 
   final List<PostComment> store = [];

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -11,12 +11,15 @@ class FakeFeedService extends FeedService {
   FakeFeedService()
       : super(
           databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
           databaseId: 'db',
           postsCollectionId: 'posts',
           commentsCollectionId: 'comments',
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
           connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
         );
 
   final List<FeedPost> store = [];

--- a/test/features/social_feed/offline_comments_controller_test.dart
+++ b/test/features/social_feed/offline_comments_controller_test.dart
@@ -43,12 +43,15 @@ void main() {
     await Hive.openBox('action_queue');
     final service = FeedService(
       databases: OfflineDatabases(),
+      storage: Storage(Client()),
+      functions: Functions(Client()),
       databaseId: 'db',
       postsCollectionId: 'posts',
       commentsCollectionId: 'comments',
       likesCollectionId: 'likes',
       repostsCollectionId: 'reposts',
       connectivity: Connectivity(),
+      linkMetadataFunctionId: 'fetch_link_metadata',
     );
     controller = CommentsController(service: service);
   });

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -104,4 +104,10 @@ void main() {
     final queue = Hive.box('post_queue');
     expect(queue.isNotEmpty, isTrue);
   });
+  test('createPostWithLink queues when offline', () async {
+    await service.createPostWithLink('u', 'name', 'hi', 'room', 'https://x.com');
+    final queue = Hive.box('action_queue');
+    expect(queue.isNotEmpty, isTrue);
+  });
+
 }

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -55,12 +55,15 @@ class FakeFeedService extends FeedService {
   FakeFeedService()
       : super(
           databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
           databaseId: 'db',
           postsCollectionId: 'posts',
           commentsCollectionId: 'comments',
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
           connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
         );
 
   final List<FeedPost> store = [];


### PR DESCRIPTION
## Summary
- extend `FeedPost` model for link posts
- support metadata fetching and posting links in `FeedService`
- wire up new fields in binding and controller
- allow URL entry in `ComposePostPage`
- render link previews in `PostCard`
- update unit tests for new constructor params and offline link posting

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684c5dce0c54832d904f27603b978888