### PR TITLE
Add feed sorting feature

### DIFF
--- a/lib/features/social_feed/screens/feed_page.dart
+++ b/lib/features/social_feed/screens/feed_page.dart
@@ -18,6 +18,39 @@ class FeedPage extends StatefulWidget {
 class _FeedPageState extends State<FeedPage> {
   late FeedController controller;
 
+  Widget _buildSortMenu(BuildContext context) {
+    return Align(
+      alignment: Alignment.centerRight,
+      child: DropdownButton<String>(
+        value: controller.sortType,
+        onChanged: (value) {
+          if (value == null) return;
+          controller.updateSortType(value);
+          final auth = Get.find<AuthController>();
+          List<String> blocked = [];
+          if (auth.userId != null && Get.isRegistered<ProfileService>()) {
+            blocked = Get.find<ProfileService>().getBlockedIds(auth.userId!);
+          }
+          controller.loadPosts(widget.roomId, blockedIds: blocked);
+        },
+        items: const [
+          DropdownMenuItem(
+            value: 'chronological',
+            child: Text('Chronological'),
+          ),
+          DropdownMenuItem(
+            value: 'most-commented',
+            child: Text('Most Commented'),
+          ),
+          DropdownMenuItem(
+            value: 'most-liked',
+            child: Text('Most Liked'),
+          ),
+        ],
+      ),
+    );
+  }
+
   @override
   void initState() {
     super.initState();
@@ -52,16 +85,26 @@ class _FeedPageState extends State<FeedPage> {
             ),
           );
         }
-        return OptimizedListView(
-          itemCount: controller.posts.length,
-          padding: EdgeInsets.all(DesignTokens.md(context)),
-          itemBuilder: (context, index) {
-            final post = controller.posts[index];
-            return Padding(
-              padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
-              child: PostCard(post: post),
-            );
-          },
+        return Column(
+          children: [
+            Padding(
+              padding: EdgeInsets.all(DesignTokens.sm(context)),
+              child: _buildSortMenu(context),
+            ),
+            Expanded(
+              child: OptimizedListView(
+                itemCount: controller.posts.length,
+                padding: EdgeInsets.all(DesignTokens.md(context)),
+                itemBuilder: (context, index) {
+                  final post = controller.posts[index];
+                  return Padding(
+                    padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                    child: PostCard(post: post),
+                  );
+                },
+              ),
+            ),
+          ],
         );
       }),
     );

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -49,6 +49,7 @@ Future<void> main() async {
   await Hive.openBox('follows');
   await Hive.openBox('bookmarks');
   await Hive.openBox('blocks');
+  await Hive.openBox('preferences');
   await dotenv.load(fileName: '.env');
 
   AuthBinding().dependencies();

--- a/test/features/social_feed/offline_comments_controller_test.dart
+++ b/test/features/social_feed/offline_comments_controller_test.dart
@@ -41,6 +41,7 @@ void main() {
     await Hive.openBox('posts');
     await Hive.openBox('comments');
     await Hive.openBox('action_queue');
+    await Hive.openBox('preferences');
     final service = FeedService(
       databases: OfflineDatabases(),
       storage: Storage(Client()),

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -58,6 +58,7 @@ void main() {
     await Hive.openBox('action_queue');
     await Hive.openBox('post_queue');
     await Hive.openBox('bookmarks');
+    await Hive.openBox('preferences');
     service = FeedService(
       databases: OfflineDatabases(),
       storage: OfflineStorage(),


### PR DESCRIPTION
## Summary
- implement `fetchSortedPosts` to query and cache posts by sort algorithm
- allow sorting control in `FeedPage` and persist preference in Hive
- maintain sort selection with `FeedController`
- open new Hive box for preferences
- update tests for Hive preferences box

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c76a7c674832da9688e3658ca0e12