### PR TITLE
Add comment loading skeletons

### DIFF
--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -81,8 +81,26 @@ class _PostDetailPageState extends State<PostDetailPage> {
         child: Column(
           children: [
             Expanded(
-              child: Obx(
-                () => OptimizedListView(
+              child: Obx(() {
+                if (_commentsController.isLoading) {
+                  return Column(
+                    children: [
+                      PostCard(post: widget.post),
+                      SizedBox(height: DesignTokens.sm(context)),
+                      ...List.generate(
+                        3,
+                        (_) => Padding(
+                          padding:
+                              EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                          child: SkeletonLoader(
+                            height: DesignTokens.xl(context),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                }
+                return OptimizedListView(
                   itemCount: _commentsController.comments.length + 1,
                   itemBuilder: (context, index) {
                     if (index == 0) return PostCard(post: widget.post);
@@ -92,8 +110,8 @@ class _PostDetailPageState extends State<PostDetailPage> {
                       child: CommentCard(comment: comment),
                     );
                   },
-                ),
-              ),
+                );
+              }),
             ),
             SizedBox(height: DesignTokens.sm(context)),
             Row(

--- a/test/features/social_feed/post_detail_page_test.dart
+++ b/test/features/social_feed/post_detail_page_test.dart
@@ -1,0 +1,57 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/social_feed/controllers/comments_controller.dart';
+import 'package:myapp/features/social_feed/models/feed_post.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+import 'package:myapp/features/social_feed/screens/post_detail_page.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/design_system/modern_ui_system.dart';
+
+class _DelayedService extends FeedService {
+  final Completer<List<PostComment>> completer = Completer<List<PostComment>>();
+  _DelayedService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          bookmarksCollectionId: 'bookmarks',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'link',
+        );
+
+  @override
+  Future<List<PostComment>> getComments(String postId) => completer.future;
+}
+
+void main() {
+  testWidgets('shows skeletons while loading', (tester) async {
+    final service = _DelayedService();
+    final controller = CommentsController(service: service);
+    Get.put(controller);
+
+    final post = FeedPost(
+      id: 'p1',
+      roomId: 'r',
+      userId: 'u',
+      username: 'user',
+      content: 'hi',
+    );
+
+    await tester.pumpWidget(GetMaterialApp(home: PostDetailPage(post: post)));
+    await tester.pump();
+
+    expect(find.byType(SkeletonLoader), findsWidgets);
+
+    service.completer.complete(<PostComment>[]);
+  });
+}


### PR DESCRIPTION
## Summary
- show skeleton placeholders in `PostDetailPage` while comments load
- test comment loading skeletons

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d861b88d8832d8002e7c101547453