### PR TITLE
Fix feed service connectivity callback

### DIFF
--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -42,12 +42,11 @@ class FeedService {
     required this.connectivity,
     required this.linkMetadataFunctionId,
   }) {
-    connectivity.onConnectivityChanged
-        .listen((ConnectivityResult result) async {
+    connectivity.onConnectivityChanged.listen((ConnectivityResult result) async {
       if (result != ConnectivityResult.none) {
         await syncQueuedActions();
       }
-    } as void Function(List<ConnectivityResult> event)?);
+    });
   }
 
   Future<List<FeedPost>> getPosts(String roomId,


### PR DESCRIPTION
## Summary
- ensure FeedService subscribes to connectivity changes without invalid cast

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9e17ad44832dab9fd4b2fd9d7486