### PR TITLE
Ensure comments load once

### DIFF
--- a/test/features/social_feed/post_detail_page_widget_test.dart
+++ b/test/features/social_feed/post_detail_page_widget_test.dart
@@ -66,6 +66,19 @@ class DelayedCommentService extends TestFeedService {
   }
 }
 
+class CountingService extends TestFeedService {
+  int calls = 0;
+
+  @override
+  Future<List<PostComment>> getComments(String postId) async {
+    calls++;
+    return [];
+  }
+
+  @override
+  Future<PostLike?> getUserLike(String itemId, String userId) async => null;
+}
+
 class MockNotificationService extends NotificationService {
   MockNotificationService()
       : super(
@@ -247,5 +260,26 @@ void main() {
     expect(find.byType(SkeletonLoader), findsWidgets);
 
     await tester.pump(const Duration(milliseconds: 150));
+  });
+
+  testWidgets('loadComments runs only once on build', (tester) async {
+    final service = CountingService();
+    final controller = CommentsController(service: service);
+    Get.put<CommentsController>(controller);
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        theme: MD3ThemeSystem.createTheme(
+          seedColor: Colors.blue,
+          brightness: Brightness.light,
+        ),
+        home: PostDetailPage(post: post),
+      ),
+    );
+
+    await tester.pump();
+    await tester.pump();
+
+    expect(service.calls, 1);
   });
 }


### PR DESCRIPTION
## Summary
- add `CountingService` test helper
- verify PostDetailPage loads comments only once

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db10cec34832d88bb7ba412ddcc5e