### PR TITLE
Refactor skeleton loader sizes

### DIFF
--- a/lib/features/admin/screens/moderation_dashboard.dart
+++ b/lib/features/admin/screens/moderation_dashboard.dart
@@ -32,7 +32,9 @@ class _ModerationDashboardState extends State<ModerationDashboard> {
                 3,
                 (_) => Padding(
                   padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
-                  child: const SkeletonLoader(height: 80),
+                  child: SkeletonLoader(
+                    height: DesignTokens.xl(context),
+                  ),
                 ),
               ),
             ),

--- a/lib/features/bookmarks/screens/bookmark_list_page.dart
+++ b/lib/features/bookmarks/screens/bookmark_list_page.dart
@@ -36,7 +36,9 @@ class _BookmarkListPageState extends State<BookmarkListPage> {
                 3,
                 (_) => Padding(
                   padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
-                  child: const SkeletonLoader(height: 80),
+                  child: SkeletonLoader(
+                    height: DesignTokens.xl(context),
+                  ),
                 ),
               ),
             ),

--- a/lib/features/discovery/screens/hashtag_search_page.dart
+++ b/lib/features/discovery/screens/hashtag_search_page.dart
@@ -45,7 +45,9 @@ class _HashtagSearchPageState extends State<HashtagSearchPage> {
                   3,
                   (_) => Padding(
                     padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
-                    child: const SkeletonLoader(height: 80),
+                    child: SkeletonLoader(
+                      height: DesignTokens.xl(context),
+                    ),
                   ),
                 ),
               ),

--- a/lib/features/profile/screens/activity_log_page.dart
+++ b/lib/features/profile/screens/activity_log_page.dart
@@ -37,7 +37,9 @@ class _ActivityLogPageState extends State<ActivityLogPage> {
                 3,
                 (_) => Padding(
                   padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
-                  child: const SkeletonLoader(height: 80),
+                  child: SkeletonLoader(
+                    height: DesignTokens.xl(context),
+                  ),
                 ),
               ),
             ),

--- a/lib/features/social_feed/screens/feed_page.dart
+++ b/lib/features/social_feed/screens/feed_page.dart
@@ -79,7 +79,9 @@ class _FeedPageState extends State<FeedPage> {
                 3,
                 (_) => Padding(
                   padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
-                  child: const SkeletonLoader(height: 80),
+                  child: SkeletonLoader(
+                    height: DesignTokens.xl(context),
+                  ),
                 ),
               ),
             ),


### PR DESCRIPTION
## Summary
- use token sizes for skeleton placeholders in feed and admin screens
- apply the same refactor across bookmark, profile and discovery pages

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4d215714832dbf42d26bb1118202