### PR TITLE
Consolidate bookmark offline handling

### DIFF
--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -621,7 +621,8 @@ class FeedService {
             await bookmarkPost(data['user_id'], data['post_id']);
             break;
           case 'remove_bookmark':
-            await removeBookmark(item['bookmark_id']);
+            final data = Map<String, dynamic>.from(item['data']);
+            await removeBookmark(data['bookmark_id']);
             break;
           case 'comment':
             await createComment(PostComment.fromJson(
@@ -725,9 +726,10 @@ class FeedService {
     } catch (_) {
       await _addToBoxWithLimit(queueBox, {
         'action': 'remove_bookmark',
-        'bookmark_id': bookmarkId,
+        'data': {'bookmark_id': bookmarkId},
         '_cachedAt': DateTime.now().toIso8601String(),
       });
+      rethrow;
     }
   }
 

--- a/test/features/bookmarks/offline_remove_bookmark_test.dart
+++ b/test/features/bookmarks/offline_remove_bookmark_test.dart
@@ -75,16 +75,16 @@ void main() {
   });
 
   test('removeBookmark queues when offline', () async {
-    await service.removeBookmark('b1');
+    await expectLater(service.removeBookmark('b1'), throwsA(anything));
     final queue = Hive.box('action_queue');
     expect(queue.isNotEmpty, isTrue);
     final item = queue.getAt(0) as Map?;
     expect(item?['action'], 'remove_bookmark');
-    expect(item?['bookmark_id'], 'b1');
+    expect(item?['data']['bookmark_id'], 'b1');
   });
 
   test('syncQueuedActions processes remove_bookmark items', () async {
-    await service.removeBookmark('b2');
+    await expectLater(service.removeBookmark('b2'), throwsA(anything));
     final counter = _CountingService();
     await counter.syncQueuedActions();
     expect(counter.ids.contains('b2'), isTrue);


### PR DESCRIPTION
## Summary
- improve BookmarkController toggle logic to revert state when offline
- queue removeBookmark actions using a `data` payload
- expose failures via exceptions so controllers can react
- update and expand bookmark tests for offline scenarios
- extend offline feed service tests for removeBookmark

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d840a1da0832db7658954bb7d7a19