### PR TITLE
Handle offline bookmark removals

### DIFF
--- a/lib/features/bookmarks/controllers/bookmark_controller.dart
+++ b/lib/features/bookmarks/controllers/bookmark_controller.dart
@@ -25,7 +25,9 @@ class BookmarkController extends GetxController {
   Future<void> toggleBookmark(String userId, String postId) async {
     if (_bookmarkIds.containsKey(postId)) {
       final id = _bookmarkIds.remove(postId)!;
-      await service.removeBookmark(id);
+      try {
+        await service.removeBookmark(id);
+      } catch (_) {}
       bookmarks.removeWhere((b) => b.post.id == postId);
     } else {
       await service.bookmarkPost(userId, postId);

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -620,6 +620,9 @@ class FeedService {
             final data = Map<String, dynamic>.from(item['data']);
             await bookmarkPost(data['user_id'], data['post_id']);
             break;
+          case 'remove_bookmark':
+            await removeBookmark(item['bookmark_id']);
+            break;
           case 'comment':
             await createComment(PostComment.fromJson(
                 Map<String, dynamic>.from(item['data'])));
@@ -713,11 +716,19 @@ class FeedService {
   }
 
   Future<void> removeBookmark(String bookmarkId) async {
-    await databases.deleteDocument(
-      databaseId: databaseId,
-      collectionId: bookmarksCollectionId,
-      documentId: bookmarkId,
-    );
+    try {
+      await databases.deleteDocument(
+        databaseId: databaseId,
+        collectionId: bookmarksCollectionId,
+        documentId: bookmarkId,
+      );
+    } catch (_) {
+      await _addToBoxWithLimit(queueBox, {
+        'action': 'remove_bookmark',
+        'bookmark_id': bookmarkId,
+        '_cachedAt': DateTime.now().toIso8601String(),
+      });
+    }
   }
 
   Future<void> deletePost(String postId) async {

--- a/test/features/bookmarks/bookmark_controller_test.dart
+++ b/test/features/bookmarks/bookmark_controller_test.dart
@@ -65,6 +65,13 @@ class FakeFeedService extends FeedService {
   }
 }
 
+class OfflineRemoveService extends FakeFeedService {
+  @override
+  Future<void> removeBookmark(String bookmarkId) {
+    return Future.error('offline');
+  }
+}
+
 void main() {
   test('toggleBookmark updates map', () async {
     final service = FakeFeedService();
@@ -78,6 +85,32 @@ void main() {
     final controller = BookmarkController(service: service);
     await controller.toggleBookmark('u', '1');
     expect(controller.isBookmarked('1'), isTrue);
+    await controller.toggleBookmark('u', '1');
+    expect(controller.isBookmarked('1'), isFalse);
+  });
+
+  test('toggleBookmark offline remove updates map', () async {
+    final service = OfflineRemoveService();
+    service.posts.add(FeedPost(
+      id: '1',
+      roomId: 'r',
+      userId: 'u',
+      username: 'n',
+      content: 'c',
+    ));
+    service.bms['1'] = 'b1';
+    final controller = BookmarkController(service: service);
+    controller.bookmarks.add(
+      BookmarkedPost(
+        bookmark: Bookmark(
+          id: 'b1',
+          postId: '1',
+          userId: 'u',
+          createdAt: DateTime.now(),
+        ),
+        post: service.posts.first,
+      ),
+    );
     await controller.toggleBookmark('u', '1');
     expect(controller.isBookmarked('1'), isFalse);
   });

--- a/test/features/bookmarks/offline_remove_bookmark_test.dart
+++ b/test/features/bookmarks/offline_remove_bookmark_test.dart
@@ -1,0 +1,94 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+
+class _OfflineDatabases extends Databases {
+  _OfflineDatabases() : super(Client());
+  @override
+  Future<void> deleteDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+class _CountingService extends FeedService {
+  final List<String> ids = [];
+  _CountingService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          bookmarksCollectionId: 'bookmarks',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'link',
+        );
+
+  @override
+  Future<void> removeBookmark(String bookmarkId) async {
+    ids.add(bookmarkId);
+  }
+}
+
+void main() {
+  late Directory dir;
+  late FeedService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('posts');
+    await Hive.openBox('comments');
+    await Hive.openBox('action_queue');
+    await Hive.openBox('post_queue');
+    await Hive.openBox('bookmarks');
+    await Hive.openBox('hashtags');
+    await Hive.openBox('preferences');
+    service = FeedService(
+      databases: _OfflineDatabases(),
+      storage: Storage(Client()),
+      functions: Functions(Client()),
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'link',
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('removeBookmark queues when offline', () async {
+    await service.removeBookmark('b1');
+    final queue = Hive.box('action_queue');
+    expect(queue.isNotEmpty, isTrue);
+    final item = queue.getAt(0) as Map?;
+    expect(item?['action'], 'remove_bookmark');
+    expect(item?['bookmark_id'], 'b1');
+  });
+
+  test('syncQueuedActions processes remove_bookmark items', () async {
+    await service.removeBookmark('b2');
+    final counter = _CountingService();
+    await counter.syncQueuedActions();
+    expect(counter.ids.contains('b2'), isTrue);
+    final queue = Hive.box('action_queue');
+    expect(queue.isEmpty, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- queue failed removeBookmark actions in feed service
- process `remove_bookmark` items when syncing queued actions
- maintain bookmark state when removal fails
- test controller behaviour when offline
- ensure queued removal actions sync correctly

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7e8b5cfc832dbfca28c99960b968