### PR TITLE
Add moderation dashboard

### DIFF
--- a/lib/bindings/moderation_binding.dart
+++ b/lib/bindings/moderation_binding.dart
@@ -1,0 +1,28 @@
+import 'package:get/get.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import '../controllers/auth_controller.dart';
+import '../features/admin/services/moderation_service.dart';
+import '../features/profile/services/activity_service.dart';
+import '../features/admin/controllers/moderation_controller.dart';
+
+class ModerationBinding extends Bindings {
+  @override
+  void dependencies() {
+    final auth = Get.find<AuthController>();
+    Get.lazyPut<ModerationService>(() => ModerationService(
+          databases: auth.databases,
+          databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
+        ));
+    if (!Get.isRegistered<ActivityService>()) {
+      Get.lazyPut<ActivityService>(() => ActivityService(
+            databases: auth.databases,
+            databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
+            collectionId: 'activity_logs',
+          ));
+    }
+    Get.lazyPut<ModerationController>(() => ModerationController(
+          service: Get.find<ModerationService>(),
+          activityService: Get.find<ActivityService>(),
+        ));
+  }
+}

--- a/lib/features/admin/controllers/moderation_controller.dart
+++ b/lib/features/admin/controllers/moderation_controller.dart
@@ -1,0 +1,45 @@
+import 'package:get/get.dart';
+import '../../profile/services/activity_service.dart';
+import '../../../controllers/auth_controller.dart';
+import '../models/report.dart';
+import '../services/moderation_service.dart';
+
+class ModerationController extends GetxController {
+  final ModerationService service;
+  final ActivityService activityService;
+
+  ModerationController({required this.service, required this.activityService});
+
+  final reports = <Report>[].obs;
+  final isLoading = false.obs;
+  final isModerator = false.obs;
+
+  Future<void> loadReports() async {
+    final auth = Get.find<AuthController>();
+    final uid = auth.userId;
+    if (uid == null) return;
+    isLoading.value = true;
+    try {
+      final memberships = await auth.account.getMemberships();
+      isModerator.value = memberships.memberships
+          .any((m) => m.teamId == 'moderators');
+      if (!isModerator.value) return;
+      reports.value = await service.fetchPendingReports();
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> reviewReport(Report report, String action) async {
+    final uid = Get.find<AuthController>().userId;
+    if (uid == null) return;
+    await service.reviewReport(report.id, uid, action);
+    await activityService.logActivity(
+      uid,
+      'review_report',
+      itemId: report.id,
+      itemType: action,
+    );
+    reports.removeWhere((r) => r.id == report.id);
+  }
+}

--- a/lib/features/admin/models/report.dart
+++ b/lib/features/admin/models/report.dart
@@ -1,0 +1,31 @@
+class Report {
+  final String id;
+  final String reporterId;
+  final String? reportedPostId;
+  final String? reportedUserId;
+  final String reportType;
+  final String description;
+  final String status;
+
+  Report({
+    required this.id,
+    required this.reporterId,
+    this.reportedPostId,
+    this.reportedUserId,
+    required this.reportType,
+    required this.description,
+    required this.status,
+  });
+
+  factory Report.fromJson(Map<String, dynamic> json) {
+    return Report(
+      id: json['\$id'] ?? json['id'],
+      reporterId: json['reporter_id'] ?? '',
+      reportedPostId: json['reported_post_id'],
+      reportedUserId: json['reported_user_id'],
+      reportType: json['report_type'] ?? '',
+      description: json['description'] ?? '',
+      status: json['status'] ?? '',
+    );
+  }
+}

--- a/lib/features/admin/screens/moderation_dashboard.dart
+++ b/lib/features/admin/screens/moderation_dashboard.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../design_system/modern_ui_system.dart';
+import '../controllers/moderation_controller.dart';
+import '../models/report.dart';
+
+class ModerationDashboard extends StatefulWidget {
+  const ModerationDashboard({super.key});
+
+  @override
+  State<ModerationDashboard> createState() => _ModerationDashboardState();
+}
+
+class _ModerationDashboardState extends State<ModerationDashboard> {
+  @override
+  void initState() {
+    super.initState();
+    Get.find<ModerationController>().loadReports();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<ModerationController>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Moderation Dashboard')),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return Padding(
+            padding: EdgeInsets.all(DesignTokens.md(context)),
+            child: Column(
+              children: List.generate(
+                3,
+                (_) => Padding(
+                  padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                  child: const SkeletonLoader(height: 80),
+                ),
+              ),
+            ),
+          );
+        }
+        if (!controller.isModerator.value) {
+          return const Center(child: Text('Access denied'));
+        }
+        return OptimizedListView(
+          itemCount: controller.reports.length,
+          padding: EdgeInsets.all(DesignTokens.md(context)),
+          itemBuilder: (context, index) {
+            final report = controller.reports[index];
+            return Padding(
+              padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+              child: _ReportCard(report: report, onAction: controller.reviewReport),
+            );
+          },
+        );
+      }),
+    );
+  }
+}
+
+class _ReportCard extends StatelessWidget {
+  final Report report;
+  final void Function(Report, String) onAction;
+
+  const _ReportCard({required this.report, required this.onAction});
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassmorphicCard(
+      padding: DesignTokens.md(context).all,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Type: ${report.reportType}', style: Theme.of(context).textTheme.titleMedium),
+          SizedBox(height: DesignTokens.xs(context)),
+          Text(report.description),
+          SizedBox(height: DesignTokens.sm(context)),
+          Row(
+            children: [
+              AnimatedButton(
+                onPressed: () => onAction(report, 'dismissed'),
+                child: const Text('Dismiss'),
+              ),
+              SizedBox(width: DesignTokens.sm(context)),
+              AnimatedButton(
+                onPressed: () => onAction(report, 'action_taken'),
+                child: const Text('Take Action'),
+              ),
+            ],
+          )
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/admin/services/moderation_service.dart
+++ b/lib/features/admin/services/moderation_service.dart
@@ -1,0 +1,36 @@
+import 'package:appwrite/appwrite.dart';
+import '../models/report.dart';
+
+class ModerationService {
+  final Databases databases;
+  final String databaseId;
+
+  ModerationService({required this.databases, required this.databaseId});
+
+  Future<List<Report>> fetchPendingReports() async {
+    final result = await databases.listDocuments(
+      databaseId: databaseId,
+      collectionId: 'user_reports',
+      queries: [Query.equal('status', 'pending')],
+    );
+    return result.documents.map((doc) => Report.fromJson(doc.data)).toList();
+  }
+
+  Future<void> reviewReport(
+    String reportId,
+    String moderatorId,
+    String actionTaken,
+  ) async {
+    await databases.updateDocument(
+      databaseId: databaseId,
+      collectionId: 'user_reports',
+      documentId: reportId,
+      data: {
+        'status': 'reviewed',
+        'reviewed_by': moderatorId,
+        'reviewed_at': DateTime.now().toIso8601String(),
+        'action_taken': actionTaken,
+      },
+    );
+  }
+}

--- a/lib/features/profile/services/activity_service.dart
+++ b/lib/features/profile/services/activity_service.dart
@@ -1,0 +1,46 @@
+import 'package:appwrite/appwrite.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+
+class ActivityService {
+  final Databases databases;
+  final String databaseId;
+  final String collectionId;
+  final Box activityBox = Hive.box('activities');
+
+  ActivityService({
+    required this.databases,
+    required this.databaseId,
+    required this.collectionId,
+  });
+
+  Future<void> logActivity(
+    String userId,
+    String actionType, {
+    String? itemId,
+    String? itemType,
+  }) async {
+    try {
+      final doc = await databases.createDocument(
+        databaseId: databaseId,
+        collectionId: collectionId,
+        documentId: ID.unique(),
+        data: {
+          'user_id': userId,
+          'action_type': actionType,
+          'item_id': itemId,
+          'item_type': itemType,
+          'created_at': DateTime.now().toIso8601String(),
+        },
+      );
+      activityBox.put(doc.$id, doc.data);
+    } catch (_) {
+      activityBox.add({
+        'user_id': userId,
+        'action_type': actionType,
+        'item_id': itemId,
+        'item_type': itemType,
+        'created_at': DateTime.now().toIso8601String(),
+      });
+    }
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -20,6 +20,7 @@ import 'features/bookmarks/screens/bookmark_list_page.dart';
 import 'features/profile/screens/profile_page.dart';
 import 'features/reports/screens/report_post_page.dart';
 import 'features/reports/screens/report_user_page.dart';
+import 'features/admin/screens/moderation_dashboard.dart';
 import 'pages/empty_page.dart';
 import 'pages/splash_screen.dart';
 import 'bindings/splash_binding.dart';
@@ -28,6 +29,7 @@ import 'bindings/search_binding.dart';
 import 'bindings/notification_binding.dart';
 import 'bindings/profile_binding.dart';
 import 'bindings/report_binding.dart';
+import 'bindings/moderation_binding.dart';
 import 'design_system/modern_ui_system.dart';
 import 'assets/translations/app_translations.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
@@ -212,6 +214,11 @@ class MyApp extends StatelessWidget {
               name: '/report-user/:userId',
               page: () => ReportUserPage(userId: Get.parameters['userId']!),
               binding: ReportBinding(),
+            ),
+            GetPage(
+              name: '/moderation',
+              page: () => const ModerationDashboard(),
+              binding: ModerationBinding(),
             ),
             GetPage(
               name: '/chat-rooms-list',


### PR DESCRIPTION
## Summary
- add activity logging service
- create admin moderation service, controller, and dashboard
- wire up route and bindings

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c76a97520832d93e9a9348addd142