### PR TITLE
Validate comment length before posting

### DIFF
--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import '../../../design_system/modern_ui_system.dart';
 import 'package:get/get.dart';
 import '../widgets/comment_thread.dart';
+import '../utils/comment_validation.dart';
 import '../models/post_comment.dart';
 import '../controllers/comments_controller.dart';
 import '../../../controllers/auth_controller.dart';
@@ -90,13 +91,23 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                 SizedBox(width: DesignTokens.sm(context)),
                 AnimatedButton(
                   onPressed: () async {
+                    final text = _controller.text.trim();
+                    if (!isValidComment(text)) {
+                      Get.snackbar(
+                        'error'.tr,
+                        'Comment must be between 1 and 2000 characters.',
+                        snackPosition: SnackPosition.BOTTOM,
+                      );
+                      return;
+                    }
+
                     final root = widget.rootComment;
                     final uid = auth.userId ?? '';
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value
                         : 'You';
                     final mentions = RegExp(r'(?:@)([A-Za-z0-9_]+)')
-                        .allMatches(_controller.text)
+                        .allMatches(text)
                         .map((m) => m.group(1)!)
                         .toSet()
                         .toList();
@@ -106,7 +117,7 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                       userId: uid,
                       username: uname,
                       parentId: root.id,
-                      content: _controller.text,
+                      content: text,
                     );
                     commentsController.replyToComment(comment);
                     await _notifyMentions(mentions, comment.id);

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -6,6 +6,7 @@ import '../models/feed_post.dart';
 import '../models/post_comment.dart';
 import '../../../controllers/auth_controller.dart';
 import '../widgets/comment_card.dart';
+import '../utils/comment_validation.dart';
 import '../widgets/post_card.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -101,12 +102,22 @@ class _PostDetailPageState extends State<PostDetailPage> {
                 SizedBox(width: DesignTokens.sm(context)),
                 AnimatedButton(
                   onPressed: () async {
+                    final text = _textController.text.trim();
+                    if (!isValidComment(text)) {
+                      Get.snackbar(
+                        'error'.tr,
+                        'Comment must be between 1 and 2000 characters.',
+                        snackPosition: SnackPosition.BOTTOM,
+                      );
+                      return;
+                    }
+
                     final uid = auth.userId ?? '';
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value
                         : 'You';
                     final mentions = RegExp(r'(?:@)([A-Za-z0-9_]+)')
-                        .allMatches(_textController.text)
+                        .allMatches(text)
                         .map((m) => m.group(1)!)
                         .toSet()
                         .toList();
@@ -115,7 +126,7 @@ class _PostDetailPageState extends State<PostDetailPage> {
                       postId: widget.post.id,
                       userId: uid,
                       username: uname,
-                      content: _textController.text,
+                      content: text,
                     );
                     commentsController.addComment(comment);
                     await _notifyMentions(mentions, comment.id);

--- a/lib/features/social_feed/utils/comment_validation.dart
+++ b/lib/features/social_feed/utils/comment_validation.dart
@@ -1,0 +1,8 @@
+const int commentMaxLength = 2000;
+
+/// Returns true if the comment text is non-empty and within the allowed length.
+bool isValidComment(String text) {
+  final trimmed = text.trim();
+  return trimmed.isNotEmpty && trimmed.length <= commentMaxLength;
+}
+

--- a/test/features/social_feed/comment_validation_test.dart
+++ b/test/features/social_feed/comment_validation_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myapp/features/social_feed/utils/comment_validation.dart';
+
+void main() {
+  test('valid comment passes validation', () {
+    expect(isValidComment('hello'), isTrue);
+  });
+
+  test('overlong comment fails validation', () {
+    final longText = 'a' * (commentMaxLength + 1);
+    expect(isValidComment(longText), isFalse);
+  });
+}
+


### PR DESCRIPTION
## Summary
- validate comment text before creating PostComment
- surface validation errors with `Get.snackbar`
- add helpers to check comment length
- test comment validation logic

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d84e5e6d4832d8a9b25be4481580f