### PR TITLE
Add hashtag discovery flow

### DIFF
--- a/lib/features/discovery/models/hashtag.dart
+++ b/lib/features/discovery/models/hashtag.dart
@@ -1,0 +1,30 @@
+class Hashtag {
+  final String id;
+  final String hashtag;
+  final int usageCount;
+  final DateTime? lastUsedAt;
+
+  Hashtag({
+    required this.id,
+    required this.hashtag,
+    this.usageCount = 1,
+    this.lastUsedAt,
+  });
+
+  factory Hashtag.fromJson(Map<String, dynamic> json) {
+    return Hashtag(
+      id: json['\$id'] ?? json['id'],
+      hashtag: json['hashtag'] ?? '',
+      usageCount: json['usage_count'] ?? 1,
+      lastUsedAt: json['last_used_at'] != null
+          ? DateTime.tryParse(json['last_used_at'])
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'hashtag': hashtag,
+        'usage_count': usageCount,
+        'last_used_at': lastUsedAt?.toIso8601String(),
+      };
+}

--- a/lib/features/discovery/screens/hashtag_search_page.dart
+++ b/lib/features/discovery/screens/hashtag_search_page.dart
@@ -1,0 +1,66 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../social_feed/services/feed_service.dart';
+import '../../social_feed/widgets/post_card.dart';
+import '../../social_feed/models/feed_post.dart';
+import '../../../design_system/modern_ui_system.dart';
+
+class HashtagSearchPage extends StatefulWidget {
+  final String hashtag;
+  const HashtagSearchPage({super.key, required this.hashtag});
+
+  @override
+  State<HashtagSearchPage> createState() => _HashtagSearchPageState();
+}
+
+class _HashtagSearchPageState extends State<HashtagSearchPage> {
+  final _posts = <FeedPost>[];
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final service = Get.find<FeedService>();
+    final posts = await service.getPostsByHashtag(widget.hashtag);
+    setState(() {
+      _posts.clear();
+      _posts.addAll(posts);
+      _loading = false;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text('#${widget.hashtag}')),
+      body: _loading
+          ? Padding(
+              padding: EdgeInsets.all(DesignTokens.md(context)),
+              child: Column(
+                children: List.generate(
+                  3,
+                  (_) => Padding(
+                    padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                    child: const SkeletonLoader(height: 80),
+                  ),
+                ),
+              ),
+            )
+          : OptimizedListView(
+              itemCount: _posts.length,
+              padding: EdgeInsets.all(DesignTokens.md(context)),
+              itemBuilder: (context, index) {
+                final post = _posts[index];
+                return Padding(
+                  padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                  child: PostCard(post: post),
+                );
+              },
+            ),
+    );
+  }
+}

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -53,8 +53,10 @@ class FeedController extends GetxController {
     String content,
     String roomId,
     File image,
+    List<String> hashtags,
   ) async {
-    await service.createPostWithImage(userId, username, content, roomId, image);
+    await service.createPostWithImage(
+        userId, username, content, roomId, image, hashtags);
     _posts.insert(
       0,
       FeedPost(
@@ -64,6 +66,7 @@ class FeedController extends GetxController {
         username: username,
         content: content,
         mediaUrls: [image.path],
+        hashtags: hashtags,
       ),
     );
   }
@@ -74,14 +77,16 @@ class FeedController extends GetxController {
     String content,
     String roomId,
     String linkUrl,
-    Map<String, dynamic> metadata,
+    List<String> hashtags,
   ) async {
+    final metadata = await service.fetchLinkMetadata(linkUrl);
     await service.createPostWithLink(
       userId,
       username,
       content,
       roomId,
       linkUrl,
+      hashtags,
     );
     _posts.insert(
       0,
@@ -93,6 +98,7 @@ class FeedController extends GetxController {
         content: content,
         linkUrl: linkUrl,
         linkMetadata: metadata,
+        hashtags: hashtags,
       ),
     );
   }

--- a/lib/features/social_feed/models/feed_post.dart
+++ b/lib/features/social_feed/models/feed_post.dart
@@ -15,6 +15,7 @@ class FeedPost {
   final int commentCount;
   final int repostCount;
   final int shareCount;
+  final List<String> hashtags;
 
   FeedPost({
     required this.id,
@@ -31,6 +32,7 @@ class FeedPost {
     this.commentCount = 0,
     this.repostCount = 0,
     this.shareCount = 0,
+    this.hashtags = const [],
   });
 
   factory FeedPost.fromJson(Map<String, dynamic> json) {
@@ -49,6 +51,7 @@ class FeedPost {
       commentCount: json['comment_count'] ?? 0,
       repostCount: json['repost_count'] ?? 0,
       shareCount: json['share_count'] ?? 0,
+      hashtags: (json['hashtags'] as List?)?.cast<String>() ?? const [],
     );
   }
 
@@ -67,6 +70,7 @@ class FeedPost {
       'comment_count': commentCount,
       'repost_count': repostCount,
       'share_count': shareCount,
+      'hashtags': hashtags,
     };
   }
 

--- a/lib/features/social_feed/screens/compose_post_page.dart
+++ b/lib/features/social_feed/screens/compose_post_page.dart
@@ -80,18 +80,24 @@ class _ComposePostPageState extends State<ComposePostPage> {
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value
                         : 'You';
+                    final tags = RegExp(r'(?:#)([A-Za-z0-9_]+)')
+                        .allMatches(_controller.text)
+                        .map((m) => m.group(1)!.toLowerCase())
+                        .toSet()
+                        .toList();
+                    if (tags.isNotEmpty) {
+                      await feedController.service.saveHashtags(tags);
+                    }
                     final linkText = _linkController.text.trim();
                     if (linkText.isNotEmpty && isURL(linkText) &&
                         linkText.startsWith('http')) {
-                      final meta =
-                          await feedController.service.fetchLinkMetadata(linkText);
                       await feedController.createPostWithLink(
                         uid,
                         uname,
                         _controller.text,
                         widget.roomId,
                         linkText,
-                        meta,
+                        tags,
                       );
                     } else if (_image != null) {
                       await feedController.createPostWithImage(
@@ -100,6 +106,7 @@ class _ComposePostPageState extends State<ComposePostPage> {
                         _controller.text,
                         widget.roomId,
                         File(_image!.path),
+                        tags,
                       );
                     } else {
                       final post = FeedPost(
@@ -108,6 +115,7 @@ class _ComposePostPageState extends State<ComposePostPage> {
                         userId: uid,
                         username: uname,
                         content: _controller.text,
+                        hashtags: tags,
                       );
                       await feedController.createPost(post);
                     }

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -8,10 +8,41 @@ import 'media_gallery.dart';
 import 'reaction_bar.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../widgets/safe_network_image.dart';
+import '../../discovery/screens/hashtag_search_page.dart';
+import 'package:flutter/gestures.dart';
 
 class PostCard extends StatelessWidget {
   final FeedPost post;
   const PostCard({super.key, required this.post});
+
+  Widget _buildContent(BuildContext context) {
+    if (post.hashtags.isEmpty) {
+      return Text(post.content);
+    }
+    final spans = <TextSpan>[];
+    final words = post.content.split(RegExp(r'(\s+)'));
+    for (final word in words) {
+      if (word.startsWith('#')) {
+        final tag = word.substring(1).toLowerCase();
+        spans.add(TextSpan(
+          text: '$word ',
+          style: TextStyle(color: Theme.of(context).colorScheme.primary),
+          recognizer: TapGestureRecognizer()
+            ..onTap = () {
+              Get.to(() => HashtagSearchPage(hashtag: tag));
+            },
+        ));
+      } else {
+        spans.add(TextSpan(text: '$word '));
+      }
+    }
+    return RichText(
+      text: TextSpan(
+        style: Theme.of(context).textTheme.bodyMedium,
+        children: spans,
+      ),
+    );
+  }
 
   void _handleLike(FeedController controller) {
     controller.toggleLikePost(post.id);
@@ -39,7 +70,7 @@ class PostCard extends StatelessWidget {
               style: Theme.of(context).textTheme.titleMedium,
             ),
             SizedBox(height: DesignTokens.sm(context)),
-            Text(post.content),
+            _buildContent(context),
             if (post.mediaUrls.isNotEmpty)
               Padding(
                 padding: EdgeInsets.only(top: DesignTokens.sm(context)),

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -100,12 +100,18 @@ void main() {
   test('createPostWithImage queues when offline', () async {
     final file = File('${dir.path}/img.jpg');
     await file.writeAsBytes(List.filled(10, 0));
-    await service.createPostWithImage('u', 'name', 'hi', 'room', file);
+    await service.createPostWithImage('u', 'name', 'hi', 'room', file, ['tag']);
     final queue = Hive.box('post_queue');
     expect(queue.isNotEmpty, isTrue);
   });
   test('createPostWithLink queues when offline', () async {
-    await service.createPostWithLink('u', 'name', 'hi', 'room', 'https://x.com');
+    await service.createPostWithLink('u', 'name', 'hi', 'room', 'https://x.com', ['tag']);
+    final queue = Hive.box('action_queue');
+    expect(queue.isNotEmpty, isTrue);
+  });
+
+  test('saveHashtags queues when offline', () async {
+    await service.saveHashtags(['tag']);
     final queue = Hive.box('action_queue');
     expect(queue.isNotEmpty, isTrue);
   });


### PR DESCRIPTION
## Summary
- extend `FeedPost` with `hashtags`
- track hashtags and store them with `FeedService`
- capture hashtags while composing posts
- make hashtags tappable and searchable
- create discovery model & page for hashtag search
- update offline service tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c606e6a08832d82979a5ac47f6171