### PR TITLE
Merge PRs 261,263,264

### DIFF
--- a/lib/bindings/notification_binding.dart
+++ b/lib/bindings/notification_binding.dart
@@ -3,17 +3,24 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../controllers/auth_controller.dart';
 import '../features/notifications/services/notification_service.dart';
 import '../features/notifications/controllers/notification_controller.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 
 class NotificationBinding extends Bindings {
   @override
   void dependencies() {
     final auth = Get.find<AuthController>();
-    Get.lazyPut<NotificationService>(() => NotificationService(
+    if (!Get.isRegistered<NotificationService>()) {
+      Get.put<NotificationService>(
+        NotificationService(
           databases: auth.databases,
           databaseId: dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB',
           collectionId:
               dotenv.env['NOTIFICATIONS_COLLECTION_ID'] ?? 'notifications',
-        ));
+          connectivity: Get.put(Connectivity()),
+        ),
+        permanent: true,
+      );
+    }
     Get.lazyPut<NotificationController>(() => NotificationController());
   }
 }

--- a/lib/features/notifications/services/notification_service.dart
+++ b/lib/features/notifications/services/notification_service.dart
@@ -4,34 +4,66 @@ import 'package:get/get.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import '../models/notification_model.dart';
 import '../../../controllers/auth_controller.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
 
 class NotificationService {
   final Databases databases;
   final String databaseId;
   final String collectionId;
+  final Connectivity connectivity;
   final Box notificationBox = Hive.box('notifications');
+  final Box queueBox = Hive.box('notification_queue');
 
-  NotificationService({required this.databases, required this.databaseId, required this.collectionId});
+  NotificationService({
+    required this.databases,
+    required this.databaseId,
+    required this.collectionId,
+    required this.connectivity,
+  }) {
+    connectivity.onConnectivityChanged.listen((List<ConnectivityResult> results) {
+      if (results.any((r) => r != ConnectivityResult.none)) {
+        syncQueuedNotifications();
+      }
+    });
+  }
 
-  Future<void> createNotification(String userId, String actorId, String actionType,{String? itemId,String? itemType}) async {
-    final doc = await databases.createDocument(
-      databaseId: databaseId,
-      collectionId: collectionId,
-      documentId: ID.unique(),
-      data: {
+  Future<void> createNotification(
+    String userId,
+    String actorId,
+    String actionType, {
+    String? itemId,
+    String? itemType,
+  }) async {
+    try {
+      final doc = await databases.createDocument(
+        databaseId: databaseId,
+        collectionId: collectionId,
+        documentId: ID.unique(),
+        data: {
+          'user_id': userId,
+          'actor_id': actorId,
+          'action_type': actionType,
+          'item_id': itemId,
+          'item_type': itemType,
+          'is_read': false,
+          'created_at': DateTime.now().toIso8601String(),
+        },
+      );
+      final cached =
+          notificationBox.get('notifications_$userId', defaultValue: []) as List;
+      cached.insert(0, doc.data);
+      await notificationBox.put('notifications_$userId', cached);
+      await _updateCount(userId, cached);
+    } catch (_) {
+      await queueBox.add({
         'user_id': userId,
         'actor_id': actorId,
         'action_type': actionType,
         'item_id': itemId,
         'item_type': itemType,
-        'is_read': false,
-        'created_at': DateTime.now().toIso8601String(),
-      },
-    );
-    final cached = notificationBox.get('notifications_$userId', defaultValue: []) as List;
-    cached.insert(0, doc.data);
-    await notificationBox.put('notifications_$userId', cached);
-    await _updateCount(userId, cached);
+        '_cachedAt': DateTime.now().toIso8601String(),
+      });
+    }
   }
 
   Future<List<NotificationModel>> fetchNotifications(String userId) async {
@@ -48,6 +80,29 @@ class NotificationService {
     } catch (_) {
       final cached = notificationBox.get('notifications_$userId', defaultValue: []);
       return (cached as List).map((e) => NotificationModel.fromJson(e)).toList();
+    }
+  }
+
+  Future<void> syncQueuedNotifications() async {
+    final expiry = DateTime.now().subtract(const Duration(days: 30));
+    final keys = queueBox.keys.toList();
+    for (final key in keys) {
+      final Map item = queueBox.get(key);
+      final ts = DateTime.tryParse(item['_cachedAt'] ?? '');
+      if (ts != null && ts.isBefore(expiry)) {
+        await queueBox.delete(key);
+        continue;
+      }
+      try {
+        await createNotification(
+          item['user_id'] as String,
+          item['actor_id'] as String,
+          item['action_type'] as String,
+          itemId: item['item_id'] as String?,
+          itemType: item['item_type'] as String?,
+        );
+        await queueBox.delete(key);
+      } catch (_) {}
     }
   }
 

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -41,6 +41,9 @@ class FeedController extends GetxController {
   final _isLoading = false.obs;
   bool get isLoading => _isLoading.value;
 
+  List<String> _limitHashtags(List<String> tags) =>
+      tags.length > 10 ? tags.sublist(0, 10) : tags;
+
   Future<void> loadPosts(String roomId, {List<String>? blockedIds}) async {
     _isLoading.value = true;
     try {
@@ -74,8 +77,32 @@ class FeedController extends GetxController {
   }
 
   Future<void> createPost(FeedPost post) async {
-    await service.createPost(post);
-    _posts.insert(0, post);
+    final limited = _limitHashtags(post.hashtags);
+    final toSave = limited.length == post.hashtags.length
+        ? post
+        : FeedPost(
+            id: post.id,
+            roomId: post.roomId,
+            userId: post.userId,
+            username: post.username,
+            userAvatar: post.userAvatar,
+            content: post.content,
+            mediaUrls: post.mediaUrls,
+            pollId: post.pollId,
+            linkUrl: post.linkUrl,
+            linkMetadata: post.linkMetadata,
+            likeCount: post.likeCount,
+            commentCount: post.commentCount,
+            repostCount: post.repostCount,
+            shareCount: post.shareCount,
+            hashtags: limited,
+            mentions: post.mentions,
+            isEdited: post.isEdited,
+            isDeleted: post.isDeleted,
+            editedAt: post.editedAt,
+          );
+    await service.createPost(toSave);
+    _posts.insert(0, toSave);
   }
 
   Future<void> createPostWithImage(
@@ -87,13 +114,14 @@ class FeedController extends GetxController {
     List<String> hashtags,
     List<String> mentions,
   ) async {
+    final limited = _limitHashtags(hashtags);
     await service.createPostWithImage(
       userId,
       username,
       content,
       roomId,
       image,
-      hashtags: hashtags,
+      hashtags: limited,
       mentions: mentions,
     );
     _posts.insert(
@@ -105,7 +133,7 @@ class FeedController extends GetxController {
         username: username,
         content: content,
         mediaUrls: [image.path],
-        hashtags: hashtags,
+        hashtags: limited,
         mentions: mentions,
       ),
     );
@@ -122,13 +150,14 @@ class FeedController extends GetxController {
     List<String> mentions,
   ) async {
     final metadata = await service.fetchLinkMetadata(linkUrl);
+    final limited = _limitHashtags(hashtags);
     await service.createPostWithLink(
       userId,
       username,
       content,
       roomId,
       linkUrl,
-      hashtags: hashtags,
+      hashtags: limited,
       mentions: mentions,
     );
     _posts.insert(
@@ -141,7 +170,7 @@ class FeedController extends GetxController {
         content: content,
         linkUrl: linkUrl,
         linkMetadata: metadata,
-        hashtags: hashtags,
+        hashtags: limited,
         mentions: mentions,
       ),
     );
@@ -201,12 +230,13 @@ class FeedController extends GetxController {
     List<String> hashtags,
     List<String> mentions,
   ) async {
-    await service.editPost(postId, content, hashtags, mentions);
+    final limited = _limitHashtags(hashtags);
+    await service.editPost(postId, content, limited, mentions);
     final index = _posts.indexWhere((p) => p.id == postId);
     if (index != -1) {
       final post = _posts[index];
       final newTags =
-          hashtags.where((t) => !post.hashtags.contains(t)).toSet().toList();
+          limited.where((t) => !post.hashtags.contains(t)).toSet().toList();
       if (newTags.isNotEmpty) {
         await service.saveHashtags(newTags);
       }
@@ -225,7 +255,7 @@ class FeedController extends GetxController {
         commentCount: post.commentCount,
         repostCount: post.repostCount,
         shareCount: post.shareCount,
-        hashtags: hashtags,
+        hashtags: limited,
         mentions: mentions,
         isEdited: true,
         editedAt: DateTime.now(),

--- a/test/features/notifications/offline_notification_service_test.dart
+++ b/test/features/notifications/offline_notification_service_test.dart
@@ -1,0 +1,50 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/notifications/services/notification_service.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+class OfflineDatabases extends Databases {
+  OfflineDatabases() : super(Client());
+
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+void main() {
+  late Directory dir;
+  late NotificationService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('notifications');
+    await Hive.openBox('notification_queue');
+    service = NotificationService(
+      databases: OfflineDatabases(),
+      databaseId: 'db',
+      collectionId: 'notifications',
+      connectivity: Connectivity(),
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('createNotification queues when offline', () async {
+    await service.createNotification('u', 'a', 'mention');
+    final queue = Hive.box('notification_queue');
+    expect(queue.isNotEmpty, isTrue);
+  });
+}

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -231,4 +231,50 @@ void main() {
     expect(service.hashtagCounts['new'], 1);
     expect(service.hashtagCounts.containsKey('old'), isFalse);
   });
+  test('createPost trims hashtags to 10', () async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    final tags = List.generate(15, (i) => 'tag\$i');
+    final post = FeedPost(
+      id: '2',
+      roomId: 'room',
+      userId: 'u2',
+      username: 'name',
+      content: 'post',
+      hashtags: tags,
+    );
+    await controller.createPost(post);
+    expect(service.store.first.hashtags.length, 10);
+    expect(controller.posts.first.hashtags.length, 10);
+  });
+
+  test('createPostWithImage trims hashtags', () async {
+    final dir = await Directory.systemTemp.createTemp();
+    final file = File('${dir.path}/img.jpg');
+    await file.writeAsBytes(List.filled(10, 0));
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    final tags = List.generate(12, (i) => 't\$i');
+    await controller.createPostWithImage('u', 'user', 'c', 'room', file, tags, []);
+    expect(service.store.first.hashtags.length, 10);
+    expect(controller.posts.first.hashtags.length, 10);
+    await dir.delete(recursive: true);
+  });
+
+  test('createPostWithLink trims hashtags', () async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    final tags = List.generate(11, (i) => 'x\$i');
+    await controller.createPostWithLink(
+      'u',
+      'user',
+      'c',
+      'room',
+      'https://x.com',
+      tags,
+      [],
+    );
+    expect(service.store.first.hashtags.length, 10);
+    expect(controller.posts.first.hashtags.length, 10);
+  });
 }

--- a/test/features/social_feed/hashtag_cache_test.dart
+++ b/test/features/social_feed/hashtag_cache_test.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:appwrite/models.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+
+class MemoryDatabases extends Databases {
+  MemoryDatabases() : super(Client());
+
+  @override
+  Future<DocumentList> listDocuments({
+    required String databaseId,
+    required String collectionId,
+    List<String>? queries,
+  }) async {
+    return DocumentList(total: 0, documents: []);
+  }
+
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) async {
+    return Document(
+      \$id: documentId,
+      \$collectionId: collectionId,
+      \$databaseId: databaseId,
+      \$createdAt: DateTime.now().toIso8601String(),
+      \$updatedAt: DateTime.now().toIso8601String(),
+      \$permissions: permissions ?? [],
+      data: data,
+    );
+  }
+}
+
+void main() {
+  late Directory dir;
+  late FeedService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('hashtags');
+    await Hive.openBox('action_queue');
+    service = FeedService(
+      databases: MemoryDatabases(),
+      storage: Storage(Client()),
+      functions: Functions(Client()),
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'fetch_link_metadata',
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('saveHashtags caches tag when online', () async {
+    await service.saveHashtags(['flutter']);
+    final box = Hive.box('hashtags');
+    final cached = box.get('flutter') as Map?;
+    expect(cached?['hashtag'], 'flutter');
+    expect(cached?['last_used_at'], isNotNull);
+    expect(Hive.box('action_queue').isEmpty, isTrue);
+  });
+}

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -57,6 +57,7 @@ void main() {
     await Hive.openBox('action_queue');
     await Hive.openBox('post_queue');
     await Hive.openBox('bookmarks');
+    await Hive.openBox('hashtags');
     await Hive.openBox('preferences');
     service = FeedService(
       databases: OfflineDatabases(),
@@ -116,10 +117,14 @@ void main() {
     expect(queue.isNotEmpty, isTrue);
   });
 
-  test('saveHashtags queues when offline', () async {
+  test('saveHashtags caches and queues when offline', () async {
     await service.saveHashtags(['tag']);
     final queue = Hive.box('action_queue');
+    final box = Hive.box('hashtags');
     expect(queue.isNotEmpty, isTrue);
+    final cached = box.get('tag') as Map?;
+    expect(cached?['hashtag'], 'tag');
+    expect(cached?['last_used_at'], isNotNull);
   });
 
   test('bookmarkPost queues when offline', () async {


### PR DESCRIPTION
## Summary
- enforce hashtag limit when creating or editing posts
- queue notifications offline and sync later
- persist hashtags locally and sync when online
- wire notification service in app startup
- add unit tests for hashtag caching and offline notifications

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4c794eec832d98b0ec42e635b57e