### PR TITLE
Add offline bookmark removal queue

### DIFF
--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -620,6 +620,10 @@ class FeedService {
             final data = Map<String, dynamic>.from(item['data']);
             await bookmarkPost(data['user_id'], data['post_id']);
             break;
+          case 'remove_bookmark':
+            final data = Map<String, dynamic>.from(item['data']);
+            await removeBookmark(data['bookmark_id']);
+            break;
           case 'comment':
             await createComment(PostComment.fromJson(
                 Map<String, dynamic>.from(item['data'])));
@@ -713,11 +717,19 @@ class FeedService {
   }
 
   Future<void> removeBookmark(String bookmarkId) async {
-    await databases.deleteDocument(
-      databaseId: databaseId,
-      collectionId: bookmarksCollectionId,
-      documentId: bookmarkId,
-    );
+    try {
+      await databases.deleteDocument(
+        databaseId: databaseId,
+        collectionId: bookmarksCollectionId,
+        documentId: bookmarkId,
+      );
+    } catch (_) {
+      await _addToBoxWithLimit(queueBox, {
+        'action': 'remove_bookmark',
+        'data': {'bookmark_id': bookmarkId},
+        '_cachedAt': DateTime.now().toIso8601String(),
+      });
+    }
   }
 
   Future<void> deletePost(String postId) async {

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -56,6 +56,7 @@ class OfflineStorage extends Storage {
 
 class _CountingService extends FeedService {
   final List<String> deletedIds = [];
+  final List<String> removedBookmarks = [];
   _CountingService()
       : super(
           databases: Databases(Client()),
@@ -74,6 +75,11 @@ class _CountingService extends FeedService {
   @override
   Future<void> deleteRepost(String repostId, String postId) async {
     deletedIds.add(repostId);
+  }
+
+  @override
+  Future<void> removeBookmark(String bookmarkId) async {
+    removedBookmarks.add(bookmarkId);
   }
 }
 
@@ -165,6 +171,15 @@ void main() {
     expect(queue.isNotEmpty, isTrue);
   });
 
+  test('removeBookmark queues when offline', () async {
+    await service.removeBookmark('b1');
+    final queue = Hive.box('action_queue');
+    expect(queue.isNotEmpty, isTrue);
+    final item = queue.getAt(queue.length - 1) as Map?;
+    expect(item?['action'], 'remove_bookmark');
+    expect(item?['data']['bookmark_id'], 'b1');
+  });
+
   test('postQueueBox capped at 50 items', () async {
     final file = File('${dir.path}/img.jpg');
     await file.writeAsBytes(List.filled(10, 0));
@@ -206,6 +221,15 @@ void main() {
     final counterService = _CountingService();
     await counterService.syncQueuedActions();
     expect(counterService.deletedIds.contains('r2'), isTrue);
+    final queue = Hive.box('action_queue');
+    expect(queue.isEmpty, isTrue);
+  });
+
+  test('syncQueuedActions processes remove_bookmark items', () async {
+    await service.removeBookmark('b2');
+    final counterService = _CountingService();
+    await counterService.syncQueuedActions();
+    expect(counterService.removedBookmarks.contains('b2'), isTrue);
     final queue = Hive.box('action_queue');
     expect(queue.isEmpty, isTrue);
   });


### PR DESCRIPTION
## Summary
- handle offline bookmark removal by queuing action
- process queued bookmark removals in `syncQueuedActions`
- test queuing and sync logic for bookmark removal when offline

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d7ea3d414832d80e71ec5f2b8e2d6