### PR TITLE
Implement activity logging

### DIFF
--- a/lib/bindings/profile_binding.dart
+++ b/lib/bindings/profile_binding.dart
@@ -4,10 +4,20 @@ import '../controllers/auth_controller.dart';
 import '../features/profile/services/profile_service.dart';
 import '../features/profile/controllers/profile_controller.dart';
 
+import '../features/profile/services/activity_service.dart';
+import '../features/profile/controllers/activity_controller.dart';
 class ProfileBinding extends Bindings {
   @override
   void dependencies() {
     final auth = Get.find<AuthController>();
+    if (!Get.isRegistered<ActivityService>()) {
+      Get.lazyPut<ActivityService>(() => ActivityService(
+            databases: auth.databases,
+            databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
+            collectionId: 'activity_logs',
+          ));
+    }
+    Get.lazyPut<ActivityController>(() => ActivityController(service: Get.find<ActivityService>()));
     Get.lazyPut<ProfileService>(() => ProfileService(
           databases: auth.databases,
           databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',

--- a/lib/features/profile/controllers/activity_controller.dart
+++ b/lib/features/profile/controllers/activity_controller.dart
@@ -1,0 +1,22 @@
+import 'package:get/get.dart';
+import '../models/activity_log.dart';
+import '../services/activity_service.dart';
+
+class ActivityController extends GetxController {
+  final ActivityService service;
+
+  ActivityController({required this.service});
+
+  final logs = <ActivityLog>[].obs;
+  final isLoading = false.obs;
+
+  Future<void> loadActivities(String userId) async {
+    isLoading.value = true;
+    try {
+      final data = await service.fetchActivities(userId);
+      logs.assignAll(data.map(ActivityLog.fromJson));
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}

--- a/lib/features/profile/controllers/profile_controller.dart
+++ b/lib/features/profile/controllers/profile_controller.dart
@@ -3,6 +3,7 @@ import '../models/user_profile.dart';
 import '../services/profile_service.dart';
 import '../../../controllers/auth_controller.dart';
 
+import '../services/activity_service.dart';
 class ProfileController extends GetxController {
   var profile = Rxn<UserProfile>();
   var isLoading = false.obs;
@@ -20,17 +21,20 @@ class ProfileController extends GetxController {
     final uid = Get.find<AuthController>().userId;
     if (uid == null) return;
     await Get.find<ProfileService>().followUser(uid, followedId);
+    await Get.find<ActivityService>().logActivity(uid, 'follow', itemId: followedId, itemType: 'user');
   }
 
   Future<void> blockUser(String blockedId) async {
     final uid = Get.find<AuthController>().userId;
     if (uid == null) return;
     await Get.find<ProfileService>().blockUser(uid, blockedId);
+    await Get.find<ActivityService>().logActivity(uid, 'block_user', itemId: blockedId, itemType: 'user');
   }
 
   Future<void> unblockUser(String blockedId) async {
     final uid = Get.find<AuthController>().userId;
     if (uid == null) return;
     await Get.find<ProfileService>().unblockUser(uid, blockedId);
+    await Get.find<ActivityService>().logActivity(uid, 'unblock_user', itemId: blockedId, itemType: 'user');
   }
 }

--- a/lib/features/profile/models/activity_log.dart
+++ b/lib/features/profile/models/activity_log.dart
@@ -1,0 +1,35 @@
+class ActivityLog {
+  final String id;
+  final String userId;
+  final String actionType;
+  final String? itemId;
+  final String? itemType;
+  final DateTime createdAt;
+
+  ActivityLog({
+    required this.id,
+    required this.userId,
+    required this.actionType,
+    this.itemId,
+    this.itemType,
+    required this.createdAt,
+  });
+
+  factory ActivityLog.fromJson(Map<String, dynamic> json) => ActivityLog(
+        id: json['\$id'] ?? json['id'],
+        userId: json['user_id'],
+        actionType: json['action_type'],
+        itemId: json['item_id'],
+        itemType: json['item_type'],
+        createdAt: DateTime.parse(json['created_at']),
+      );
+
+  Map<String, dynamic> toJson() => {
+        '\$id': id,
+        'user_id': userId,
+        'action_type': actionType,
+        'item_id': itemId,
+        'item_type': itemType,
+        'created_at': createdAt.toIso8601String(),
+      };
+}

--- a/lib/features/profile/screens/activity_log_page.dart
+++ b/lib/features/profile/screens/activity_log_page.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../controllers/auth_controller.dart';
+import '../controllers/activity_controller.dart';
+import '../../../design_system/modern_ui_system.dart';
+
+class ActivityLogPage extends StatefulWidget {
+  const ActivityLogPage({super.key});
+
+  @override
+  State<ActivityLogPage> createState() => _ActivityLogPageState();
+}
+
+class _ActivityLogPageState extends State<ActivityLogPage> {
+  @override
+  void initState() {
+    super.initState();
+    final uid = Get.isRegistered<AuthController>()
+        ? Get.find<AuthController>().userId
+        : null;
+    if (uid != null) {
+      Get.find<ActivityController>().loadActivities(uid);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<ActivityController>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Activity')),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return Padding(
+            padding: EdgeInsets.all(DesignTokens.md(context)),
+            child: Column(
+              children: List.generate(
+                3,
+                (_) => Padding(
+                  padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                  child: const SkeletonLoader(height: 80),
+                ),
+              ),
+            ),
+          );
+        }
+        return OptimizedListView(
+          itemCount: controller.logs.length,
+          padding: EdgeInsets.all(DesignTokens.md(context)),
+          itemBuilder: (context, index) {
+            final log = controller.logs[index];
+            return ListTile(
+              title: Text(log.actionType),
+              subtitle: Text(log.createdAt.toString()),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/features/profile/services/activity_service.dart
+++ b/lib/features/profile/services/activity_service.dart
@@ -43,4 +43,24 @@ class ActivityService {
       });
     }
   }
+
+  Future<List<Map<String, dynamic>>> fetchActivities(String userId) async {
+    try {
+      final res = await databases.listDocuments(
+        databaseId: databaseId,
+        collectionId: collectionId,
+        queries: [
+          Query.equal("user_id", userId),
+          Query.orderDesc("created_at"),
+          Query.limit(50),
+        ],
+      );
+      final logs = res.documents.map((e) => e.data).toList();
+      await activityBox.put("activities_" + userId, logs);
+      return logs.cast<Map<String, dynamic>>();
+    } catch (_) {
+      final cached = activityBox.get("activities_" + userId, defaultValue: []);
+      return (cached as List).cast<Map<String, dynamic>>();
+    }
+  }
 }

--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -1,6 +1,7 @@
 import 'package:get/get.dart';
 import '../../../controllers/auth_controller.dart';
 import '../models/post_comment.dart';
+import "../../profile/services/activity_service.dart";
 import '../services/feed_service.dart';
 
 class CommentsController extends GetxController {
@@ -41,6 +42,7 @@ class CommentsController extends GetxController {
   Future<void> addComment(PostComment comment) async {
     await service.createComment(comment);
     _comments.add(comment);
+    await Get.find<ActivityService>().logActivity(comment.userId, 'reply', itemId: comment.id, itemType: 'comment');
     _likeCounts[comment.id] = comment.likeCount;
   }
 

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -4,6 +4,7 @@ import 'package:hive/hive.dart';
 import '../../../controllers/auth_controller.dart';
 import '../../profile/services/profile_service.dart';
 import '../models/feed_post.dart';
+import "../../profile/services/activity_service.dart";
 import '../services/feed_service.dart';
 
 class FeedController extends GetxController {
@@ -108,6 +109,7 @@ class FeedController extends GetxController {
         mentions: mentions,
       ),
     );
+    await Get.find<ActivityService>().logActivity(userId, 'create_post', itemId: _posts.first.id, itemType: 'post');
   }
 
   Future<void> createPostWithLink(
@@ -143,6 +145,7 @@ class FeedController extends GetxController {
         mentions: mentions,
       ),
     );
+    await Get.find<ActivityService>().logActivity(userId, 'create_post', itemId: _posts.first.id, itemType: 'post');
   }
 
   Future<void> toggleLikePost(String postId) async {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,6 +52,7 @@ Future<void> main() async {
   await Hive.openBox('bookmarks');
   await Hive.openBox('blocks');
   await Hive.openBox('preferences');
+  await Hive.openBox('activities');
   await dotenv.load(fileName: '.env');
 
   AuthBinding().dependencies();


### PR DESCRIPTION
## Summary
- add `ActivityLog` model and `ActivityController`
- extend `ActivityService` with `fetchActivities`
- wire new activity dependencies in `ProfileBinding`
- log user actions for posts, replies and follows
- create `ActivityLogPage`
- open Hive box for activities

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c7c19dfbc832d8db9665aefe56a17