### PR TITLE
Add hashtag tracking on edit

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -205,6 +205,11 @@ class FeedController extends GetxController {
     final index = _posts.indexWhere((p) => p.id == postId);
     if (index != -1) {
       final post = _posts[index];
+      final newTags =
+          hashtags.where((t) => !post.hashtags.contains(t)).toSet().toList();
+      if (newTags.isNotEmpty) {
+        await service.saveHashtags(newTags);
+      }
       _posts[index] = FeedPost(
         id: post.id,
         roomId: post.roomId,


### PR DESCRIPTION
## Summary
- update `FeedController.editPost` to record newly added hashtags
- extend feed controller tests with hashtag tracking logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d48b0a170832d81ac9e4b766e9d66