### PR TITLE
Fix comment thread loading

### DIFF
--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -24,6 +24,17 @@ class CommentThreadPage extends StatefulWidget {
 class _CommentThreadPageState extends State<CommentThreadPage> {
   final _controller = TextEditingController();
 
+  @override
+  void initState() {
+    super.initState();
+    final commentsController = Get.find<CommentsController>();
+    if (commentsController.comments.isEmpty ||
+        commentsController.comments.first.postId !=
+            widget.rootComment.postId) {
+      commentsController.loadComments(widget.rootComment.postId);
+    }
+  }
+
   Future<void> _notifyParentAuthor(String authorId, String commentId) async {
     if (!Get.isRegistered<NotificationService>()) return;
     try {

--- a/test/features/social_feed/comment_thread_page_widget_test.dart
+++ b/test/features/social_feed/comment_thread_page_widget_test.dart
@@ -162,4 +162,35 @@ void main() {
     expect(controller.comments.length, 2);
     expect(find.text('hello'), findsOneWidget);
   });
+
+  testWidgets('replies shown when opening thread without preloading',
+      (tester) async {
+    final service = TestFeedService();
+    final reply = PostComment(
+      id: 'c2',
+      postId: root.postId,
+      userId: 'u2',
+      username: 'other',
+      parentId: root.id,
+      content: 'reply',
+    );
+    service.commentStore.addAll([root, reply]);
+    final controller = CommentsController(service: service);
+    Get.put<CommentsController>(controller);
+    Get.put<NotificationService>(MockNotificationService());
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        theme: MD3ThemeSystem.createTheme(
+          seedColor: Colors.blue,
+          brightness: Brightness.light,
+        ),
+        home: CommentThreadPage(rootComment: root),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('reply'), findsOneWidget);
+  });
 }


### PR DESCRIPTION
## Summary
- load comments in CommentThreadPage initState when needed
- test thread auto-loads replies

## Testing
- `flutter test test/features/social_feed/comment_thread_page_widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db2e9f0dc832d86d1c5af1db9f64f