### PR TITLE
Add Most Recent feed sort option

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -10,6 +10,7 @@ import '../services/feed_service.dart';
 class FeedController extends GetxController {
   final FeedService service;
 
+  // Persist user preferences like sorting mode
   final Box _prefs = Hive.box('preferences');
 
   FeedController({required this.service});
@@ -28,6 +29,7 @@ class FeedController extends GetxController {
     super.onInit();
   }
 
+  /// Update the current sort type and store the preference in Hive.
   void updateSortType(String value) {
     _sortType.value = value;
     _prefs.put('feed_sort_type', value);

--- a/lib/features/social_feed/screens/feed_page.dart
+++ b/lib/features/social_feed/screens/feed_page.dart
@@ -21,7 +21,10 @@ class _FeedPageState extends State<FeedPage> {
   Widget _buildSortMenu(BuildContext context) {
     return Align(
       alignment: Alignment.centerRight,
-      child: DropdownButton<String>(
+      child: Tooltip(
+        message:
+            'Chronological shows the oldest posts first. Most Recent lists the newest posts first.',
+        child: DropdownButton<String>(
         value: controller.sortType,
         onChanged: (value) {
           if (value == null) return;
@@ -37,6 +40,10 @@ class _FeedPageState extends State<FeedPage> {
           DropdownMenuItem(
             value: 'chronological',
             child: Text('Chronological'),
+          ),
+          DropdownMenuItem(
+            value: 'most-recent',
+            child: Text('Most Recent'),
           ),
           DropdownMenuItem(
             value: 'most-commented',

--- a/social media features implementation_guide.markdown
+++ b/social media features implementation_guide.markdown
@@ -1517,6 +1517,9 @@ Below are instructions for implementing the 26 features, mapped to your project 
 ### 24. Feed Algorithms
 
 - **Description**: Sort feeds by chronological, most commented, or most liked.
+- **Sort Modes**:
+  - *Chronological*: Oldest to newest.
+  - *Most Recent*: Newest to oldest.
 
 - **Collections**: `feed_posts` (`like_count`, `comment_count`).
 


### PR DESCRIPTION
## Summary
- show a "Most Recent" option in the feed sort menu
- store sort preference via `FeedController`
- clarify the meaning of `Chronological` and `Most Recent` in docs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d4d389870832db03ea5fc6e4ca45f