### PR TITLE
Add like count update functions

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -56,7 +56,7 @@ class CommentsController extends GetxController {
     if (uid == null) return;
     if (_likedIds.containsKey(commentId)) {
       final likeId = _likedIds.remove(commentId)!;
-      await service.unlikeComment(likeId);
+      await service.unlikeComment(likeId, commentId);
       _likeCounts[commentId] = (_likeCounts[commentId] ?? 1) - 1;
     } else {
       await service.likeComment(commentId, uid);

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -185,7 +185,11 @@ class FeedController extends GetxController {
     if (uid == null) return;
     if (_likedIds.containsKey(postId)) {
       final likeId = _likedIds.remove(postId)!;
-      await service.deleteLike(likeId);
+      await service.deleteLike(
+        likeId,
+        itemId: postId,
+        itemType: 'post',
+      );
       _likeCounts[postId] = (_likeCounts[postId] ?? 1) - 1;
     } else {
       await service.createLike({

--- a/test/features/social_feed/comment_card_test.dart
+++ b/test/features/social_feed/comment_card_test.dart
@@ -64,7 +64,7 @@ class _FakeService extends FeedService {
   }
 
   @override
-  Future<void> unlikeComment(String likeId) async {
+  Future<void> unlikeComment(String likeId, String commentId) async {
     likes.removeWhere((key, value) => value == likeId);
   }
 
@@ -77,7 +77,11 @@ class _FakeService extends FeedService {
   }
 
   @override
-  Future<void> deleteLike(String likeId) async {
+  Future<void> deleteLike(
+    String likeId, {
+    required String itemId,
+    required String itemType,
+  }) async {
     likes.removeWhere((key, value) => value == likeId);
   }
 

--- a/test/features/social_feed/comments_controller_test.dart
+++ b/test/features/social_feed/comments_controller_test.dart
@@ -44,7 +44,7 @@ class FakeFeedService extends FeedService {
   }
 
   @override
-  Future<void> unlikeComment(String likeId) async {
+  Future<void> unlikeComment(String likeId, String commentId) async {
     likes.removeWhere((key, value) => value == likeId);
   }
 
@@ -57,7 +57,11 @@ class FakeFeedService extends FeedService {
   }
 
   @override
-  Future<void> deleteLike(String likeId) async {
+  Future<void> deleteLike(
+    String likeId, {
+    required String itemId,
+    required String itemType,
+  }) async {
     likes.removeWhere((key, value) => value == likeId);
   }
 }

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -54,7 +54,11 @@ class FakeFeedService extends FeedService {
   }
 
   @override
-  Future<void> deleteLike(String likeId) async {
+  Future<void> deleteLike(
+    String likeId, {
+    required String itemId,
+    required String itemType,
+  }) async {
     likes.removeWhere((key, value) => value == likeId);
   }
 

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -114,7 +114,11 @@ class FakeFeedService extends FeedService {
   }
 
   @override
-  Future<void> deleteLike(String likeId) async {
+  Future<void> deleteLike(
+    String likeId, {
+    required String itemId,
+    required String itemType,
+  }) async {
     likes.removeWhere((key, value) => value == likeId);
   }
 


### PR DESCRIPTION
## Summary
- call serverless functions to increment/decrement like counts
- support comment like functions
- queue unlike actions for offline sync
- adjust controllers and tests for new service APIs

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d542d4384832d952b2fed4543c973