### PR TITLE
Replace ElevatedButton with AnimatedButton

### DIFF
--- a/lib/features/profile/screens/profile_page.dart
+++ b/lib/features/profile/screens/profile_page.dart
@@ -43,8 +43,14 @@ class _UserProfilePageState extends State<UserProfilePage> {
               child: Text(profile.bio!),
             ),
             const SizedBox(height: 16),
-            ElevatedButton(
+            AnimatedButton(
               onPressed: () => controller.followUser(profile.id),
+              style: FilledButton.styleFrom(
+                padding: EdgeInsets.symmetric(
+                  horizontal: DesignTokens.md(context),
+                  vertical: DesignTokens.sm(context),
+                ),
+              ),
               child: const Text('Follow'),
             ),
             Padding(

--- a/lib/pages/profile_page.dart
+++ b/lib/pages/profile_page.dart
@@ -8,6 +8,7 @@ import 'package:image_cropper/image_cropper.dart';
 import '../controllers/auth_controller.dart';
 import '../widgets/safe_network_image.dart';
 import '../controllers/user_type_controller.dart';
+import '../design_system/modern_ui_system.dart';
 
 class ProfilePage extends GetView<AuthController> {
   const ProfilePage({super.key});
@@ -57,13 +58,25 @@ class ProfilePage extends GetView<AuthController> {
                 style: const TextStyle(fontSize: 20),
               ),
               const SizedBox(height: 16),
-              ElevatedButton(
+              AnimatedButton(
                 onPressed: () => Get.toNamed('/set_username'),
+                style: FilledButton.styleFrom(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: DesignTokens.md(context),
+                    vertical: DesignTokens.sm(context),
+                  ),
+                ),
                 child: Text('change_username'.tr),
               ),
               const SizedBox(height: 8),
-              ElevatedButton(
+              AnimatedButton(
                 onPressed: _changePicture,
+                style: FilledButton.styleFrom(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: DesignTokens.md(context),
+                    vertical: DesignTokens.sm(context),
+                  ),
+                ),
                 child: Text('change_picture'.tr),
               ),
               const SizedBox(height: 16),

--- a/lib/pages/set_username_page.dart
+++ b/lib/pages/set_username_page.dart
@@ -134,12 +134,18 @@ class SetUsernamePage extends GetView<AuthController> {
                 SizedBox(height: DesignTokens.spacing(context, 20)),
                 SizedBox(
                   width: double.infinity,
-                  child: Obx(() => ElevatedButton(
+                  child: Obx(() => AnimatedButton(
                         onPressed: controller.isLoading.value ||
                                 !controller.isUsernameValid.value ||
                                 !controller.usernameAvailable.value
                             ? null
                             : controller.submitUsername,
+                        style: FilledButton.styleFrom(
+                          padding: EdgeInsets.symmetric(
+                            horizontal: DesignTokens.md(context),
+                            vertical: DesignTokens.sm(context),
+                          ),
+                        ),
                         child: controller.isLoading.value
                             ? const CircularProgressIndicator()
                             : Text('save'.tr),

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -3,6 +3,7 @@ import 'package:get/get.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import '../controllers/auth_controller.dart';
 import '../controllers/theme_controller.dart';
+import '../design_system/modern_ui_system.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -62,8 +63,14 @@ class _SettingsPageState extends State<SettingsPage> {
                       onPressed: () => Navigator.pop(context, false),
                       child: Text('cancel'.tr),
                     ),
-                    ElevatedButton(
+                    AnimatedButton(
                       onPressed: () => Navigator.pop(context, true),
+                      style: FilledButton.styleFrom(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: DesignTokens.md(context),
+                          vertical: DesignTokens.sm(context),
+                        ),
+                      ),
                       child: Text('delete'.tr),
                     )
                   ],
@@ -88,8 +95,14 @@ class _SettingsPageState extends State<SettingsPage> {
                       onPressed: () => Navigator.pop(context, false),
                       child: Text('cancel'.tr),
                     ),
-                    ElevatedButton(
+                    AnimatedButton(
                       onPressed: () => Navigator.pop(context, true),
+                      style: FilledButton.styleFrom(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: DesignTokens.md(context),
+                          vertical: DesignTokens.sm(context),
+                        ),
+                      ),
                       child: Text('logout'.tr),
                     )
                   ],

--- a/lib/pages/sign_in_page.dart
+++ b/lib/pages/sign_in_page.dart
@@ -80,9 +80,15 @@ class _SignInPageState extends State<SignInPage> {
         SizedBox(height: DesignTokens.spacing(context, 20)),
         SizedBox(
           width: double.infinity,
-          child: Obx(() => ElevatedButton(
+          child: Obx(() => AnimatedButton(
                 onPressed:
                     controller.isLoading.value ? null : controller.sendOTP,
+                style: FilledButton.styleFrom(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: DesignTokens.md(context),
+                    vertical: DesignTokens.sm(context),
+                  ),
+                ),
                 child: controller.isLoading.value
                     ? SkeletonLoader(
                         height: DesignTokens.lg(context),
@@ -151,9 +157,15 @@ class _SignInPageState extends State<SignInPage> {
           SizedBox(height: DesignTokens.spacing(context, 20)),
           SizedBox(
             width: double.infinity,
-            child: Obx(() => ElevatedButton(
+            child: Obx(() => AnimatedButton(
                   onPressed:
                       controller.isLoading.value ? null : controller.verifyOTP,
+                  style: FilledButton.styleFrom(
+                    padding: EdgeInsets.symmetric(
+                      horizontal: DesignTokens.md(context),
+                      vertical: DesignTokens.sm(context),
+                    ),
+                  ),
                   child: controller.isLoading.value
                       ? SkeletonLoader(
                           height: DesignTokens.lg(context),

--- a/lib/widgets/complete_enhanced_watchlist.dart
+++ b/lib/widgets/complete_enhanced_watchlist.dart
@@ -1273,11 +1273,15 @@ class SwipeableWatchlistCard extends StatelessWidget {
                 onPressed: () => Get.back(result: false),
                 child: const Text('Cancel'),
               ),
-              ElevatedButton(
+              AnimatedButton(
                 onPressed: () => Get.back(result: true),
-                style: ElevatedButton.styleFrom(
+                style: FilledButton.styleFrom(
                   backgroundColor: context.colorScheme.error,
                   foregroundColor: context.colorScheme.onError,
+                  padding: EdgeInsets.symmetric(
+                    horizontal: DesignTokens.md(context),
+                    vertical: DesignTokens.sm(context),
+                  ),
                 ),
                 child: const Text('Remove'),
               ),
@@ -1464,10 +1468,22 @@ class EnhancedWatchlistWidget extends StatelessWidget {
                       textAlign: TextAlign.center,
                     ),
                     const SizedBox(height: 24),
-                    ElevatedButton.icon(
+                    AnimatedButton(
                       onPressed: () => _showAddItemDialog(context, controller),
-                      icon: const Icon(Icons.add),
-                      label: const Text('Add Your First Item'),
+                      style: FilledButton.styleFrom(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: DesignTokens.md(context),
+                          vertical: DesignTokens.sm(context),
+                        ),
+                      ),
+                      child: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          const Icon(Icons.add),
+                          SizedBox(width: DesignTokens.sm(context)),
+                          const Text('Add Your First Item'),
+                        ],
+                      ),
                     ),
                   ],
                 ),
@@ -1603,7 +1619,7 @@ class EnhancedWatchlistWidget extends StatelessWidget {
             actions: [
               TextButton(
                   onPressed: () => Get.back(), child: const Text('Cancel')),
-              ElevatedButton(
+              AnimatedButton(
                 onPressed: (selectedRashi != null && selectedNakshatra != null)
                     ? () {
                         controller.addThreeWatchlistItems(
@@ -1611,6 +1627,12 @@ class EnhancedWatchlistWidget extends StatelessWidget {
                         Get.back();
                       }
                     : null,
+                style: FilledButton.styleFrom(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: DesignTokens.md(context),
+                    vertical: DesignTokens.sm(context),
+                  ),
+                ),
                 child: const Text('Add Items'),
               ),
             ],
@@ -1669,11 +1691,17 @@ class EnhancedWatchlistWidget extends StatelessWidget {
                 onPressed: () => Get.back(),
                 child: const Text('Cancel'),
               ),
-              ElevatedButton(
+              AnimatedButton(
                 onPressed: () {
                   controller.updateItem(item.id, color: selectedColor);
                   Get.back();
                 },
+                style: FilledButton.styleFrom(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: DesignTokens.md(context),
+                    vertical: DesignTokens.sm(context),
+                  ),
+                ),
                 child: const Text('Update'),
               ),
             ],
@@ -1709,14 +1737,18 @@ class EnhancedWatchlistWidget extends StatelessWidget {
             onPressed: () => Get.back(),
             child: const Text('Cancel'),
           ),
-          ElevatedButton(
+          AnimatedButton(
             onPressed: () {
               controller.clearAllItems();
               Get.back();
             },
-            style: ElevatedButton.styleFrom(
+            style: FilledButton.styleFrom(
               backgroundColor: context.colorScheme.error,
               foregroundColor: context.colorScheme.onError,
+              padding: EdgeInsets.symmetric(
+                horizontal: DesignTokens.md(context),
+                vertical: DesignTokens.sm(context),
+              ),
             ),
             child: const Text('Clear All'),
           ),

--- a/lib/widgets/user_type_switcher.dart
+++ b/lib/widgets/user_type_switcher.dart
@@ -34,15 +34,27 @@ class UserTypeSwitcher extends StatelessWidget {
                 ],
               ),
               const SizedBox(height: 16),
-              ElevatedButton.icon(
+              AnimatedButton(
                 onPressed: userTypeController.toggleUserType,
-                icon: Icon(
-                  userTypeController.isAstrologerRx.value
-                      ? Icons.person
-                      : Icons.stars,
+                style: FilledButton.styleFrom(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: DesignTokens.md(context),
+                    vertical: DesignTokens.sm(context),
+                  ),
                 ),
-                label: Text(
-                  'Switch to ${userTypeController.isAstrologerRx.value ? "General User" : "Astrologer"}',
+                child: Row(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Icon(
+                      userTypeController.isAstrologerRx.value
+                          ? Icons.person
+                          : Icons.stars,
+                    ),
+                    SizedBox(width: DesignTokens.sm(context)),
+                    Text(
+                      'Switch to ${userTypeController.isAstrologerRx.value ? "General User" : "Astrologer"}',
+                    ),
+                  ],
                 ),
               ),
             ],


### PR DESCRIPTION
## Summary
- refactor buttons in watchlist, user profile, and settings pages
- apply AnimatedButton from design system with token-based padding
- import design system where needed

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4cf11598832d8ac4d08bb875ce7f