### PR TITLE
Add post editing

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -136,6 +136,38 @@ class FeedController extends GetxController {
     _repostCounts[postId] = (_repostCounts[postId] ?? 0) + 1;
   }
 
+  Future<void> editPost(
+    String postId,
+    String content,
+    List<String> hashtags,
+    List<String> mentions,
+  ) async {
+    await service.editPost(postId, content, hashtags, mentions);
+    final index = _posts.indexWhere((p) => p.id == postId);
+    if (index != -1) {
+      final post = _posts[index];
+      _posts[index] = FeedPost(
+        id: post.id,
+        roomId: post.roomId,
+        userId: post.userId,
+        username: post.username,
+        userAvatar: post.userAvatar,
+        content: content,
+        mediaUrls: post.mediaUrls,
+        pollId: post.pollId,
+        linkUrl: post.linkUrl,
+        linkMetadata: post.linkMetadata,
+        likeCount: post.likeCount,
+        commentCount: post.commentCount,
+        repostCount: post.repostCount,
+        shareCount: post.shareCount,
+        hashtags: hashtags,
+        isEdited: true,
+        editedAt: DateTime.now(),
+      );
+    }
+  }
+
   bool isPostLiked(String postId) => _likedIds.containsKey(postId);
   bool isPostReposted(String postId) => _repostedIds.containsKey(postId);
   int postLikeCount(String postId) => _likeCounts[postId] ?? 0;

--- a/lib/features/social_feed/models/feed_post.dart
+++ b/lib/features/social_feed/models/feed_post.dart
@@ -16,6 +16,8 @@ class FeedPost {
   final int repostCount;
   final int shareCount;
   final List<String> hashtags;
+  final bool isEdited;
+  final DateTime? editedAt;
 
   FeedPost({
     required this.id,
@@ -33,6 +35,8 @@ class FeedPost {
     this.repostCount = 0,
     this.shareCount = 0,
     this.hashtags = const [],
+    this.isEdited = false,
+    this.editedAt,
   });
 
   factory FeedPost.fromJson(Map<String, dynamic> json) {
@@ -52,6 +56,10 @@ class FeedPost {
       repostCount: json['repost_count'] ?? 0,
       shareCount: json['share_count'] ?? 0,
       hashtags: (json['hashtags'] as List?)?.cast<String>() ?? const [],
+      isEdited: json['is_edited'] ?? false,
+      editedAt: json['edited_at'] != null
+          ? DateTime.tryParse(json['edited_at'])
+          : null,
     );
   }
 
@@ -71,6 +79,8 @@ class FeedPost {
       'repost_count': repostCount,
       'share_count': shareCount,
       'hashtags': hashtags,
+      'is_edited': isEdited,
+      'edited_at': editedAt?.toIso8601String(),
     };
   }
 

--- a/lib/features/social_feed/screens/edit_post_page.dart
+++ b/lib/features/social_feed/screens/edit_post_page.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../design_system/modern_ui_system.dart';
+import '../models/feed_post.dart';
+import '../controllers/feed_controller.dart';
+
+class EditPostPage extends StatefulWidget {
+  final FeedPost post;
+  const EditPostPage({super.key, required this.post});
+
+  @override
+  State<EditPostPage> createState() => _EditPostPageState();
+}
+
+class _EditPostPageState extends State<EditPostPage> {
+  late TextEditingController _controller;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: widget.post.content);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final feedController = Get.find<FeedController>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Edit Post')),
+      body: Padding(
+        padding: EdgeInsets.all(DesignTokens.md(context)),
+        child: Column(
+          children: [
+            TextField(
+              controller: _controller,
+              maxLines: 5,
+              decoration: const InputDecoration(hintText: 'Update your post'),
+            ),
+            SizedBox(height: DesignTokens.md(context)),
+            Row(
+              children: [
+                const Spacer(),
+                AnimatedButton(
+                  onPressed: () async {
+                    final tags = RegExp(r'(?:#)([A-Za-z0-9_]+)')
+                        .allMatches(_controller.text)
+                        .map((m) => m.group(1)!.toLowerCase())
+                        .toSet()
+                        .toList();
+                    final mentions = RegExp(r'(?:@)([A-Za-z0-9_]+)')
+                        .allMatches(_controller.text)
+                        .map((m) => m.group(1)!)
+                        .toSet()
+                        .toList();
+                    await feedController.editPost(
+                      widget.post.id,
+                      _controller.text,
+                      tags,
+                      mentions,
+                    );
+                    Get.back();
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -4,6 +4,7 @@ import '../../../design_system/modern_ui_system.dart';
 import '../models/feed_post.dart';
 import '../controllers/feed_controller.dart';
 import '../screens/post_detail_page.dart';
+import '../screens/edit_post_page.dart';
 import 'media_gallery.dart';
 import 'reaction_bar.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -73,9 +74,33 @@ class PostCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            Text(
-              post.username,
-              style: Theme.of(context).textTheme.titleMedium,
+            Row(
+              children: [
+                Text(
+                  post.username,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                if (post.isEdited)
+                  Padding(
+                    padding: EdgeInsets.only(left: DesignTokens.xs(context)),
+                    child: Text(
+                      'Edited',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ),
+                const Spacer(),
+                if (auth.userId == post.userId)
+                  AccessibilityWrapper(
+                    semanticLabel: 'Edit post',
+                    isButton: true,
+                    child: AnimatedButton(
+                      onPressed: () {
+                        Get.to(() => EditPostPage(post: post));
+                      },
+                      child: const Text('Edit'),
+                    ),
+                  ),
+              ],
             ),
             SizedBox(height: DesignTokens.sm(context)),
             _buildContent(context),

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -66,6 +66,32 @@ class FakeFeedService extends FeedService {
         ? null
         : PostRepost(id: id, postId: postId, userId: userId);
   }
+
+  @override
+  Future<void> editPost(
+      String postId, String content, List<String> hashtags, List<String> mentions) async {
+    final index = store.indexWhere((p) => p.id == postId);
+    if (index != -1) {
+      final p = store[index];
+      store[index] = FeedPost(
+        id: p.id,
+        roomId: p.roomId,
+        userId: p.userId,
+        username: p.username,
+        content: content,
+        mediaUrls: p.mediaUrls,
+        pollId: p.pollId,
+        linkUrl: p.linkUrl,
+        linkMetadata: p.linkMetadata,
+        likeCount: p.likeCount,
+        commentCount: p.commentCount,
+        repostCount: p.repostCount,
+        shareCount: p.shareCount,
+        hashtags: hashtags,
+        isEdited: true,
+      );
+    }
+  }
 }
 
 void main() {
@@ -127,5 +153,22 @@ void main() {
     await controller.loadPosts('room');
     await controller.repostPost('1');
     expect(controller.postRepostCount('1'), 1);
+  });
+
+  test('editPost updates content', () async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    final post = FeedPost(
+      id: '1',
+      roomId: 'room',
+      userId: 'u1',
+      username: 'user',
+      content: 'hello',
+    );
+    service.store.add(post);
+    await controller.loadPosts('room');
+    await controller.editPost('1', 'updated', [], []);
+    expect(controller.posts.first.content, 'updated');
+    expect(controller.posts.first.isEdited, isTrue);
   });
 }


### PR DESCRIPTION
## Summary
- add `isEdited` and `editedAt` to `FeedPost`
- implement `editPost` in `FeedService`
- handle editing state in `FeedController`
- add `EditPostPage`
- expose Edit option and show Edited label in `PostCard`
- test feed controller editing logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c65548c04832da99cb12c941287d4