### PR TITLE
Handle offline like retrieval

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -193,8 +193,16 @@ class FeedController extends GetxController {
         'item_type': 'post',
         'user_id': uid,
       });
-      final like = await service.getUserLike(postId, uid);
-      if (like != null) _likedIds[postId] = like.id;
+      try {
+        final like = await service.getUserLike(postId, uid);
+        if (like != null) {
+          _likedIds[postId] = like.id;
+        } else {
+          _likedIds[postId] = 'offline';
+        }
+      } catch (_) {
+        _likedIds[postId] = 'offline';
+      }
       _likeCounts[postId] = (_likeCounts[postId] ?? 0) + 1;
     }
   }

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -155,6 +155,31 @@ void main() {
     expect(controller.isPostLiked('1'), isFalse);
   });
 
+  test('toggleLikePost offline still updates locally', () async {
+    class OfflineLikeService extends FakeFeedService {
+      @override
+      Future<PostLike?> getUserLike(String itemId, String userId) {
+        return Future.error('offline');
+      }
+    }
+
+    final service = OfflineLikeService();
+    final controller = FeedController(service: service);
+    service.store.add(
+      FeedPost(
+        id: '1',
+        roomId: 'room',
+        userId: 'u1',
+        username: 'user',
+        content: 'text',
+      ),
+    );
+    await controller.loadPosts('room');
+    await controller.toggleLikePost('1');
+    expect(controller.isPostLiked('1'), isTrue);
+    expect(controller.postLikeCount('1'), 1);
+  });
+
   test('repostPost stores id and increases count', () async {
     final service = FakeFeedService();
     final controller = FeedController(service: service);


### PR DESCRIPTION
## Summary
- ensure offline like ID stored when getUserLike fails
- test offline like flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d53dcd7ec832da1c3711d2de90dd0