### PR TITLE
Improve hashtag caching

### DIFF
--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -26,6 +26,7 @@ class FeedService {
   final Box postsBox = Hive.box('posts');
   final Box commentsBox = Hive.box('comments');
   final Box bookmarksBox = Hive.box('bookmarks');
+  final Box hashtagsBox = Hive.box('hashtags');
   final Box queueBox = Hive.box('action_queue');
   final Box postQueueBox = Hive.box('post_queue');
 
@@ -317,7 +318,8 @@ class FeedService {
   }
 
   Future<void> saveHashtags(List<String> tags) async {
-    for (final tag in tags) {
+    final uniqueTags = <String>{for (final t in tags) t.toLowerCase()};
+    for (final tag in uniqueTags) {
       try {
         final existing = await databases.listDocuments(
           databaseId: databaseId,
@@ -348,7 +350,15 @@ class FeedService {
             },
           );
         }
+        await hashtagsBox.put(tag, {
+          'hashtag': tag,
+          'last_used_at': DateTime.now().toIso8601String(),
+        });
       } catch (_) {
+        await hashtagsBox.put(tag, {
+          'hashtag': tag,
+          'last_used_at': DateTime.now().toIso8601String(),
+        });
         await queueBox.add({
           'action': 'hashtag',
           'data': tag,
@@ -510,7 +520,12 @@ class FeedService {
             );
             break;
           case 'hashtag':
-            await saveHashtags([item['data'] as String]);
+            final tag = (item['data'] as String).toLowerCase();
+            await saveHashtags([tag]);
+            await hashtagsBox.put(tag, {
+              'hashtag': tag,
+              'last_used_at': DateTime.now().toIso8601String(),
+            });
             break;
           case 'follow':
             await createFollow(Map<String, dynamic>.from(item['data']));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,6 +51,7 @@ Future<void> main() async {
   await Hive.openBox('notifications');
   await Hive.openBox('follows');
   await Hive.openBox('bookmarks');
+  await Hive.openBox('hashtags');
   await Hive.openBox('blocks');
   await Hive.openBox('preferences');
   await Hive.openBox('activities');

--- a/test/features/social_feed/hashtag_cache_test.dart
+++ b/test/features/social_feed/hashtag_cache_test.dart
@@ -1,0 +1,79 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:appwrite/models.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+
+class MemoryDatabases extends Databases {
+  MemoryDatabases() : super(Client());
+
+  @override
+  Future<DocumentList> listDocuments({
+    required String databaseId,
+    required String collectionId,
+    List<String>? queries,
+  }) async {
+    return DocumentList(total: 0, documents: []);
+  }
+
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) async {
+    return Document(
+      \$id: documentId,
+      \$collectionId: collectionId,
+      \$databaseId: databaseId,
+      \$createdAt: DateTime.now().toIso8601String(),
+      \$updatedAt: DateTime.now().toIso8601String(),
+      \$permissions: permissions ?? [],
+      data: data,
+    );
+  }
+}
+
+void main() {
+  late Directory dir;
+  late FeedService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('hashtags');
+    await Hive.openBox('action_queue');
+    service = FeedService(
+      databases: MemoryDatabases(),
+      storage: Storage(Client()),
+      functions: Functions(Client()),
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'fetch_link_metadata',
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('saveHashtags caches tag when online', () async {
+    await service.saveHashtags(['flutter']);
+    final box = Hive.box('hashtags');
+    final cached = box.get('flutter') as Map?;
+    expect(cached?['hashtag'], 'flutter');
+    expect(cached?['last_used_at'], isNotNull);
+    expect(Hive.box('action_queue').isEmpty, isTrue);
+  });
+}
+

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -57,6 +57,7 @@ void main() {
     await Hive.openBox('action_queue');
     await Hive.openBox('post_queue');
     await Hive.openBox('bookmarks');
+    await Hive.openBox('hashtags');
     await Hive.openBox('preferences');
     service = FeedService(
       databases: OfflineDatabases(),
@@ -116,10 +117,14 @@ void main() {
     expect(queue.isNotEmpty, isTrue);
   });
 
-  test('saveHashtags queues when offline', () async {
+  test('saveHashtags caches and queues when offline', () async {
     await service.saveHashtags(['tag']);
     final queue = Hive.box('action_queue');
+    final box = Hive.box('hashtags');
     expect(queue.isNotEmpty, isTrue);
+    final cached = box.get('tag') as Map?;
+    expect(cached?['hashtag'], 'tag');
+    expect(cached?['last_used_at'], isNotNull);
   });
 
   test('bookmarkPost queues when offline', () async {


### PR DESCRIPTION
## Summary
- cache hashtags locally and update on sync
- deduplicate tags before saving
- keep hashtags box open at startup
- extend offline tests to check caching
- add online hashtag caching test

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4845da3c832d8f2470e3f5bdb89b