### PR TITLE
Add repost toggle support

### DIFF
--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -252,6 +252,7 @@ class PostCard extends StatelessWidget {
               onRepost: () => _handleRepost(controller),
               onBookmark: () => _handleBookmark(bookmarkController, auth.userId ?? ''),
               postId: post.id,
+              isReposted: controller.isPostReposted(post.id),
               isLiked: controller.isPostLiked(post.id),
               isBookmarked: bookmarkController.isBookmarked(post.id),
               likeCount: controller.postLikeCount(post.id),

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -20,6 +20,7 @@ class ReactionBar extends StatelessWidget {
   final int repostCount;
   final int shareCount;
   final ReactionTarget target;
+  final bool isReposted;
 
   const ReactionBar({
     super.key,
@@ -36,6 +37,7 @@ class ReactionBar extends StatelessWidget {
     this.repostCount = 0,
     this.shareCount = 0,
     this.target = ReactionTarget.post,
+    this.isReposted = false,
   });
 
   @override
@@ -125,8 +127,13 @@ class ReactionBar extends StatelessWidget {
     if ((onRepost != null || repostCount > 0) && target == ReactionTarget.post) {
       addItem(
         buildItem(
-          icon: const Icon(Icons.repeat),
-          label: 'Repost',
+          icon: Icon(
+            Icons.repeat,
+            color: isReposted
+                ? context.colorScheme.primary
+                : ContextExtensions(context).theme.iconTheme.color,
+          ),
+          label: isReposted ? 'Undo Repost' : 'Repost',
           onTap: onRepost,
           count: repostCount,
         ),

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -72,6 +72,30 @@ void main() {
     await tester.pump();
     expect(find.text('Reposted by you'), findsOneWidget);
   });
+
+  testWidgets('repost button label switches to undo', (tester) async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    Get.put(controller);
+    final post = FeedPost(
+      id: '1',
+      roomId: 'r1',
+      userId: 'u1',
+      username: 'user',
+      content: 'hello',
+    );
+    service.store.add(post);
+    await controller.loadPosts('r1');
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PostCard(post: post),
+      ),
+    );
+    expect(find.text('Repost'), findsOneWidget);
+    await controller.repostPost('1');
+    await tester.pump();
+    expect(find.text('Undo Repost'), findsOneWidget);
+  });
 }
 
 class FakeFeedService extends FeedService {


### PR DESCRIPTION
## Summary
- support toggling repost state in `ReactionBar`
- forward reposted status from `PostCard`
- show "Undo Repost" when post already reposted
- test label change for repost button

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d58251514832daf1cf9ac7c765af0