### PR TITLE
Implement repost count function calls

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -238,7 +238,7 @@ class FeedController extends GetxController {
     final uid = auth.userId;
     if (uid == null || !_repostedIds.containsKey(postId)) return;
     final repostId = _repostedIds.remove(postId)!;
-    await service.deleteRepost(repostId);
+    await service.deleteRepost(repostId, postId);
     _repostCounts[postId] = (_repostCounts[postId] ?? 1) - 1;
   }
 

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -69,7 +69,7 @@ class FakeFeedService extends FeedService {
   }
 
   @override
-  Future<void> deleteRepost(String repostId) async {
+  Future<void> deleteRepost(String repostId, String postId) async {
     reposts.removeWhere((key, value) => value == repostId);
   }
 

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -126,7 +126,7 @@ class FakeFeedService extends FeedService {
   Future<String?> createRepost(Map<String, dynamic> repost) async => 'r1';
 
   @override
-  Future<void> deleteRepost(String repostId) async {}
+  Future<void> deleteRepost(String repostId, String postId) async {}
 
   @override
   Future<PostRepost?> getUserRepost(String postId, String userId) async => null;

--- a/test/features/social_feed/repost_function_execution_test.dart
+++ b/test/features/social_feed/repost_function_execution_test.dart
@@ -1,0 +1,173 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:appwrite/models.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+
+class RecordingFunctions extends Functions {
+  RecordingFunctions() : super(Client());
+
+  String? lastFunctionId;
+  String? lastBody;
+
+  @override
+  Future<Execution> createExecution({
+    required String functionId,
+    String? body,
+    Map<String, dynamic>? xHeaders,
+    String? path,
+  }) async {
+    lastFunctionId = functionId;
+    lastBody = body;
+    return Execution.fromMap({
+      '\$id': '1',
+      '\$createdAt': '',
+      '\$updatedAt': '',
+      '\$permissions': [],
+      'functionId': functionId,
+      'trigger': 'http',
+      'status': 'completed',
+      'requestMethod': 'GET',
+      'requestPath': '/',
+      'requestHeaders': [],
+      'responseStatusCode': 200,
+      'responseBody': '',
+      'responseHeaders': [],
+      'logs': '',
+      'errors': '',
+      'duration': 0.0,
+    });
+  }
+}
+
+class FakeDatabases extends Databases {
+  FakeDatabases() : super(Client());
+
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) async {
+    return Document.fromMap({
+      '\$id': documentId,
+      '\$collectionId': collectionId,
+      '\$databaseId': databaseId,
+      '\$createdAt': '',
+      '\$updatedAt': '',
+      '\$permissions': [],
+      ...data,
+    });
+  }
+
+  @override
+  Future<void> deleteDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+  }) async {}
+}
+
+class OfflineDatabases extends FakeDatabases {
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+void main() {
+  late Directory dir;
+  late RecordingFunctions functions;
+  late FeedService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    for (final box in [
+      'posts',
+      'comments',
+      'action_queue',
+      'post_queue',
+      'bookmarks',
+      'hashtags',
+      'preferences'
+    ]) {
+      await Hive.openBox(box);
+    }
+    functions = RecordingFunctions();
+    service = FeedService(
+      databases: FakeDatabases(),
+      storage: Storage(Client()),
+      functions: functions,
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'link',
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('createRepost triggers function execution', () async {
+    await service.createRepost({'post_id': '1', 'user_id': 'u'});
+    expect(functions.lastFunctionId, 'increment_repost_count');
+    expect(functions.lastBody, '{"post_id":"1"}');
+  });
+
+  test('deleteRepost triggers decrement function', () async {
+    await service.deleteRepost('r1', '1');
+    expect(functions.lastFunctionId, 'decrement_repost_count');
+    expect(functions.lastBody, '{"post_id":"1"}');
+  });
+
+  test('queued repost executes function on sync', () async {
+    service = FeedService(
+      databases: OfflineDatabases(),
+      storage: Storage(Client()),
+      functions: functions,
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'link',
+    );
+    await service.createRepost({'post_id': '2', 'user_id': 'u'});
+    expect(functions.lastFunctionId, isNull);
+    service = FeedService(
+      databases: FakeDatabases(),
+      storage: Storage(Client()),
+      functions: functions,
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'link',
+    );
+    await service.syncQueuedActions();
+    expect(functions.lastFunctionId, 'increment_repost_count');
+    expect(functions.lastBody, '{"post_id":"2"}');
+  });
+}


### PR DESCRIPTION
## Summary
- trigger `increment_repost_count` when creating reposts
- trigger `decrement_repost_count` when undoing reposts
- ensure queued reposts also invoke count increment
- adapt controller and tests for new deleteRepost signature
- add unit tests verifying function execution

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d58132034832d8fa16334123eacd5