### PR TITLE
Fix connectivity listener in feed service

### DIFF
--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -42,9 +42,9 @@ class FeedService {
     required this.connectivity,
     required this.linkMetadataFunctionId,
   }) {
-    connectivity.onConnectivityChanged.listen((ConnectivityResult result) async {
+    connectivity.onConnectivityChanged.listen((ConnectivityResult result) {
       if (result != ConnectivityResult.none) {
-        await syncQueuedActions();
+        syncQueuedActions();
       }
     });
   }


### PR DESCRIPTION
## Summary
- fix connectivity callback in `FeedService`

## Testing
- `flutter analyze` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c9f1556c0832dbe7aabfd3f0342ea