### PR TITLE
Add delete actions for posts and comments

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -74,6 +74,13 @@ class CommentsController extends GetxController {
     }
   }
 
+  Future<void> deleteComment(String commentId) async {
+    await service.deleteComment(commentId);
+    _comments.removeWhere((c) => c.id == commentId);
+    _likedIds.remove(commentId);
+    _likeCounts.remove(commentId);
+  }
+
   bool isCommentLiked(String id) => _likedIds.containsKey(id);
   int commentLikeCount(String id) => _likeCounts[id] ?? 0;
 }

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -168,6 +168,15 @@ class FeedController extends GetxController {
     }
   }
 
+  Future<void> deletePost(String postId) async {
+    await service.deletePost(postId);
+    _posts.removeWhere((p) => p.id == postId);
+    _likedIds.remove(postId);
+    _repostedIds.remove(postId);
+    _likeCounts.remove(postId);
+    _repostCounts.remove(postId);
+  }
+
   bool isPostLiked(String postId) => _likedIds.containsKey(postId);
   bool isPostReposted(String postId) => _repostedIds.containsKey(postId);
   int postLikeCount(String postId) => _likeCounts[postId] ?? 0;

--- a/lib/features/social_feed/models/feed_post.dart
+++ b/lib/features/social_feed/models/feed_post.dart
@@ -17,6 +17,7 @@ class FeedPost {
   final int shareCount;
   final List<String> hashtags;
   final bool isEdited;
+  final bool isDeleted;
   final DateTime? editedAt;
 
   FeedPost({
@@ -36,6 +37,7 @@ class FeedPost {
     this.shareCount = 0,
     this.hashtags = const [],
     this.isEdited = false,
+    this.isDeleted = false,
     this.editedAt,
   });
 
@@ -57,6 +59,7 @@ class FeedPost {
       shareCount: json['share_count'] ?? 0,
       hashtags: (json['hashtags'] as List?)?.cast<String>() ?? const [],
       isEdited: json['is_edited'] ?? false,
+      isDeleted: json['is_deleted'] ?? false,
       editedAt: json['edited_at'] != null
           ? DateTime.tryParse(json['edited_at'])
           : null,
@@ -80,6 +83,7 @@ class FeedPost {
       'share_count': shareCount,
       'hashtags': hashtags,
       'is_edited': isEdited,
+      'is_deleted': isDeleted,
       'edited_at': editedAt?.toIso8601String(),
     };
   }

--- a/lib/features/social_feed/models/post_comment.dart
+++ b/lib/features/social_feed/models/post_comment.dart
@@ -9,6 +9,7 @@ class PostComment {
   final List<String> mediaUrls;
   final int likeCount;
   final int replyCount;
+  final bool isDeleted;
 
   PostComment({
     required this.id,
@@ -21,6 +22,7 @@ class PostComment {
     this.mediaUrls = const [],
     this.likeCount = 0,
     this.replyCount = 0,
+    this.isDeleted = false,
   });
 
   factory PostComment.fromJson(Map<String, dynamic> json) {
@@ -35,6 +37,7 @@ class PostComment {
       mediaUrls: (json['media_urls'] as List?)?.cast<String>() ?? const [],
       likeCount: json['like_count'] ?? 0,
       replyCount: json['reply_count'] ?? 0,
+      isDeleted: json['is_deleted'] ?? false,
     );
   }
 
@@ -49,6 +52,7 @@ class PostComment {
       'media_urls': mediaUrls,
       'like_count': likeCount,
       'reply_count': replyCount,
+      'is_deleted': isDeleted,
     };
   }
 }

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -63,6 +63,28 @@ class PostCard extends StatelessWidget {
     controller.toggleBookmark(userId, post.id);
   }
 
+  Future<void> _handleDelete(FeedController controller) async {
+    final confirm = await Get.dialog<bool>(
+      AlertDialog(
+        title: const Text('Delete Post?'),
+        content: const Text('This action cannot be undone.'),
+        actions: [
+          TextButton(
+            onPressed: () => Get.back(result: false),
+            child: const Text('Cancel'),
+          ),
+          TextButton(
+            onPressed: () => Get.back(result: true),
+            child: const Text('Delete'),
+          ),
+        ],
+      ),
+    );
+    if (confirm == true) {
+      await controller.deletePost(post.id);
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     final controller = Get.find<FeedController>();
@@ -89,7 +111,7 @@ class PostCard extends StatelessWidget {
                     ),
                   ),
                 const Spacer(),
-                if (auth.userId == post.userId)
+                if (auth.userId == post.userId) ...[
                   AccessibilityWrapper(
                     semanticLabel: 'Edit post',
                     isButton: true,
@@ -100,6 +122,16 @@ class PostCard extends StatelessWidget {
                       child: const Text('Edit'),
                     ),
                   ),
+                  SizedBox(width: DesignTokens.xs(context)),
+                  AccessibilityWrapper(
+                    semanticLabel: 'Delete post',
+                    isButton: true,
+                    child: AnimatedButton(
+                      onPressed: () => _handleDelete(controller),
+                      child: const Text('Delete'),
+                    ),
+                  ),
+                ],
               ],
             ),
             SizedBox(height: DesignTokens.sm(context)),


### PR DESCRIPTION
## Summary
- handle soft deletion of posts and comments in `FeedService`
- expose delete helpers in `FeedController` and `CommentsController`
- show Delete buttons for owners in `PostCard` and `CommentCard`
- filter deleted items when loading posts or comments
- extend post and comment models with `isDeleted`

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format -o write ...` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6699d860832d9eb056ded4a43c48