### PR TITLE
Implement repost with comments & undo

### DIFF
--- a/lib/features/social_feed/screens/repost_page.dart
+++ b/lib/features/social_feed/screens/repost_page.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../design_system/modern_ui_system.dart';
+import '../controllers/feed_controller.dart';
+import '../models/feed_post.dart';
+
+class RepostPage extends StatefulWidget {
+  final FeedPost post;
+  const RepostPage({super.key, required this.post});
+
+  @override
+  State<RepostPage> createState() => _RepostPageState();
+}
+
+class _RepostPageState extends State<RepostPage> {
+  final _controller = TextEditingController();
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final feedController = Get.find<FeedController>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Repost')),
+      body: Padding(
+        padding: EdgeInsets.all(DesignTokens.md(context)),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              widget.post.content,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            SizedBox(height: DesignTokens.md(context)),
+            TextField(
+              controller: _controller,
+              maxLines: 3,
+              decoration:
+                  const InputDecoration(hintText: 'Add a comment (optional)'),
+            ),
+            SizedBox(height: DesignTokens.md(context)),
+            Row(
+              children: [
+                const Spacer(),
+                AnimatedButton(
+                  onPressed: () async {
+                    final comment =
+                        _controller.text.trim().isEmpty ? null : _controller.text.trim();
+                    await feedController.repostPost(widget.post.id, comment);
+                    Get.back();
+                  },
+                  child: const Text('Repost'),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -278,21 +278,31 @@ class FeedService {
     }
   }
 
-  Future<void> createRepost(Map<String, dynamic> repost) async {
+  Future<String?> createRepost(Map<String, dynamic> repost) async {
     try {
-      await databases.createDocument(
+      final doc = await databases.createDocument(
         databaseId: databaseId,
         collectionId: repostsCollectionId,
         documentId: ID.unique(),
         data: repost,
       );
+      return doc.$id;
     } catch (_) {
       await queueBox.add({
         'action': 'repost',
         'data': repost,
         '_cachedAt': DateTime.now().toIso8601String(),
       });
+      return null;
     }
+  }
+
+  Future<void> deleteRepost(String repostId) async {
+    await databases.deleteDocument(
+      databaseId: databaseId,
+      collectionId: repostsCollectionId,
+      documentId: repostId,
+    );
   }
 
   Future<void> saveHashtags(List<String> tags) async {

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -5,6 +5,7 @@ import '../models/feed_post.dart';
 import '../controllers/feed_controller.dart';
 import '../screens/post_detail_page.dart';
 import '../screens/edit_post_page.dart';
+import '../screens/repost_page.dart';
 import 'media_gallery.dart';
 import 'reaction_bar.dart';
 import 'package:url_launcher/url_launcher.dart';
@@ -56,7 +57,11 @@ class PostCard extends StatelessWidget {
   }
 
   void _handleRepost(FeedController controller) {
-    controller.repostPost(post.id);
+    if (controller.isPostReposted(post.id)) {
+      controller.undoRepost(post.id);
+    } else {
+      Get.to(() => RepostPage(post: post));
+    }
   }
 
   void _handleBookmark(BookmarkController controller, String userId) {
@@ -96,6 +101,14 @@ class PostCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (controller.isPostReposted(post.id))
+              Padding(
+                padding: EdgeInsets.only(bottom: DesignTokens.xs(context)),
+                child: Text(
+                  'Reposted by you',
+                  style: Theme.of(context).textTheme.labelMedium,
+                ),
+              ),
             Row(
               children: [
                 Text(

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -49,6 +49,29 @@ void main() {
     await tester.pump();
     expect(controller.isPostLiked('1'), isTrue);
   });
+
+  testWidgets('shows repost attribution', (tester) async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    Get.put(controller);
+    final post = FeedPost(
+      id: '1',
+      roomId: 'r1',
+      userId: 'u1',
+      username: 'user',
+      content: 'hello',
+    );
+    service.store.add(post);
+    await controller.loadPosts('r1');
+    await controller.repostPost('1');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PostCard(post: post),
+      ),
+    );
+    await tester.pump();
+    expect(find.text('Reposted by you'), findsOneWidget);
+  });
 }
 
 class FakeFeedService extends FeedService {
@@ -93,7 +116,10 @@ class FakeFeedService extends FeedService {
   }
 
   @override
-  Future<void> createRepost(Map<String, dynamic> repost) async {}
+  Future<String?> createRepost(Map<String, dynamic> repost) async => 'r1';
+
+  @override
+  Future<void> deleteRepost(String repostId) async {}
 
   @override
   Future<PostRepost?> getUserRepost(String postId, String userId) async => null;


### PR DESCRIPTION
## Summary
- support reposting with an optional comment
- add undo repost logic and store repost ids
- show attribution when user reposted a post
- allow entering a comment via new `RepostPage`
- update tests for repost logic and widget display

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c67ebe360832daf9c6f7f845f2a2b