### PR TITLE
Add connectivity sync for queued notifications

### DIFF
--- a/lib/bindings/notification_binding.dart
+++ b/lib/bindings/notification_binding.dart
@@ -3,17 +3,24 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../controllers/auth_controller.dart';
 import '../features/notifications/services/notification_service.dart';
 import '../features/notifications/controllers/notification_controller.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 
 class NotificationBinding extends Bindings {
   @override
   void dependencies() {
     final auth = Get.find<AuthController>();
-    Get.lazyPut<NotificationService>(() => NotificationService(
+    if (!Get.isRegistered<NotificationService>()) {
+      Get.put<NotificationService>(
+        NotificationService(
           databases: auth.databases,
           databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
           collectionId:
               dotenv.env['NOTIFICATIONS_COLLECTION_ID'] ?? 'notifications',
-        ));
+          connectivity: Get.put(Connectivity()),
+        ),
+        permanent: true,
+      );
+    }
     Get.lazyPut<NotificationController>(() => NotificationController());
   }
 }

--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -2,6 +2,7 @@ import 'package:appwrite/appwrite.dart';
 import 'package:flutter_app_badge/flutter_app_badge.dart';
 import 'package:get/get.dart';
 import 'package:hive_flutter/hive_flutter.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 import '../models/notification_model.dart';
 import '../../../controllers/auth_controller.dart';
 
@@ -9,29 +10,60 @@ class NotificationService {
   final Databases databases;
   final String databaseId;
   final String collectionId;
+  final Connectivity connectivity;
   final Box notificationBox = Hive.box('notifications');
+  final Box queueBox = Hive.box('notification_queue');
 
-  NotificationService({required this.databases, required this.databaseId, required this.collectionId});
+  NotificationService({
+    required this.databases,
+    required this.databaseId,
+    required this.collectionId,
+    required this.connectivity,
+  }) {
+    connectivity.onConnectivityChanged.listen((List<ConnectivityResult> results) {
+      if (results.any((r) => r != ConnectivityResult.none)) {
+        syncQueuedNotifications();
+      }
+    });
+  }
 
-  Future<void> createNotification(String userId, String actorId, String actionType,{String? itemId,String? itemType}) async {
-    final doc = await databases.createDocument(
-      databaseId: databaseId,
-      collectionId: collectionId,
-      documentId: ID.unique(),
-      data: {
+  Future<void> createNotification(
+    String userId,
+    String actorId,
+    String actionType, {
+    String? itemId,
+    String? itemType,
+  }) async {
+    try {
+      final doc = await databases.createDocument(
+        databaseId: databaseId,
+        collectionId: collectionId,
+        documentId: ID.unique(),
+        data: {
+          'user_id': userId,
+          'actor_id': actorId,
+          'action_type': actionType,
+          'item_id': itemId,
+          'item_type': itemType,
+          'is_read': false,
+          'created_at': DateTime.now().toIso8601String(),
+        },
+      );
+      final cached =
+          notificationBox.get('notifications_$userId', defaultValue: []) as List;
+      cached.insert(0, doc.data);
+      await notificationBox.put('notifications_$userId', cached);
+      await _updateCount(userId, cached);
+    } catch (_) {
+      await queueBox.add({
         'user_id': userId,
         'actor_id': actorId,
         'action_type': actionType,
         'item_id': itemId,
         'item_type': itemType,
-        'is_read': false,
-        'created_at': DateTime.now().toIso8601String(),
-      },
-    );
-    final cached = notificationBox.get('notifications_$userId', defaultValue: []) as List;
-    cached.insert(0, doc.data);
-    await notificationBox.put('notifications_$userId', cached);
-    await _updateCount(userId, cached);
+        '_cachedAt': DateTime.now().toIso8601String(),
+      });
+    }
   }
 
   Future<List<NotificationModel>> fetchNotifications(String userId) async {
@@ -66,6 +98,29 @@ class NotificationService {
       cached[index]['is_read'] = true;
       await notificationBox.put('notifications_$userId', cached);
       await _updateCount(userId, cached);
+    }
+  }
+
+  Future<void> syncQueuedNotifications() async {
+    final expiry = DateTime.now().subtract(const Duration(days: 30));
+    final keys = queueBox.keys.toList();
+    for (final key in keys) {
+      final Map item = queueBox.get(key);
+      final ts = DateTime.tryParse(item['_cachedAt'] ?? '');
+      if (ts != null && ts.isBefore(expiry)) {
+        await queueBox.delete(key);
+        continue;
+      }
+      try {
+        await createNotification(
+          item['user_id'] as String,
+          item['actor_id'] as String,
+          item['action_type'] as String,
+          itemId: item['item_id'] as String?,
+          itemType: item['item_type'] as String?,
+        );
+        await queueBox.delete(key);
+      } catch (_) {}
     }
   }
 

--- a/lib/features/social_feed/screens/compose_post_page.dart
+++ b/lib/features/social_feed/screens/compose_post_page.dart
@@ -31,20 +31,22 @@ class _ComposePostPageState extends State<ComposePostPage> {
     final profilesId =
         dotenv.env['USER_PROFILES_COLLECTION_ID'] ?? 'user_profiles';
     for (final name in mentions) {
-      final res = await auth.databases.listDocuments(
-        databaseId: dbId,
-        collectionId: profilesId,
-        queries: [Query.equal('username', name)],
-      );
-      if (res.documents.isNotEmpty) {
-        await Get.find<NotificationService>().createNotification(
-          res.documents.first.data['\$id'],
-          auth.userId ?? '',
-          'mention',
-          itemId: itemId,
-          itemType: 'post',
+      try {
+        final res = await auth.databases.listDocuments(
+          databaseId: dbId,
+          collectionId: profilesId,
+          queries: [Query.equal('username', name)],
         );
-      }
+        if (res.documents.isNotEmpty) {
+          await Get.find<NotificationService>().createNotification(
+            res.documents.first.data['\$id'],
+            auth.userId ?? '',
+            'mention',
+            itemId: itemId,
+            itemType: 'post',
+          );
+        }
+      } catch (_) {}
     }
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -17,6 +17,7 @@ import 'pages/chat_rooms_list_page.dart';
 import 'features/social_feed/screens/compose_post_page.dart';
 import 'features/search/screens/search_page.dart';
 import 'features/notifications/screens/notification_page.dart';
+import 'features/notifications/services/notification_service.dart';
 import 'features/bookmarks/screens/bookmark_list_page.dart';
 import 'features/profile/screens/profile_page.dart';
 import 'features/reports/screens/report_post_page.dart';
@@ -49,6 +50,7 @@ Future<void> main() async {
   await Hive.openBox('post_queue');
   await Hive.openBox('profiles');
   await Hive.openBox('notifications');
+  await Hive.openBox('notification_queue');
   await Hive.openBox('follows');
   await Hive.openBox('bookmarks');
   await Hive.openBox('blocks');
@@ -58,6 +60,7 @@ Future<void> main() async {
 
   AuthBinding().dependencies();
   final auth = Get.find<AuthController>();
+  final connectivity = Connectivity();
   final feedService = FeedService(
     databases: auth.databases,
     storage: auth.storage,
@@ -70,23 +73,28 @@ Future<void> main() async {
     repostsCollectionId:
         dotenv.env['POST_REPOSTS_COLLECTION_ID'] ?? 'post_reposts',
     bookmarksCollectionId: dotenv.env['BOOKMARKS_COLLECTION_ID'] ?? 'bookmarks',
-    connectivity: Connectivity(),
+    connectivity: connectivity,
     linkMetadataFunctionId:
         dotenv.env['FETCH_LINK_METADATA_FUNCTION_ID'] ?? 'fetch_link_metadata',
   );
+  final notificationService = NotificationService(
+    databases: auth.databases,
+    databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
+    collectionId: dotenv.env['NOTIFICATIONS_COLLECTION_ID'] ?? 'notifications',
+    connectivity: connectivity,
+  );
   Get.put(feedService, permanent: true);
-  if (!(await Connectivity()
-          .checkConnectivity())
-      .contains(ConnectivityResult.none)) {
+  Get.put(notificationService, permanent: true);
+  if (!(await connectivity.checkConnectivity()).contains(ConnectivityResult.none)) {
     await feedService.syncQueuedActions();
+    await notificationService.syncQueuedNotifications();
   }
-  Connectivity()
-      .onConnectivityChanged
-      .listen((List<ConnectivityResult> results) async {
-        if (results.any((r) => r != ConnectivityResult.none)) {
-          await feedService.syncQueuedActions();
-        }
-      });
+  connectivity.onConnectivityChanged.listen((List<ConnectivityResult> results) async {
+    if (results.any((r) => r != ConnectivityResult.none)) {
+      await feedService.syncQueuedActions();
+      await notificationService.syncQueuedNotifications();
+    }
+  });
 
   runApp(const MyApp());
 }

--- a/test/features/notifications/offline_notification_service_test.dart
+++ b/test/features/notifications/offline_notification_service_test.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/notifications/services/notification_service.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class OfflineDatabases extends Databases {
+  OfflineDatabases() : super(Client());
+
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+void main() {
+  late Directory dir;
+  late NotificationService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('notifications');
+    await Hive.openBox('notification_queue');
+    service = NotificationService(
+      databases: OfflineDatabases(),
+      databaseId: 'db',
+      collectionId: 'notifications',
+      connectivity: Connectivity(),
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('createNotification queues when offline', () async {
+    await service.createNotification('u', 'a', 'mention');
+    final queue = Hive.box('notification_queue');
+    expect(queue.isNotEmpty, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- keep NotificationService aware of connectivity
- sync queued notifications when network is available
- register NotificationService at startup via NotificationBinding
- extend offline test to pass connectivity instance

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d48013d10832da564637a02d11511