### PR TITLE
Add comment like controls

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -52,14 +52,10 @@ class CommentsController extends GetxController {
     if (uid == null) return;
     if (_likedIds.containsKey(commentId)) {
       final likeId = _likedIds.remove(commentId)!;
-      await service.deleteLike(likeId);
+      await service.unlikeComment(likeId);
       _likeCounts[commentId] = (_likeCounts[commentId] ?? 1) - 1;
     } else {
-      await service.createLike({
-        'item_id': commentId,
-        'item_type': 'comment',
-        'user_id': uid,
-      });
+      await service.likeComment(commentId, uid);
       try {
         final like = await service.getUserLike(commentId, uid);
         if (like != null) {

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -368,6 +368,30 @@ class FeedService {
     );
   }
 
+  Future<void> likeComment(String commentId, String userId) async {
+    await createLike({
+      'item_id': commentId,
+      'item_type': 'comment',
+      'user_id': userId,
+    });
+  }
+
+  Future<void> unlikeComment(String likeId) async {
+    await deleteLike(likeId);
+  }
+
+  Future<void> likeRepost(String repostId, String userId) async {
+    await createLike({
+      'item_id': repostId,
+      'item_type': 'repost',
+      'user_id': userId,
+    });
+  }
+
+  Future<void> unlikeRepost(String likeId) async {
+    await deleteLike(likeId);
+  }
+
   Future<PostRepost?> getUserRepost(String postId, String userId) async {
     final res = await databases.listDocuments(
       databaseId: databaseId,

--- a/lib/features/social_feed/widgets/comment_card.dart
+++ b/lib/features/social_feed/widgets/comment_card.dart
@@ -75,6 +75,7 @@ class CommentCard extends StatelessWidget {
             ReactionBar(
               onLike: handleLike,
               onComment: handleReply,
+              target: ReactionTarget.comment,
               isLiked: controller.isCommentLiked(comment.id),
               likeCount: controller.commentLikeCount(comment.id),
               commentCount: comment.replyCount,

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import '../../../design_system/modern_ui_system.dart';
 
+enum ReactionTarget { post, comment, repost }
+
 class ReactionBar extends StatelessWidget {
   final VoidCallback? onLike;
   final VoidCallback? onComment;
@@ -11,6 +13,7 @@ class ReactionBar extends StatelessWidget {
   final int likeCount;
   final int commentCount;
   final int repostCount;
+  final ReactionTarget target;
   const ReactionBar({
     super.key,
     this.onLike,
@@ -22,6 +25,7 @@ class ReactionBar extends StatelessWidget {
     this.likeCount = 0,
     this.commentCount = 0,
     this.repostCount = 0,
+    this.target = ReactionTarget.post,
   });
 
   @override
@@ -50,34 +54,66 @@ class ReactionBar extends StatelessWidget {
       );
     }
 
-    return Row(
-      children: [
-        buildItem(
-          icon: Icon(
-            isLiked ? Icons.favorite : Icons.favorite_border,
-            color: isLiked
-                ? context.colorScheme.primary
-                : context.theme.iconTheme.color,
-          ),
-          label: isLiked ? 'Unlike post' : 'Like post',
-          onTap: onLike,
-          count: likeCount,
+    String targetName() {
+      switch (target) {
+        case ReactionTarget.comment:
+          return 'comment';
+        case ReactionTarget.repost:
+          return 'repost';
+        case ReactionTarget.post:
+        default:
+          return 'post';
+      }
+    }
+
+    final children = <Widget>[];
+
+    void addItem(Widget item) {
+      if (children.isNotEmpty) {
+        children.add(SizedBox(width: DesignTokens.sm(context)));
+      }
+      children.add(item);
+    }
+
+    addItem(
+      buildItem(
+        icon: Icon(
+          isLiked ? Icons.favorite : Icons.favorite_border,
+          color:
+              isLiked ? context.colorScheme.primary : context.theme.iconTheme.color,
         ),
-        SizedBox(width: DesignTokens.sm(context)),
+        label: isLiked ? 'Unlike ${targetName()}' : 'Like ${targetName()}',
+        onTap: onLike,
+        count: likeCount,
+      ),
+    );
+
+    if (onComment != null || commentCount > 0) {
+      addItem(
         buildItem(
           icon: const Icon(Icons.mode_comment_outlined),
-          label: 'Comment on post',
+          label: target == ReactionTarget.comment
+              ? 'Reply to comment'
+              : 'Comment on ${targetName()}',
           onTap: onComment,
           count: commentCount,
         ),
-        SizedBox(width: DesignTokens.sm(context)),
+      );
+    }
+
+    if ((onRepost != null || repostCount > 0) && target == ReactionTarget.post) {
+      addItem(
         buildItem(
           icon: const Icon(Icons.repeat),
           label: 'Repost',
           onTap: onRepost,
           count: repostCount,
         ),
-        SizedBox(width: DesignTokens.sm(context)),
+      );
+    }
+
+    if (onBookmark != null) {
+      addItem(
         buildItem(
           icon: Icon(
             isBookmarked ? Icons.bookmark : Icons.bookmark_border,
@@ -88,7 +124,9 @@ class ReactionBar extends StatelessWidget {
           label: isBookmarked ? 'Remove bookmark' : 'Bookmark',
           onTap: onBookmark,
         ),
-      ],
-    );
+      );
+    }
+
+    return Row(children: children);
   }
 }

--- a/test/features/social_feed/comment_card_test.dart
+++ b/test/features/social_feed/comment_card_test.dart
@@ -59,6 +59,16 @@ class _FakeService extends FeedService {
   }
 
   @override
+  Future<void> likeComment(String commentId, String userId) async {
+    likes[commentId] = '1';
+  }
+
+  @override
+  Future<void> unlikeComment(String likeId) async {
+    likes.removeWhere((key, value) => value == likeId);
+  }
+
+  @override
   Future<PostLike?> getUserLike(String itemId, String userId) async {
     final id = likes[itemId];
     return id == null

--- a/test/features/social_feed/comments_controller_test.dart
+++ b/test/features/social_feed/comments_controller_test.dart
@@ -39,6 +39,16 @@ class FakeFeedService extends FeedService {
   }
 
   @override
+  Future<void> likeComment(String commentId, String userId) async {
+    likes[commentId] = 'l1';
+  }
+
+  @override
+  Future<void> unlikeComment(String likeId) async {
+    likes.removeWhere((key, value) => value == likeId);
+  }
+
+  @override
   Future<PostLike?> getUserLike(String itemId, String userId) async {
     final id = likes[itemId];
     return id == null


### PR DESCRIPTION
## Summary
- extend `ReactionBar` with item target and conditional actions
- show like/unlike UI on `CommentCard`
- add `likeComment`/`unlikeComment` and repost like helpers to `FeedService`
- update `CommentsController` to use new service methods
- adjust related tests for new service API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c69bd58f4832d9edc66f36b856c12