### PR TITLE
Fix membership and link metadata API usage

### DIFF
--- a/lib/features/admin/controllers/moderation_controller.dart
+++ b/lib/features/admin/controllers/moderation_controller.dart
@@ -20,7 +20,7 @@ class ModerationController extends GetxController {
     if (uid == null) return;
     isLoading.value = true;
     try {
-      final memberships = await auth.account.getMemberships();
+      final memberships = await auth.account.listMemberships();
       isModerator.value = memberships.memberships
           .any((m) => m.teamId == 'moderators');
       if (!isModerator.value) return;

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -173,9 +173,9 @@ class FeedService {
   Future<Map<String, dynamic>> fetchLinkMetadata(String url) async {
     final result = await functions.createExecution(
       functionId: linkMetadataFunctionId,
-      data: jsonEncode({'url': url}),
+      body: jsonEncode({'url': url}),
     );
-    return jsonDecode(result.response) as Map<String, dynamic>;
+    return jsonDecode(result.responseBody) as Map<String, dynamic>;
   }
 
   Future<void> createPostWithLink(


### PR DESCRIPTION
## Summary
- use `listMemberships` instead of deprecated `getMemberships`
- invoke cloud function correctly when fetching link metadata

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8d321eb0832da7783b684ddfb718