### PR TITLE
Add semantics to send buttons

### DIFF
--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -89,8 +89,11 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                   ),
                 ),
                 SizedBox(width: DesignTokens.sm(context)),
-                AnimatedButton(
-                  onPressed: () async {
+                AccessibilityWrapper(
+                  semanticLabel: 'Send reply',
+                  isButton: true,
+                  child: AnimatedButton(
+                    onPressed: () async {
                     final text = _controller.text.trim();
                     if (!isValidComment(text)) {
                       Get.snackbar(
@@ -123,7 +126,8 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                     await _notifyMentions(mentions, comment.id);
                     _controller.clear();
                   },
-                  child: const Text('Send'),
+                    child: const Text('Send'),
+                  ),
                 ),
               ],
             ),

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -106,39 +106,43 @@ class _PostDetailPageState extends State<PostDetailPage> {
                   ),
                 ),
                 SizedBox(width: DesignTokens.sm(context)),
-                AnimatedButton(
-                  onPressed: () async {
-                    final text = _textController.text.trim();
-                    if (!isValidComment(text)) {
-                      Get.snackbar(
-                        'error'.tr,
-                        'Comment must be between 1 and 2000 characters.',
-                        snackPosition: SnackPosition.BOTTOM,
-                      );
-                      return;
-                    }
+                AccessibilityWrapper(
+                  semanticLabel: 'Send comment',
+                  isButton: true,
+                  child: AnimatedButton(
+                    onPressed: () async {
+                      final text = _textController.text.trim();
+                      if (!isValidComment(text)) {
+                        Get.snackbar(
+                          'error'.tr,
+                          'Comment must be between 1 and 2000 characters.',
+                          snackPosition: SnackPosition.BOTTOM,
+                        );
+                        return;
+                      }
 
-                    final uid = auth.userId ?? '';
-                    final uname = auth.username.value.isNotEmpty
-                        ? auth.username.value
-                        : 'You';
-                    final mentions = RegExp(r'(?:@)([A-Za-z0-9_]+)')
-                        .allMatches(text)
-                        .map((m) => m.group(1)!)
-                        .toSet()
-                        .toList();
-                    final comment = PostComment(
-                      id: DateTime.now().toIso8601String(),
-                      postId: widget.post.id,
-                      userId: uid,
-                      username: uname,
-                      content: text,
-                    );
-                    _commentsController.addComment(comment);
-                    await _notifyMentions(mentions, comment.id);
-                    _textController.clear();
-                  },
-                  child: const Text('Send'),
+                      final uid = auth.userId ?? '';
+                      final uname = auth.username.value.isNotEmpty
+                          ? auth.username.value
+                          : 'You';
+                      final mentions = RegExp(r'(?:@)([A-Za-z0-9_]+)')
+                          .allMatches(text)
+                          .map((m) => m.group(1)!)
+                          .toSet()
+                          .toList();
+                      final comment = PostComment(
+                        id: DateTime.now().toIso8601String(),
+                        postId: widget.post.id,
+                        userId: uid,
+                        username: uname,
+                        content: text,
+                      );
+                      _commentsController.addComment(comment);
+                      await _notifyMentions(mentions, comment.id);
+                      _textController.clear();
+                    },
+                    child: const Text('Send'),
+                  ),
                 ),
               ],
             ),

--- a/test/features/social_feed/send_button_semantics_test.dart
+++ b/test/features/social_feed/send_button_semantics_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/social_feed/screens/post_detail_page.dart';
+import 'package:myapp/features/social_feed/screens/comment_thread_page.dart';
+import 'package:myapp/features/social_feed/models/feed_post.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+import 'package:myapp/features/social_feed/controllers/comments_controller.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+
+class _FakeService extends FeedService {
+  _FakeService()
+      : super(
+          databases: Databases(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          connectivity: Connectivity(),
+        );
+
+  @override
+  Future<List<PostComment>> getComments(String postId) async => [];
+
+  @override
+  Future<void> createComment(PostComment comment) async {}
+}
+
+class _TestAuthController extends AuthController {
+  @override
+  void onInit() {
+    userId = 'u1';
+    username.value = 'tester';
+  }
+
+  @override
+  Future<void> checkExistingSession({bool navigateOnMissing = true}) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    Get.testMode = true;
+    Get.put<AuthController>(_TestAuthController());
+    Get.put<CommentsController>(CommentsController(service: _FakeService()));
+  });
+
+  tearDown(Get.reset);
+
+  testWidgets('PostDetailPage send button has semantics', (tester) async {
+    final post = FeedPost(
+      id: 'p1',
+      roomId: 'r1',
+      userId: 'u1',
+      username: 'tester',
+      content: 'content',
+    );
+    await tester.pumpWidget(MaterialApp(home: PostDetailPage(post: post)));
+    expect(find.bySemanticsLabel('Send comment'), findsOneWidget);
+  });
+
+  testWidgets('CommentThreadPage send button has semantics', (tester) async {
+    final comment = PostComment(
+      id: 'c1',
+      postId: 'p1',
+      userId: 'u1',
+      username: 'tester',
+      content: 'hi',
+    );
+    await tester.pumpWidget(MaterialApp(home: CommentThreadPage(rootComment: comment)));
+    expect(find.bySemanticsLabel('Send reply'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add semantic labels for "Send" buttons in post and comment pages
- test semantics labels in PostDetailPage & CommentThreadPage

## Testing
- `flutter test` *(fails: flutter not found)*
- `flutter analyze` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d865a8130832d860e1044b1cf08dd