### PR TITLE
Fix comment submission entity handling

### DIFF
--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -11,6 +11,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../../notifications/services/notification_service.dart';
 import '../../../utils/logger.dart';
 import 'package:flutter/foundation.dart';
+import 'package:html_unescape/html_unescape.dart';
 
 class CommentThreadPage extends StatefulWidget {
   final PostComment rootComment;
@@ -124,8 +125,9 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value
                         : 'You';
+                    final sanitized = HtmlUnescape().convert(text);
                     final mentions = RegExp(r'(?:@)([A-Za-z0-9_]+)')
-                        .allMatches(text)
+                        .allMatches(sanitized)
                         .map((m) => m.group(1)!)
                         .toSet()
                         .toList();
@@ -135,7 +137,7 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                       userId: uid,
                       username: uname,
                       parentId: root.id,
-                      content: text,
+                      content: sanitized,
                     );
                     commentsController.replyToComment(comment);
                     await _notifyMentions(mentions, comment.id);

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -13,6 +13,7 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../../notifications/services/notification_service.dart';
 import '../../../utils/logger.dart';
 import 'package:flutter/foundation.dart';
+import 'package:html_unescape/html_unescape.dart';
 
 class PostDetailPage extends StatefulWidget {
   final FeedPost post;
@@ -158,8 +159,9 @@ class _PostDetailPageState extends State<PostDetailPage> {
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value
                         : 'You';
+                    final sanitized = HtmlUnescape().convert(text);
                     final mentions = RegExp(r'(?:@)([A-Za-z0-9_]+)')
-                        .allMatches(text)
+                        .allMatches(sanitized)
                         .map((m) => m.group(1)!)
                         .toSet()
                         .toList();
@@ -168,7 +170,7 @@ class _PostDetailPageState extends State<PostDetailPage> {
                       postId: widget.post.id,
                       userId: uid,
                       username: uname,
-                      content: text,
+                      content: sanitized,
                     );
                     _commentsController.addComment(comment);
                     await _notifyMentions(mentions, comment.id);

--- a/test/features/social_feed/post_detail_page_widget_test.dart
+++ b/test/features/social_feed/post_detail_page_widget_test.dart
@@ -175,6 +175,31 @@ void main() {
     expect(find.text('hello'), findsOneWidget);
   });
 
+  testWidgets('HTML entities are unescaped before submission', (tester) async {
+    final service = TestFeedService();
+    final controller = CommentsController(service: service);
+    Get.put<CommentsController>(controller);
+    Get.put<NotificationService>(MockNotificationService());
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        theme: MD3ThemeSystem.createTheme(
+          seedColor: Colors.blue,
+          brightness: Brightness.light,
+        ),
+        home: PostDetailPage(post: post),
+      ),
+    );
+
+    await tester.pump();
+    const input = 'hello &amp; world';
+    await tester.enterText(find.byType(TextField), input);
+    await tester.tap(find.text('Send'));
+    await tester.pump();
+
+    expect(service.commentStore.first.content, 'hello & world');
+  });
+
   testWidgets('displays skeleton loaders while isLoading true', (tester) async {
     final service = DelayedFeedService();
     final controller = FeedController(service: service);


### PR DESCRIPTION
## Summary
- sanitize comment text in post detail and comment thread screens
- ensure HTML entities are unescaped before building `PostComment`
- test that unescaping happens when submitting comments

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da3cc1814832dbda2b00040745e67