### PR TITLE
Add realtime comments subscription

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -122,8 +122,9 @@ class CommentsController extends GetxController {
           _comments.add(comment);
           _likeCounts[id] = comment.likeCount;
         }
-      } else if (event.events.any((e) => e.contains('.update')) &&
-          payload['is_deleted'] == true) {
+      } else if ((event.events.any((e) => e.contains('.update')) &&
+              payload['is_deleted'] == true) ||
+          event.events.any((e) => e.contains('.delete'))) {
         _comments.removeWhere((c) => c.id == id);
         _likedIds.remove(id);
         _likeCounts.remove(id);
@@ -131,9 +132,14 @@ class CommentsController extends GetxController {
     });
   }
 
+  void disposeSubscription() {
+    _subscription?.close();
+    _subscription = null;
+  }
+
   @override
   void onClose() {
-    _subscription?.close();
+    disposeSubscription();
     super.onClose();
   }
 }

--- a/test/features/social_feed/comments_realtime_test.dart
+++ b/test/features/social_feed/comments_realtime_test.dart
@@ -78,6 +78,18 @@ void main() {
     realtime.emit(
       RealtimeMessage(
         events: ['create'],
+        payload: {...comment.toJson(), '\$id': 'c1', 'post_id': 'other'},
+        channels: const [],
+        timestamp: DateTime.now().toIso8601String(),
+      ),
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.comments.isEmpty, isTrue);
+
+    realtime.emit(
+      RealtimeMessage(
+        events: ['create'],
         payload: {...comment.toJson(), '\$id': 'c1'},
         channels: const [],
         timestamp: DateTime.now().toIso8601String(),
@@ -89,8 +101,8 @@ void main() {
 
     realtime.emit(
       RealtimeMessage(
-        events: ['update'],
-        payload: {...comment.toJson(), '\$id': 'c1', 'is_deleted': true},
+        events: ['delete'],
+        payload: {...comment.toJson(), '\$id': 'c1'},
         channels: const [],
         timestamp: DateTime.now().toIso8601String(),
       ),
@@ -98,6 +110,32 @@ void main() {
 
     await Future<void>.delayed(Duration.zero);
     expect(controller.comments.isEmpty, isTrue);
+
+    realtime.emit(
+      RealtimeMessage(
+        events: ['create'],
+        payload: {...comment.toJson(), '\$id': 'c1'},
+        channels: const [],
+        timestamp: DateTime.now().toIso8601String(),
+      ),
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.comments.length, 1);
+
+    controller.disposeSubscription();
+
+    realtime.emit(
+      RealtimeMessage(
+        events: ['delete'],
+        payload: {...comment.toJson(), '\$id': 'c1'},
+        channels: const [],
+        timestamp: DateTime.now().toIso8601String(),
+      ),
+    );
+
+    await Future<void>.delayed(Duration.zero);
+    expect(controller.comments.length, 1);
   });
 }
 


### PR DESCRIPTION
## Summary
- handle comment deletions via realtime
- expose `disposeSubscription()` to clean up
- ignore events for other posts
- test realtime add/remove and cleanup logic

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684da3ed2e34832db24398af72ebaa15