### PR TITLE
Add widget tests for comments and threads

### DIFF
--- a/test/features/social_feed/comment_thread_page_widget_test.dart
+++ b/test/features/social_feed/comment_thread_page_widget_test.dart
@@ -193,4 +193,44 @@ void main() {
 
     expect(find.text('reply'), findsOneWidget);
   });
+
+  testWidgets('nested replies display correctly', (tester) async {
+    final service = TestFeedService();
+    final reply1 = PostComment(
+      id: 'c2',
+      postId: root.postId,
+      userId: 'u2',
+      username: 'other',
+      parentId: root.id,
+      content: 'first',
+    );
+    final reply2 = PostComment(
+      id: 'c3',
+      postId: root.postId,
+      userId: 'u3',
+      username: 'third',
+      parentId: reply1.id,
+      content: 'second',
+    );
+    service.commentStore.addAll([root, reply1, reply2]);
+    final controller = CommentsController(service: service);
+    await controller.loadComments(root.postId);
+    Get.put<CommentsController>(controller);
+    Get.put<NotificationService>(MockNotificationService());
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        theme: MD3ThemeSystem.createTheme(
+          seedColor: Colors.blue,
+          brightness: Brightness.light,
+        ),
+        home: CommentThreadPage(rootComment: root),
+      ),
+    );
+
+    await tester.pump();
+
+    expect(find.text('first'), findsOneWidget);
+    expect(find.text('second'), findsOneWidget);
+  });
 }

--- a/test/features/social_feed/post_detail_page_widget_test.dart
+++ b/test/features/social_feed/post_detail_page_widget_test.dart
@@ -282,4 +282,34 @@ void main() {
 
     expect(service.calls, 1);
   });
+
+  testWidgets('submitting comment increments feed count', (tester) async {
+    final service = TestFeedService();
+    final feed = FeedController(service: service);
+    service.postStore.add(post);
+    await feed.loadPosts('r1');
+    Get.put<FeedController>(feed);
+
+    final controller = CommentsController(service: service);
+    Get.put<CommentsController>(controller);
+    Get.put<NotificationService>(MockNotificationService());
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        theme: MD3ThemeSystem.createTheme(
+          seedColor: Colors.blue,
+          brightness: Brightness.light,
+        ),
+        home: PostDetailPage(post: post),
+      ),
+    );
+
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), 'new comment');
+    await tester.tap(find.text('Send'));
+    await tester.pump();
+
+    expect(find.text('new comment'), findsOneWidget);
+    expect(feed.postCommentCount(post.id), 1);
+  });
 }


### PR DESCRIPTION
## Summary
- verify submitting a comment updates feed count on `PostDetailPage`
- ensure nested replies display correctly in `CommentThreadPage`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db6502340832db4c55a8a7387ec11