### PR TITLE
Fix like count underflow

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -1,3 +1,4 @@
+import 'dart:math' as math;
 import 'package:get/get.dart';
 import '../../../controllers/auth_controller.dart';
 import '../models/post_comment.dart';
@@ -57,7 +58,8 @@ class CommentsController extends GetxController {
     if (_likedIds.containsKey(commentId)) {
       final likeId = _likedIds.remove(commentId)!;
       await service.unlikeComment(likeId);
-      _likeCounts[commentId] = (_likeCounts[commentId] ?? 1) - 1;
+      _likeCounts[commentId] =
+          math.max(0, (_likeCounts[commentId] ?? 1) - 1);
     } else {
       await service.likeComment(commentId, uid);
       try {

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -1,5 +1,6 @@
-import 'package:get/get.dart';
 import 'dart:io';
+import 'dart:math' as math;
+import 'package:get/get.dart';
 import 'package:hive/hive.dart';
 import '../../../controllers/auth_controller.dart';
 import '../../profile/services/profile_service.dart';
@@ -186,7 +187,7 @@ class FeedController extends GetxController {
     if (_likedIds.containsKey(postId)) {
       final likeId = _likedIds.remove(postId)!;
       await service.deleteLike(likeId);
-      _likeCounts[postId] = (_likeCounts[postId] ?? 1) - 1;
+      _likeCounts[postId] = math.max(0, (_likeCounts[postId] ?? 1) - 1);
     } else {
       await service.createLike({
         'item_id': postId,

--- a/test/features/social_feed/comments_controller_test.dart
+++ b/test/features/social_feed/comments_controller_test.dart
@@ -85,4 +85,23 @@ void main() {
     expect(controller.isCommentLiked('1'), isTrue);
     expect(controller.commentLikeCount('1'), 1);
   });
+
+  test('like counts never drop below zero', () async {
+    final service = FakeFeedService();
+    final controller = CommentsController(service: service);
+    final c = PostComment(
+      id: '1',
+      postId: 'p1',
+      userId: 'u',
+      username: 'user',
+      content: 'hi',
+    );
+    service.store.add(c);
+    service.likes['1'] = 'l1';
+    await controller.loadComments('p1');
+    await controller.toggleLikeComment('1');
+    expect(controller.commentLikeCount('1'), 0);
+    await controller.toggleLikeComment('1');
+    expect(controller.commentLikeCount('1'), 1);
+  });
 }

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -155,6 +155,26 @@ void main() {
     expect(controller.isPostLiked('1'), isFalse);
   });
 
+  test('post like count never below zero', () async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    service.store.add(
+      FeedPost(
+        id: '2',
+        roomId: 'room',
+        userId: 'u1',
+        username: 'user',
+        content: 'text',
+      ),
+    );
+    service.likes['2'] = 'l1';
+    await controller.loadPosts('room');
+    await controller.toggleLikePost('2');
+    expect(controller.postLikeCount('2'), 0);
+    await controller.toggleLikePost('2');
+    expect(controller.postLikeCount('2'), 1);
+  });
+
   test('repostPost stores id and increases count', () async {
     final service = FakeFeedService();
     final controller = FeedController(service: service);


### PR DESCRIPTION
## Summary
- avoid negative like counts in feed & comments controllers
- ensure like counts never go below zero via tests

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5406e028832da22ecea40b78c3d2