### PR TITLE
Add basic bookmark feature

### DIFF
--- a/lib/bindings/feed_binding.dart
+++ b/lib/bindings/feed_binding.dart
@@ -6,6 +6,7 @@ import 'package:connectivity_plus/connectivity_plus.dart';
 import '../features/social_feed/services/feed_service.dart';
 import '../features/social_feed/controllers/feed_controller.dart';
 import '../features/social_feed/controllers/comments_controller.dart';
+import '../features/bookmarks/controllers/bookmark_controller.dart';
 import 'package:appwrite/appwrite.dart';
 
 class FeedBinding extends Bindings {
@@ -27,11 +28,14 @@ class FeedBinding extends Bindings {
             dotenv.env['POST_LIKES_COLLECTION_ID'] ?? 'post_likes',
         repostsCollectionId:
             dotenv.env['POST_REPOSTS_COLLECTION_ID'] ?? 'post_reposts',
+        bookmarksCollectionId:
+            dotenv.env['BOOKMARKS_COLLECTION_ID'] ?? 'bookmarks',
         connectivity: Get.put(Connectivity()),
         linkMetadataFunctionId:
             dotenv.env['FETCH_LINK_METADATA_FUNCTION_ID'] ?? 'fetch_link_metadata',
       );
       Get.put<FeedController>(FeedController(service: service));
+      Get.put<BookmarkController>(BookmarkController(service: service));
     }
 
     if (!Get.isRegistered<CommentsController>()) {

--- a/lib/features/bookmarks/controllers/bookmark_controller.dart
+++ b/lib/features/bookmarks/controllers/bookmark_controller.dart
@@ -1,0 +1,45 @@
+import 'package:get/get.dart';
+import '../../social_feed/services/feed_service.dart';
+import '../models/bookmark.dart';
+import '../../social_feed/models/feed_post.dart';
+import '../../social_feed/controllers/feed_controller.dart';
+
+class BookmarkController extends GetxController {
+  final FeedService service;
+  BookmarkController({required this.service});
+
+  final bookmarks = <BookmarkedPost>[].obs;
+  final _bookmarkIds = <String, String>{}.obs; // postId -> bookmarkId
+  final isLoading = false.obs;
+
+  Future<void> loadBookmarks(String userId) async {
+    isLoading.value = true;
+    try {
+      final data = await service.listBookmarks(userId);
+      bookmarks.assignAll(data);
+      _bookmarkIds.assignAll({for (final b in data) b.post.id: b.bookmark.id});
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> toggleBookmark(String userId, String postId) async {
+    if (_bookmarkIds.containsKey(postId)) {
+      final id = _bookmarkIds.remove(postId)!;
+      await service.removeBookmark(id);
+      bookmarks.removeWhere((b) => b.post.id == postId);
+    } else {
+      await service.bookmarkPost(userId, postId);
+      final bm = await service.getUserBookmark(postId, userId);
+      final post = Get.find<FeedController>().posts.firstWhereOrNull((p) => p.id == postId);
+      if (bm != null && post != null) {
+        _bookmarkIds[postId] = bm.id;
+        bookmarks.insert(0, BookmarkedPost(bookmark: bm, post: post));
+      } else {
+        _bookmarkIds[postId] = 'offline';
+      }
+    }
+  }
+
+  bool isBookmarked(String postId) => _bookmarkIds.containsKey(postId);
+}

--- a/lib/features/bookmarks/models/bookmark.dart
+++ b/lib/features/bookmarks/models/bookmark.dart
@@ -1,0 +1,51 @@
+import "../../social_feed/models/feed_post.dart";
+
+class Bookmark {
+  final String id;
+  final String postId;
+  final String userId;
+  final DateTime createdAt;
+
+  Bookmark({
+    required this.id,
+    required this.postId,
+    required this.userId,
+    required this.createdAt,
+  });
+
+  factory Bookmark.fromJson(Map<String, dynamic> json) {
+    return Bookmark(
+      id: json['\$id'] ?? json['id'],
+      postId: json['post_id'],
+      userId: json['user_id'],
+      createdAt: DateTime.parse(json['created_at']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'post_id': postId,
+      'user_id': userId,
+      'created_at': createdAt.toIso8601String(),
+    };
+  }
+}
+
+class BookmarkedPost {
+  final Bookmark bookmark;
+  final FeedPost post;
+
+  BookmarkedPost({required this.bookmark, required this.post});
+
+  factory BookmarkedPost.fromMap(Map<String, dynamic> map) {
+    return BookmarkedPost(
+      bookmark: Bookmark.fromJson(Map<String, dynamic>.from(map['bookmark'])),
+      post: FeedPost.fromJson(Map<String, dynamic>.from(map['post'])),
+    );
+  }
+
+  Map<String, dynamic> toMap() => {
+        'bookmark': bookmark.toJson(),
+        'post': post.toJson(),
+      };
+}

--- a/lib/features/bookmarks/screens/bookmark_list_page.dart
+++ b/lib/features/bookmarks/screens/bookmark_list_page.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../design_system/modern_ui_system.dart';
+import '../controllers/bookmark_controller.dart';
+import '../../social_feed/widgets/post_card.dart';
+import '../../../controllers/auth_controller.dart';
+
+class BookmarkListPage extends StatefulWidget {
+  const BookmarkListPage({super.key});
+
+  @override
+  State<BookmarkListPage> createState() => _BookmarkListPageState();
+}
+
+class _BookmarkListPageState extends State<BookmarkListPage> {
+  @override
+  void initState() {
+    super.initState();
+    final userId = Get.find<AuthController>().userId;
+    if (userId != null) {
+      Get.find<BookmarkController>().loadBookmarks(userId);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<BookmarkController>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Bookmarks')),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return Padding(
+            padding: EdgeInsets.all(DesignTokens.md(context)),
+            child: Column(
+              children: List.generate(
+                3,
+                (_) => Padding(
+                  padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                  child: const SkeletonLoader(height: 80),
+                ),
+              ),
+            ),
+          );
+        }
+        return OptimizedListView(
+          itemCount: controller.bookmarks.length,
+          padding: EdgeInsets.all(DesignTokens.md(context)),
+          itemBuilder: (context, index) {
+            final post = controller.bookmarks[index].post;
+            return Padding(
+              padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+              child: PostCard(post: post),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -9,6 +9,8 @@ import 'reaction_bar.dart';
 import 'package:url_launcher/url_launcher.dart';
 import '../../../widgets/safe_network_image.dart';
 import '../../discovery/screens/hashtag_search_page.dart';
+import '../../bookmarks/controllers/bookmark_controller.dart';
+import '../../../controllers/auth_controller.dart';
 import 'package:flutter/gestures.dart';
 
 class PostCard extends StatelessWidget {
@@ -56,9 +58,15 @@ class PostCard extends StatelessWidget {
     controller.repostPost(post.id);
   }
 
+  void _handleBookmark(BookmarkController controller, String userId) {
+    controller.toggleBookmark(userId, post.id);
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = Get.find<FeedController>();
+    final bookmarkController = Get.find<BookmarkController>();
+    final auth = Get.find<AuthController>();
     return Obx(
       () => GlassmorphicCard(
         padding: DesignTokens.md(context).all,
@@ -125,7 +133,9 @@ class PostCard extends StatelessWidget {
               onLike: () => _handleLike(controller),
               onComment: _handleComment,
               onRepost: () => _handleRepost(controller),
+              onBookmark: () => _handleBookmark(bookmarkController, auth.userId ?? ''),
               isLiked: controller.isPostLiked(post.id),
+              isBookmarked: bookmarkController.isBookmarked(post.id),
               likeCount: controller.postLikeCount(post.id),
               commentCount: post.commentCount,
               repostCount: controller.postRepostCount(post.id),

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -5,7 +5,9 @@ class ReactionBar extends StatelessWidget {
   final VoidCallback? onLike;
   final VoidCallback? onComment;
   final VoidCallback? onRepost;
+  final VoidCallback? onBookmark;
   final bool isLiked;
+  final bool isBookmarked;
   final int likeCount;
   final int commentCount;
   final int repostCount;
@@ -14,7 +16,9 @@ class ReactionBar extends StatelessWidget {
     this.onLike,
     this.onComment,
     this.onRepost,
+    this.onBookmark,
     this.isLiked = false,
+    this.isBookmarked = false,
     this.likeCount = 0,
     this.commentCount = 0,
     this.repostCount = 0,
@@ -26,7 +30,7 @@ class ReactionBar extends StatelessWidget {
       required Widget icon,
       required String label,
       required VoidCallback? onTap,
-      required int count,
+      int? count,
     }) {
       return AccessibilityWrapper(
         semanticLabel: label,
@@ -36,8 +40,10 @@ class ReactionBar extends StatelessWidget {
           child: Row(
             children: [
               icon,
-              SizedBox(width: DesignTokens.xs(context)),
-              Text('$count'),
+              if (count != null) ...[
+                SizedBox(width: DesignTokens.xs(context)),
+                Text('$count'),
+              ]
             ],
           ),
         ),
@@ -70,6 +76,17 @@ class ReactionBar extends StatelessWidget {
           label: 'Repost',
           onTap: onRepost,
           count: repostCount,
+        ),
+        SizedBox(width: DesignTokens.sm(context)),
+        buildItem(
+          icon: Icon(
+            isBookmarked ? Icons.bookmark : Icons.bookmark_border,
+            color: isBookmarked
+                ? context.colorScheme.primary
+                : context.theme.iconTheme.color,
+          ),
+          label: isBookmarked ? 'Remove bookmark' : 'Bookmark',
+          onTap: onBookmark,
         ),
       ],
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -16,6 +16,7 @@ import 'pages/chat_rooms_list_page.dart';
 import 'features/social_feed/screens/compose_post_page.dart';
 import 'features/search/screens/search_page.dart';
 import 'features/notifications/screens/notification_page.dart';
+import 'features/bookmarks/screens/bookmark_list_page.dart';
 import 'features/profile/screens/profile_page.dart';
 import 'pages/empty_page.dart';
 import 'pages/splash_screen.dart';
@@ -43,6 +44,7 @@ Future<void> main() async {
   await Hive.openBox('profiles');
   await Hive.openBox('notifications');
   await Hive.openBox('follows');
+  await Hive.openBox('bookmarks');
   await dotenv.load(fileName: '.env');
 
   AuthBinding().dependencies();
@@ -59,6 +61,8 @@ Future<void> main() async {
         dotenv.env['POST_LIKES_COLLECTION_ID'] ?? 'post_likes',
     repostsCollectionId:
         dotenv.env['POST_REPOSTS_COLLECTION_ID'] ?? 'post_reposts',
+    bookmarksCollectionId:
+        dotenv.env['BOOKMARKS_COLLECTION_ID'] ?? 'bookmarks',
     connectivity: Connectivity(),
   );
   Get.put(feedService, permanent: true);
@@ -169,6 +173,11 @@ class MyApp extends StatelessWidget {
               name: '/notifications',
               page: () => const NotificationPage(),
               binding: NotificationBinding(),
+            ),
+            GetPage(
+              name: '/bookmarks',
+              page: () => const BookmarkListPage(),
+              bindings: [AuthBinding(), FeedBinding()],
             ),
             GetPage(
               name: '/user-profile/:userId',

--- a/test/features/bookmarks/bookmark_controller_test.dart
+++ b/test/features/bookmarks/bookmark_controller_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/bookmarks/controllers/bookmark_controller.dart';
+import 'package:myapp/features/bookmarks/models/bookmark.dart';
+import 'package:myapp/features/social_feed/models/feed_post.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+
+class FakeFeedService extends FeedService {
+  FakeFeedService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          bookmarksCollectionId: 'bookmarks',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'link',
+        );
+
+  final List<FeedPost> posts = [];
+  final Map<String, String> bms = {};
+
+  @override
+  Future<List<BookmarkedPost>> listBookmarks(String userId) async {
+    return bms.entries
+        .map(
+          (e) => BookmarkedPost(
+            bookmark: Bookmark(
+                id: e.value,
+                postId: e.key,
+                userId: userId,
+                createdAt: DateTime.now()),
+            post: posts.firstWhere((p) => p.id == e.key),
+          ),
+        )
+        .toList();
+  }
+
+  @override
+  Future<void> bookmarkPost(String userId, String postId) async {
+    bms[postId] = 'b1';
+  }
+
+  @override
+  Future<void> removeBookmark(String bookmarkId) async {
+    bms.removeWhere((key, value) => value == bookmarkId);
+  }
+
+  @override
+  Future<Bookmark?> getUserBookmark(String postId, String userId) async {
+    final id = bms[postId];
+    return id == null
+        ? null
+        : Bookmark(
+            id: id,
+            postId: postId,
+            userId: userId,
+            createdAt: DateTime.now(),
+          );
+  }
+}
+
+void main() {
+  test('toggleBookmark updates map', () async {
+    final service = FakeFeedService();
+    service.posts.add(FeedPost(
+      id: '1',
+      roomId: 'r',
+      userId: 'u',
+      username: 'n',
+      content: 'c',
+    ));
+    final controller = BookmarkController(service: service);
+    await controller.toggleBookmark('u', '1');
+    expect(controller.isBookmarked('1'), isTrue);
+    await controller.toggleBookmark('u', '1');
+    expect(controller.isBookmarked('1'), isFalse);
+  });
+}

--- a/test/features/bookmarks/bookmark_list_page_test.dart
+++ b/test/features/bookmarks/bookmark_list_page_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:myapp/features/bookmarks/controllers/bookmark_controller.dart';
+import 'package:myapp/features/bookmarks/screens/bookmark_list_page.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/bookmarks/models/bookmark.dart';
+
+void main() {
+  testWidgets('renders bookmark list page', (tester) async {
+    Get.put(BookmarkController(service: FakeService()));
+    await tester.pumpWidget(const GetMaterialApp(home: BookmarkListPage()));
+    expect(find.text('Bookmarks'), findsOneWidget);
+  });
+}
+
+class FakeService extends FeedService {
+  FakeService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          bookmarksCollectionId: 'bookmarks',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'link',
+        );
+
+  @override
+  Future<List<BookmarkedPost>> listBookmarks(String userId) async => [];
+}

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -57,6 +57,7 @@ void main() {
     await Hive.openBox('comments');
     await Hive.openBox('action_queue');
     await Hive.openBox('post_queue');
+    await Hive.openBox('bookmarks');
     service = FeedService(
       databases: OfflineDatabases(),
       storage: OfflineStorage(),
@@ -65,6 +66,7 @@ void main() {
       commentsCollectionId: 'comments',
       likesCollectionId: 'likes',
       repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
       connectivity: Connectivity(),
     );
   });
@@ -112,6 +114,12 @@ void main() {
 
   test('saveHashtags queues when offline', () async {
     await service.saveHashtags(['tag']);
+    final queue = Hive.box('action_queue');
+    expect(queue.isNotEmpty, isTrue);
+  });
+
+  test('bookmarkPost queues when offline', () async {
+    await service.bookmarkPost('u', '1');
     final queue = Hive.box('action_queue');
     expect(queue.isNotEmpty, isTrue);
   });


### PR DESCRIPTION
## Summary
- setup Hive box for bookmarks and add route for BookmarkListPage
- create bookmark model, controller, and list page
- support bookmarking in feed service and reaction bar
- expose bookmark button on posts
- add unit and widget tests for bookmark functionality
- expand offline service tests to cover bookmark queueing

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c62df726c832d856664f21d4e7d54