### PR TITLE
Update repost button to toggle state

### DIFF
--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -91,7 +91,7 @@ class PostCard extends StatelessWidget {
     if (controller.isPostReposted(post.id)) {
       controller.undoRepost(post.id);
     } else {
-      Get.to(() => RepostPage(post: post));
+      controller.repostPost(post.id);
     }
   }
 
@@ -258,6 +258,7 @@ class PostCard extends StatelessWidget {
               commentCount: post.commentCount,
               repostCount: controller.postRepostCount(post.id),
               shareCount: post.shareCount,
+              isReposted: controller.isPostReposted(post.id),
             ),
           ],
         ),

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -15,6 +15,7 @@ class ReactionBar extends StatelessWidget {
   final String? postId;
   final bool isLiked;
   final bool isBookmarked;
+  final bool isReposted;
   final int likeCount;
   final int commentCount;
   final int repostCount;
@@ -31,6 +32,7 @@ class ReactionBar extends StatelessWidget {
     this.postId,
     this.isLiked = false,
     this.isBookmarked = false,
+    this.isReposted = false,
     this.likeCount = 0,
     this.commentCount = 0,
     this.repostCount = 0,
@@ -125,8 +127,13 @@ class ReactionBar extends StatelessWidget {
     if ((onRepost != null || repostCount > 0) && target == ReactionTarget.post) {
       addItem(
         buildItem(
-          icon: const Icon(Icons.repeat),
-          label: 'Repost',
+          icon: Icon(
+            Icons.repeat,
+            color: isReposted
+                ? context.colorScheme.primary
+                : ContextExtensions(context).theme.iconTheme.color,
+          ),
+          label: isReposted ? 'Undo Repost' : 'Repost',
           onTap: onRepost,
           count: repostCount,
         ),

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -72,6 +72,39 @@ void main() {
     await tester.pump();
     expect(find.text('Reposted by you'), findsOneWidget);
   });
+
+  testWidgets('repost button label updates when toggled', (tester) async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    Get.put(controller);
+    final post = FeedPost(
+      id: '1',
+      roomId: 'r1',
+      userId: 'u1',
+      username: 'user',
+      content: 'hello',
+    );
+    service.store.add(post);
+    await controller.loadPosts('r1');
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: PostCard(post: post),
+      ),
+    );
+
+    expect(find.bySemanticsLabel('Repost'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.repeat));
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('Undo Repost'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.repeat));
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('Repost'), findsOneWidget);
+  });
 }
 
 class FakeFeedService extends FeedService {


### PR DESCRIPTION
## Summary
- highlight repost state in `ReactionBar`
- toggle reposts directly in `PostCard`
- test ReactionBar semantics when reposting

## Testing
- `flutter test test/features/social_feed/post_card_test.dart -r compact` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d58163e14832da41bca3e57934896