### PR TITLE
Integrate repost function fixes

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -237,9 +237,14 @@ class FeedController extends GetxController {
     final auth = Get.find<AuthController>();
     final uid = auth.userId;
     if (uid == null || !_repostedIds.containsKey(postId)) return;
-    final repostId = _repostedIds.remove(postId)!;
-    await service.deleteRepost(repostId);
-    _repostCounts[postId] = (_repostCounts[postId] ?? 1) - 1;
+    final repostId = _repostedIds[postId]!;
+    try {
+      await service.deleteRepost(repostId, postId);
+      _repostedIds.remove(postId);
+      _repostCounts[postId] = (_repostCounts[postId] ?? 1) - 1;
+    } catch (_) {
+      // keep id until synced
+    }
   }
 
   Future<void> editPost(

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -96,7 +96,7 @@ class PostCard extends StatelessWidget {
         Get.snackbar('Error', 'Login required');
         return;
       }
-      Get.to(() => RepostPage(post: post));
+      controller.repostPost(post.id);
     }
   }
 

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -54,6 +54,29 @@ class OfflineStorage extends Storage {
   }
 }
 
+class _CountingService extends FeedService {
+  final List<String> deletedIds = [];
+  _CountingService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          bookmarksCollectionId: 'bookmarks',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
+        );
+
+  @override
+  Future<void> deleteRepost(String repostId, String postId) async {
+    deletedIds.add(repostId);
+  }
+}
+
 void main() {
   late Directory dir;
   late FeedService service;
@@ -170,12 +193,21 @@ void main() {
   });
 
   test('deleteRepost queues when offline', () async {
-    await service.deleteRepost('repost1');
+    await expectLater(service.deleteRepost('r1', 'p1'), throwsA(anything));
     final queue = Hive.box('action_queue');
     expect(queue.isNotEmpty, isTrue);
-    final item = queue.getAt(0) as Map?;
-    expect(item?['action'], 'undo_repost');
-    expect(item?['repost_id'], 'repost1');
+    final item = queue.getAt(queue.length - 1) as Map?;
+    expect(item?['action'], 'delete_repost');
+    expect(item?['id'], 'r1');
+  });
+
+  test('syncQueuedActions processes delete_repost items', () async {
+    await expectLater(service.deleteRepost('r2', 'p2'), throwsA(anything));
+    final counterService = _CountingService();
+    await counterService.syncQueuedActions();
+    expect(counterService.deletedIds.contains('r2'), isTrue);
+    final queue = Hive.box('action_queue');
+    expect(queue.isEmpty, isTrue);
   });
 
 }

--- a/test/features/social_feed/offline_undo_repost_test.dart
+++ b/test/features/social_feed/offline_undo_repost_test.dart
@@ -52,13 +52,13 @@ class _OfflineService extends FeedService {
   }
 
   @override
-  Future<void> deleteRepost(String repostId) async {
+  Future<void> deleteRepost(String repostId, String postId) async {
     final box = Hive.box('action_queue');
     if (box.length >= 50) {
       final key = box.keys.first;
       await box.delete(key);
     }
-    await box.add({'action': 'delete_repost', 'repost_id': repostId});
+    await box.add({'action': 'delete_repost', 'id': repostId, 'post_id': postId});
   }
 }
 
@@ -101,7 +101,7 @@ void main() {
     final queue = Hive.box('action_queue');
     expect(queue.isEmpty, isTrue);
     await controller.undoRepost('1');
-    expect(controller.isPostReposted('1'), isFalse);
+    expect(controller.isPostReposted('1'), isTrue);
     expect(queue.isNotEmpty, isTrue);
   });
 }

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -73,7 +73,7 @@ void main() {
     expect(find.text('Reposted by you'), findsOneWidget);
   });
 
-  testWidgets('repost button label switches to undo', (tester) async {
+  testWidgets('repost button label updates when toggled', (tester) async {
     final service = FakeFeedService();
     final controller = FeedController(service: service);
     Get.put(controller);
@@ -91,10 +91,17 @@ void main() {
         home: PostCard(post: post),
       ),
     );
-    expect(find.text('Repost'), findsOneWidget);
-    await controller.repostPost('1');
+    expect(find.bySemanticsLabel('Repost'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.repeat));
     await tester.pump();
-    expect(find.text('Undo Repost'), findsOneWidget);
+
+    expect(find.bySemanticsLabel('Undo Repost'), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.repeat));
+    await tester.pump();
+
+    expect(find.bySemanticsLabel('Repost'), findsOneWidget);
   });
 }
 
@@ -150,7 +157,7 @@ class FakeFeedService extends FeedService {
   Future<String?> createRepost(Map<String, dynamic> repost) async => 'r1';
 
   @override
-  Future<void> deleteRepost(String repostId) async {}
+  Future<void> deleteRepost(String repostId, String postId) async {}
 
   @override
   Future<PostRepost?> getUserRepost(String postId, String userId) async => null;

--- a/test/features/social_feed/repost_comment_test.dart
+++ b/test/features/social_feed/repost_comment_test.dart
@@ -42,7 +42,7 @@ class _TrackingService extends FeedService {
   Future<PostRepost?> getUserRepost(String postId, String userId) async => null;
 
   @override
-  Future<void> deleteRepost(String repostId) async {}
+  Future<void> deleteRepost(String repostId, String postId) async {}
 }
 
 void main() {

--- a/test/features/social_feed/repost_function_execution_test.dart
+++ b/test/features/social_feed/repost_function_execution_test.dart
@@ -1,0 +1,173 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:appwrite/models.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+
+class RecordingFunctions extends Functions {
+  RecordingFunctions() : super(Client());
+
+  String? lastFunctionId;
+  String? lastBody;
+
+  @override
+  Future<Execution> createExecution({
+    required String functionId,
+    String? body,
+    Map<String, dynamic>? xHeaders,
+    String? path,
+  }) async {
+    lastFunctionId = functionId;
+    lastBody = body;
+    return Execution.fromMap({
+      '\$id': '1',
+      '\$createdAt': '',
+      '\$updatedAt': '',
+      '\$permissions': [],
+      'functionId': functionId,
+      'trigger': 'http',
+      'status': 'completed',
+      'requestMethod': 'GET',
+      'requestPath': '/',
+      'requestHeaders': [],
+      'responseStatusCode': 200,
+      'responseBody': '',
+      'responseHeaders': [],
+      'logs': '',
+      'errors': '',
+      'duration': 0.0,
+    });
+  }
+}
+
+class FakeDatabases extends Databases {
+  FakeDatabases() : super(Client());
+
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) async {
+    return Document.fromMap({
+      '\$id': documentId,
+      '\$collectionId': collectionId,
+      '\$databaseId': databaseId,
+      '\$createdAt': '',
+      '\$updatedAt': '',
+      '\$permissions': [],
+      ...data,
+    });
+  }
+
+  @override
+  Future<void> deleteDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+  }) async {}
+}
+
+class OfflineDatabases extends FakeDatabases {
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+void main() {
+  late Directory dir;
+  late RecordingFunctions functions;
+  late FeedService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    for (final box in [
+      'posts',
+      'comments',
+      'action_queue',
+      'post_queue',
+      'bookmarks',
+      'hashtags',
+      'preferences'
+    ]) {
+      await Hive.openBox(box);
+    }
+    functions = RecordingFunctions();
+    service = FeedService(
+      databases: FakeDatabases(),
+      storage: Storage(Client()),
+      functions: functions,
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'link',
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('createRepost triggers function execution', () async {
+    await service.createRepost({'post_id': '1', 'user_id': 'u'});
+    expect(functions.lastFunctionId, 'increment_repost_count');
+    expect(functions.lastBody, '{"post_id":"1"}');
+  });
+
+  test('deleteRepost triggers decrement function', () async {
+    await service.deleteRepost('r1', '1');
+    expect(functions.lastFunctionId, 'decrement_repost_count');
+    expect(functions.lastBody, '{"post_id":"1"}');
+  });
+
+  test('queued repost executes function on sync', () async {
+    service = FeedService(
+      databases: OfflineDatabases(),
+      storage: Storage(Client()),
+      functions: functions,
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'link',
+    );
+    await service.createRepost({'post_id': '2', 'user_id': 'u'});
+    expect(functions.lastFunctionId, isNull);
+    service = FeedService(
+      databases: FakeDatabases(),
+      storage: Storage(Client()),
+      functions: functions,
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'link',
+    );
+    await service.syncQueuedActions();
+    expect(functions.lastFunctionId, 'increment_repost_count');
+    expect(functions.lastBody, '{"post_id":"2"}');
+  });
+}


### PR DESCRIPTION
## Summary
- keep repost ID when undoing offline
- trigger decrement function when removing a repost
- make repost button immediately repost without page
- update offline queue handling
- add tests for function executions and offline behaviour

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d5a817860832da314146f6d4c33e0