### PR TITLE
Encode link metadata before storing in Appwrite

### DIFF
--- a/lib/features/social_feed/models/feed_post.dart
+++ b/lib/features/social_feed/models/feed_post.dart
@@ -79,7 +79,8 @@ class FeedPost {
       'media_urls': mediaUrls,
       'poll_id': pollId,
       'link_url': linkUrl,
-      'link_metadata': linkMetadata,
+      'link_metadata':
+          linkMetadata != null ? jsonEncode(linkMetadata) : null,
       'like_count': likeCount,
       'comment_count': commentCount,
       'repost_count': repostCount,


### PR DESCRIPTION
## Summary
- store `link_metadata` as a JSON-encoded string

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c87f5cfc4832dafffea1b78ae97af