### PR TITLE
Implement threaded comment display

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -8,6 +8,8 @@ class CommentsController extends GetxController {
 
   CommentsController({required this.service});
 
+  static const int maxDepth = 5;
+
   final _comments = <PostComment>[].obs;
   List<PostComment> get comments => _comments;
 
@@ -79,4 +81,8 @@ class CommentsController extends GetxController {
 
   bool isCommentLiked(String id) => _likedIds.containsKey(id);
   int commentLikeCount(String id) => _likeCounts[id] ?? 0;
+
+  List<PostComment> getReplies(String commentId) {
+    return _comments.where((c) => c.parentId == commentId).toList();
+  }
 }

--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -1,14 +1,14 @@
 import 'package:flutter/material.dart';
 import '../../../design_system/modern_ui_system.dart';
 import 'package:get/get.dart';
-import '../widgets/comment_card.dart';
+import '../widgets/comment_thread.dart';
 import '../models/post_comment.dart';
 import '../controllers/comments_controller.dart';
 import '../../../controllers/auth_controller.dart';
 
 class CommentThreadPage extends StatefulWidget {
-  final List<PostComment> thread;
-  const CommentThreadPage({super.key, required this.thread});
+  final PostComment rootComment;
+  const CommentThreadPage({super.key, required this.rootComment});
 
   @override
   State<CommentThreadPage> createState() => _CommentThreadPageState();
@@ -36,20 +36,9 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
           children: [
             Expanded(
               child: Obx(
-                () {
-                  final root = widget.thread.first;
-                  final items = commentsController.comments
-                      .where((c) => c.id == root.id || c.parentId == root.id)
-                      .toList();
-                  return OptimizedListView(
-                    itemCount: items.length,
-                    itemBuilder: (context, index) => Padding(
-                      padding:
-                          EdgeInsets.only(bottom: DesignTokens.sm(context)),
-                      child: CommentCard(comment: items[index]),
-                    ),
-                  );
-                },
+                () => SingleChildScrollView(
+                  child: CommentThread(comment: widget.rootComment),
+                ),
               ),
             ),
             SizedBox(height: DesignTokens.sm(context)),
@@ -65,7 +54,7 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                 SizedBox(width: DesignTokens.sm(context)),
                 AnimatedButton(
                   onPressed: () {
-                    final root = widget.thread.first;
+                    final root = widget.rootComment;
                     final uid = auth.userId ?? '';
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value

--- a/lib/features/social_feed/widgets/comment_card.dart
+++ b/lib/features/social_feed/widgets/comment_card.dart
@@ -17,10 +17,7 @@ class CommentCard extends StatelessWidget {
     final auth = Get.find<AuthController>();
     void handleLike() => controller.toggleLikeComment(comment.id);
     void handleReply() {
-      final thread = controller.comments
-          .where((c) => c.id == comment.id || c.parentId == comment.id)
-          .toList();
-      Get.to(() => CommentThreadPage(thread: thread));
+      Get.to(() => CommentThreadPage(rootComment: comment));
     }
 
     Future<void> handleDelete() async {

--- a/lib/features/social_feed/widgets/comment_thread.dart
+++ b/lib/features/social_feed/widgets/comment_thread.dart
@@ -1,0 +1,45 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../design_system/modern_ui_system.dart';
+import '../models/post_comment.dart';
+import '../controllers/comments_controller.dart';
+import 'comment_card.dart';
+
+class CommentThread extends StatelessWidget {
+  final PostComment comment;
+  final int depth;
+
+  const CommentThread({
+    super.key,
+    required this.comment,
+    this.depth = 0,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<CommentsController>();
+    final replies = controller.getReplies(comment.id);
+    final canNest = depth < CommentsController.maxDepth;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        CommentCard(comment: comment),
+        if (canNest && replies.isNotEmpty)
+          Padding(
+            padding: EdgeInsets.only(left: DesignTokens.sm(context)),
+            child: Column(
+              children: replies
+                  .map(
+                    (reply) => CommentThread(
+                      comment: reply,
+                      depth: depth + 1,
+                    ),
+                  )
+                  .toList(),
+            ),
+          ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- implement recursive `CommentThread` widget
- add depth constant and `getReplies` helper in `CommentsController`
- update `CommentThreadPage` to use new widget
- open `CommentThreadPage` from comment card

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6b1f1e10832d937a7724324fc712