### PR TITLE
Implement offline undo repost logic

### DIFF
--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -169,4 +169,13 @@ void main() {
     expect(item?['like_id'], 'like1');
   });
 
+  test('deleteRepost queues when offline', () async {
+    await service.deleteRepost('repost1');
+    final queue = Hive.box('action_queue');
+    expect(queue.isNotEmpty, isTrue);
+    final item = queue.getAt(0) as Map?;
+    expect(item?['action'], 'undo_repost');
+    expect(item?['repost_id'], 'repost1');
+  });
+
 }


### PR DESCRIPTION
## Summary
- queue failed deleteRepost actions in FeedService
- process queued undo reposts in syncQueuedActions
- test offline deleteRepost queuing

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d58271938832da6fcaf9774958c17