### PR TITLE
Fix analyzer stubs for Connectivity in tests

### DIFF
--- a/test/features/bookmarks/bookmark_controller_test.dart
+++ b/test/features/bookmarks/bookmark_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import '../test_utils/fake_connectivity.dart';
 import 'package:myapp/features/bookmarks/controllers/bookmark_controller.dart';
 import 'package:myapp/features/bookmarks/models/bookmark.dart';
 import 'package:myapp/features/social_feed/models/feed_post.dart';
@@ -18,7 +19,7 @@ class FakeFeedService extends FeedService {
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
           bookmarksCollectionId: 'bookmarks',
-          connectivity: Connectivity(),
+          connectivity: FakeConnectivity(),
           linkMetadataFunctionId: 'link',
         );
 

--- a/test/features/bookmarks/bookmark_list_page_test.dart
+++ b/test/features/bookmarks/bookmark_list_page_test.dart
@@ -5,6 +5,7 @@ import 'package:myapp/features/bookmarks/screens/bookmark_list_page.dart';
 import 'package:myapp/features/social_feed/services/feed_service.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import '../test_utils/fake_connectivity.dart';
 import 'package:myapp/features/bookmarks/models/bookmark.dart';
 
 void main() {
@@ -27,7 +28,7 @@ class FakeService extends FeedService {
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
           bookmarksCollectionId: 'bookmarks',
-          connectivity: Connectivity(),
+          connectivity: FakeConnectivity(),
           linkMetadataFunctionId: 'link',
         );
 

--- a/test/features/social_feed/comment_card_test.dart
+++ b/test/features/social_feed/comment_card_test.dart
@@ -7,6 +7,7 @@ import 'package:myapp/features/social_feed/models/post_comment.dart';
 import 'package:myapp/features/social_feed/models/post_like.dart';
 import 'package:myapp/features/social_feed/services/feed_service.dart';
 import 'package:myapp/features/social_feed/widgets/comment_card.dart';
+import '../../test_utils/fake_connectivity.dart';
 
 void main() {
   testWidgets('like comment updates controller', (tester) async {
@@ -42,7 +43,7 @@ class _FakeService extends FeedService {
           commentsCollectionId: 'comments',
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
-          connectivity: Connectivity(),
+          connectivity: FakeConnectivity(),
         );
 
   final List<PostComment> store = [];

--- a/test/features/social_feed/comments_controller_test.dart
+++ b/test/features/social_feed/comments_controller_test.dart
@@ -4,6 +4,7 @@ import 'package:myapp/features/social_feed/models/post_comment.dart';
 import 'package:myapp/features/social_feed/models/post_like.dart';
 import 'package:myapp/features/social_feed/services/feed_service.dart';
 import 'package:appwrite/appwrite.dart';
+import '../../test_utils/fake_connectivity.dart';
 
 class FakeFeedService extends FeedService {
   FakeFeedService()
@@ -16,7 +17,7 @@ class FakeFeedService extends FeedService {
           commentsCollectionId: 'comments',
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
-          connectivity: Connectivity(),
+          connectivity: FakeConnectivity(),
           linkMetadataFunctionId: 'fetch_link_metadata',
         );
 

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import '../../test_utils/fake_connectivity.dart';
 import 'package:myapp/features/social_feed/controllers/feed_controller.dart';
 import 'package:myapp/features/social_feed/models/feed_post.dart';
 import 'package:myapp/features/social_feed/models/post_like.dart';
@@ -18,7 +19,7 @@ class FakeFeedService extends FeedService {
           commentsCollectionId: 'comments',
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
-          connectivity: Connectivity(),
+          connectivity: FakeConnectivity(),
           linkMetadataFunctionId: 'fetch_link_metadata',
         );
 

--- a/test/features/social_feed/offline_comments_controller_test.dart
+++ b/test/features/social_feed/offline_comments_controller_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import '../../test_utils/fake_connectivity.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:appwrite/models.dart';
 import 'package:myapp/features/social_feed/services/feed_service.dart';
@@ -51,7 +52,7 @@ void main() {
       commentsCollectionId: 'comments',
       likesCollectionId: 'likes',
       repostsCollectionId: 'reposts',
-      connectivity: Connectivity(),
+      connectivity: FakeConnectivity(),
       linkMetadataFunctionId: 'fetch_link_metadata',
     );
     controller = CommentsController(service: service);

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import '../../test_utils/fake_connectivity.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:appwrite/models.dart';
 import 'package:myapp/features/social_feed/services/feed_service.dart';
@@ -68,7 +69,7 @@ void main() {
       likesCollectionId: 'likes',
       repostsCollectionId: 'reposts',
       bookmarksCollectionId: 'bookmarks',
-      connectivity: Connectivity(),
+      connectivity: FakeConnectivity(),
     );
   });
 

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -7,6 +7,7 @@ import 'package:myapp/features/social_feed/controllers/feed_controller.dart';
 import 'package:myapp/features/social_feed/services/feed_service.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import '../../test_utils/fake_connectivity.dart';
 import 'package:myapp/features/social_feed/models/post_like.dart';
 import 'package:myapp/features/social_feed/models/post_repost.dart';
 
@@ -85,7 +86,7 @@ class FakeFeedService extends FeedService {
           commentsCollectionId: 'comments',
           likesCollectionId: 'likes',
           repostsCollectionId: 'reposts',
-          connectivity: Connectivity(),
+          connectivity: FakeConnectivity(),
           linkMetadataFunctionId: 'fetch_link_metadata',
         );
 

--- a/test/test_utils/fake_connectivity.dart
+++ b/test/test_utils/fake_connectivity.dart
@@ -1,0 +1,12 @@
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+/// A simple fake for [Connectivity] used in tests.
+class FakeConnectivity extends Connectivity {
+  @override
+  Future<ConnectivityResult> checkConnectivity() async {
+    return ConnectivityResult.wifi;
+  }
+
+  @override
+  Stream<ConnectivityResult> get onConnectivityChanged => const Stream.empty();
+}


### PR DESCRIPTION
## Summary
- add a simple FakeConnectivity class for tests
- use FakeConnectivity in fake services across tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c8d7921f8832dae5f89c86de549f3