### PR TITLE
Add user blocking capability

### DIFF
--- a/lib/bindings/profile_binding.dart
+++ b/lib/bindings/profile_binding.dart
@@ -13,6 +13,7 @@ class ProfileBinding extends Bindings {
           databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
           profilesCollection: dotenv.env['USER_PROFILES_COLLECTION_ID'] ?? 'user_profiles',
           followsCollection: 'follows',
+          blocksCollection: 'blocked_users',
         ));
     Get.lazyPut<ProfileController>(() => ProfileController());
   }

--- a/lib/features/profile/controllers/profile_controller.dart
+++ b/lib/features/profile/controllers/profile_controller.dart
@@ -21,4 +21,16 @@ class ProfileController extends GetxController {
     if (uid == null) return;
     await Get.find<ProfileService>().followUser(uid, followedId);
   }
+
+  Future<void> blockUser(String blockedId) async {
+    final uid = Get.find<AuthController>().userId;
+    if (uid == null) return;
+    await Get.find<ProfileService>().blockUser(uid, blockedId);
+  }
+
+  Future<void> unblockUser(String blockedId) async {
+    final uid = Get.find<AuthController>().userId;
+    if (uid == null) return;
+    await Get.find<ProfileService>().unblockUser(uid, blockedId);
+  }
 }

--- a/lib/features/profile/screens/profile_page.dart
+++ b/lib/features/profile/screens/profile_page.dart
@@ -47,6 +47,34 @@ class _UserProfilePageState extends State<UserProfilePage> {
               onPressed: () => controller.followUser(profile.id),
               child: const Text('Follow'),
             ),
+            Padding(
+              padding: const EdgeInsets.only(top: 8),
+              child: AnimatedButton(
+                onPressed: () async {
+                  final confirm = await showDialog<bool>(
+                    context: context,
+                    builder: (context) => AlertDialog(
+                      title: const Text('Block User'),
+                      content: const Text('Are you sure you want to block this user?'),
+                      actions: [
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, false),
+                          child: const Text('Cancel'),
+                        ),
+                        TextButton(
+                          onPressed: () => Navigator.pop(context, true),
+                          child: const Text('Block'),
+                        ),
+                      ],
+                    ),
+                  );
+                  if (confirm == true) {
+                    await controller.blockUser(profile.id);
+                  }
+                },
+                child: const Text('Block'),
+              ),
+            ),
             if (Get.find<AuthController>().userId != null &&
                 Get.find<AuthController>().userId != profile.id)
               Padding(

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -1,6 +1,7 @@
 import 'package:get/get.dart';
 import 'dart:io';
 import '../../../controllers/auth_controller.dart';
+import '../../profile/services/profile_service.dart';
 import '../models/feed_post.dart';
 import '../services/feed_service.dart';
 
@@ -20,10 +21,19 @@ class FeedController extends GetxController {
   final _isLoading = false.obs;
   bool get isLoading => _isLoading.value;
 
-  Future<void> loadPosts(String roomId) async {
+  Future<void> loadPosts(String roomId, {List<String>? blockedIds}) async {
     _isLoading.value = true;
     try {
-      final data = await service.getPosts(roomId);
+      List<String> ids = blockedIds ?? [];
+      if (ids.isEmpty &&
+          Get.isRegistered<AuthController>() &&
+          Get.isRegistered<ProfileService>()) {
+        final uid = Get.find<AuthController>().userId;
+        if (uid != null) {
+          ids = Get.find<ProfileService>().getBlockedIds(uid);
+        }
+      }
+      final data = await service.getPosts(roomId, blockedIds: ids);
       _posts.assignAll(data);
       _likeCounts.assignAll({for (final p in data) p.id: p.likeCount});
       _repostCounts.assignAll({for (final p in data) p.id: p.repostCount});

--- a/lib/features/social_feed/screens/feed_page.dart
+++ b/lib/features/social_feed/screens/feed_page.dart
@@ -4,6 +4,8 @@ import '../../../design_system/modern_ui_system.dart';
 import '../controllers/feed_controller.dart';
 import '../widgets/post_card.dart';
 import 'compose_post_page.dart';
+import '../../../controllers/auth_controller.dart';
+import '../../profile/services/profile_service.dart';
 
 class FeedPage extends StatefulWidget {
   final String roomId;
@@ -20,7 +22,12 @@ class _FeedPageState extends State<FeedPage> {
   void initState() {
     super.initState();
     controller = Get.find<FeedController>();
-    controller.loadPosts(widget.roomId);
+    final auth = Get.find<AuthController>();
+    List<String> blocked = [];
+    if (auth.userId != null && Get.isRegistered<ProfileService>()) {
+      blocked = Get.find<ProfileService>().getBlockedIds(auth.userId!);
+    }
+    controller.loadPosts(widget.roomId, blockedIds: blocked);
   }
 
   @override

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,6 +48,7 @@ Future<void> main() async {
   await Hive.openBox('notifications');
   await Hive.openBox('follows');
   await Hive.openBox('bookmarks');
+  await Hive.openBox('blocks');
   await dotenv.load(fileName: '.env');
 
   AuthBinding().dependencies();

--- a/test/features/profile/profile_controller_test.dart
+++ b/test/features/profile/profile_controller_test.dart
@@ -13,9 +13,11 @@ class FakeProfileService extends ProfileService {
           databaseId: 'db',
           profilesCollection: 'profiles',
           followsCollection: 'follows',
+          blocksCollection: 'blocked_users',
         );
   UserProfile? profile;
   bool followed = false;
+  bool blocked = false;
 
   @override
   Future<UserProfile> fetchProfile(String userId) async {
@@ -25,6 +27,16 @@ class FakeProfileService extends ProfileService {
   @override
   Future<void> followUser(String followerId, String followedId) async {
     followed = true;
+  }
+
+  @override
+  Future<void> blockUser(String blockerId, String blockedId) async {
+    blocked = true;
+  }
+
+  @override
+  Future<void> unblockUser(String blockerId, String blockedId) async {
+    blocked = false;
   }
 }
 

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -27,8 +27,11 @@ class FakeFeedService extends FeedService {
   final Map<String, String> reposts = {}; // repostId by postId
 
   @override
-  Future<List<FeedPost>> getPosts(String roomId) async {
-    return store.where((p) => p.roomId == roomId).toList();
+  Future<List<FeedPost>> getPosts(String roomId,
+      {List<String> blockedIds = const []}) async {
+    return store
+        .where((p) => p.roomId == roomId && !blockedIds.contains(p.userId))
+        .toList();
   }
 
   @override

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -93,8 +93,11 @@ class FakeFeedService extends FeedService {
   final Map<String, String> likes = {};
 
   @override
-  Future<List<FeedPost>> getPosts(String roomId) async {
-    return store.where((e) => e.roomId == roomId).toList();
+  Future<List<FeedPost>> getPosts(String roomId,
+      {List<String> blockedIds = const []}) async {
+    return store
+        .where((e) => e.roomId == roomId && !blockedIds.contains(e.userId))
+        .toList();
   }
 
   @override


### PR DESCRIPTION
## Summary
- maintain a new `blocks` Hive box
- extend `ProfileService` with methods for blocking and unblocking users
- pass blocked IDs to `FeedService` to filter server-side and client-side
- load blocked IDs when retrieving feed
- add a block option on user profiles with a confirmation dialog
- update tests and fakes for new APIs

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c6e24a3a4832da94d321416278456