### PR TITLE
Add post sharing

### DIFF
--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -21,7 +21,6 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../../profile/screens/profile_page.dart';
 import '../../../bindings/profile_binding.dart';
 import '../services/feed_service.dart';
-import 'package:share_plus/share_plus.dart';
 
 class PostCard extends StatelessWidget {
   final FeedPost post;
@@ -101,14 +100,6 @@ class PostCard extends StatelessWidget {
     controller.toggleBookmark(userId, post.id);
   }
 
-  Future<void> _handleShare() async {
-    try {
-      final link = await Get.find<FeedService>().sharePost(post.id);
-      await Share.share('Check out this post: $link');
-    } catch (e) {
-      Get.snackbar('Error', 'Failed to share post');
-    }
-  }
 
   Future<void> _handleDelete(FeedController controller) async {
     final confirm = await Get.dialog<bool>(
@@ -261,7 +252,7 @@ class PostCard extends StatelessWidget {
               onComment: _handleComment,
               onRepost: () => _handleRepost(controller),
               onBookmark: () => _handleBookmark(bookmarkController, auth.userId ?? ''),
-              onShare: _handleShare,
+              postId: post.id,
               isLiked: controller.isPostLiked(post.id),
               isBookmarked: bookmarkController.isBookmarked(post.id),
               likeCount: controller.postLikeCount(post.id),

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -1,5 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import 'package:share_plus/share_plus.dart';
 import '../../../design_system/modern_ui_system.dart';
+import '../services/feed_service.dart';
 
 enum ReactionTarget { post, comment, repost }
 
@@ -9,6 +12,7 @@ class ReactionBar extends StatelessWidget {
   final VoidCallback? onRepost;
   final VoidCallback? onBookmark;
   final VoidCallback? onShare;
+  final String? postId;
   final bool isLiked;
   final bool isBookmarked;
   final int likeCount;
@@ -16,6 +20,7 @@ class ReactionBar extends StatelessWidget {
   final int repostCount;
   final int shareCount;
   final ReactionTarget target;
+
   const ReactionBar({
     super.key,
     this.onLike,
@@ -23,6 +28,7 @@ class ReactionBar extends StatelessWidget {
     this.onRepost,
     this.onBookmark,
     this.onShare,
+    this.postId,
     this.isLiked = false,
     this.isBookmarked = false,
     this.likeCount = 0,
@@ -57,6 +63,16 @@ class ReactionBar extends StatelessWidget {
         ),
       );
     }
+    Future<void> _defaultShare() async {
+      if (postId == null) return;
+      try {
+        final link = await Get.find<FeedService>().sharePost(postId!);
+        await Share.share("Check out this post: " + link);
+      } catch (_) {
+        Get.snackbar("Error", "Failed to share post");
+      }
+    }
+
 
     String targetName() {
       switch (target) {
@@ -116,12 +132,13 @@ class ReactionBar extends StatelessWidget {
       );
     }
 
-    if ((onShare != null || shareCount > 0) && target == ReactionTarget.post) {
+    if ((onShare != null || postId != null || shareCount > 0) &&
+        target == ReactionTarget.post) {
       addItem(
         buildItem(
           icon: const Icon(Icons.share),
           label: 'Share',
-          onTap: onShare,
+          onTap: onShare ?? _defaultShare,
           count: shareCount,
         ),
       );


### PR DESCRIPTION
## Summary
- implement sharing logic in `ReactionBar`
- use `postId` in PostCard to enable default sharing

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c744288dc832da79cf3997bf16eb7