### PR TITLE
Add realtime comments subscription

### DIFF
--- a/test/features/social_feed/comments_realtime_test.dart
+++ b/test/features/social_feed/comments_realtime_test.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+
+import 'package:myapp/features/social_feed/controllers/comments_controller.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+
+class FakeFeedService extends FeedService {
+  FakeFeedService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
+        );
+
+  @override
+  Future<List<PostComment>> getComments(String postId) async => [];
+}
+
+class FakeAuthController extends AuthController {
+  FakeAuthController() {
+    userId = 'u1';
+    client.setEndpoint('http://localhost').setProject('p');
+  }
+
+  @override
+  void onInit() {}
+
+  @override
+  Future<void> checkExistingSession({bool navigateOnMissing = true}) async {}
+}
+
+class FakeRealtime extends Realtime {
+  FakeRealtime() : super(Client());
+
+  final controller = StreamController<RealtimeMessage>.broadcast();
+
+  @override
+  RealtimeSubscription subscribe(List<String> channels) {
+    return RealtimeSubscription(
+      close: () async {},
+      channels: channels,
+      controller: controller,
+    );
+  }
+
+  void emit(RealtimeMessage message) => controller.add(message);
+}
+
+void main() {
+  test('realtime updates comments list', () async {
+    Get.testMode = true;
+    final realtime = FakeRealtime();
+    final service = FakeFeedService();
+    final controller = CommentsController(service: service, realtime: realtime);
+    Get.put<AuthController>(FakeAuthController());
+
+    await controller.loadComments('p1');
+
+    final comment = PostComment(
+      id: 'c1',
+      postId: 'p1',
+      userId: 'u',
+      username: 'user',
+      content: 'hi',
+    );
+
+    realtime.emit(
+      RealtimeMessage(
+        events: ['create'],
+        payload: {...comment.toJson(), '\$id': 'c1'},
+        channels: const [],
+        timestamp: DateTime.now().toIso8601String(),
+      ),
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.comments.length, 1);
+
+    realtime.emit(
+      RealtimeMessage(
+        events: ['update'],
+        payload: {...comment.toJson(), '\$id': 'c1', 'is_deleted': true},
+        channels: const [],
+        timestamp: DateTime.now().toIso8601String(),
+      ),
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.comments.isEmpty, isTrue);
+  });
+}
+


### PR DESCRIPTION
## Summary
- listen to realtime `post_comments` changes in CommentsController
- dispose realtime subscription
- cover realtime updates with unit test using a mocked stream

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d862cd254832d925cf76e4b6d1ce3