### PR TITLE
Add haptic feedback to repost and reaction buttons

### DIFF
--- a/lib/features/social_feed/screens/repost_page.dart
+++ b/lib/features/social_feed/screens/repost_page.dart
@@ -53,6 +53,7 @@ class _RepostPageState extends State<RepostPage> {
                     await feedController.repostPost(widget.post.id, comment);
                     Get.back();
                   },
+                  enableHaptics: true,
                   child: const Text('Repost'),
                 ),
               ],

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -53,6 +53,7 @@ class ReactionBar extends StatelessWidget {
         isButton: true,
         child: AnimatedButton(
           onPressed: onTap,
+          enableHaptics: true,
           child: Row(
             children: [
               icon,


### PR DESCRIPTION
## Summary
- update `RepostPage` repost button to enable haptics
- enable haptics on every `ReactionBar` button item

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d582393cc832d9715c37584a779de