### PR TITLE
Add social feed unit and widget tests

### DIFF
--- a/test/features/social_feed/comments_controller_counts_test.dart
+++ b/test/features/social_feed/comments_controller_counts_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/social_feed/controllers/comments_controller.dart';
+import 'package:myapp/features/social_feed/controllers/feed_controller.dart';
+import 'package:myapp/features/social_feed/models/feed_post.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/features/profile/services/activity_service.dart';
+
+class _RecordingFeedService extends FeedService {
+  _RecordingFeedService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
+        );
+
+  final List<PostComment> store = [];
+
+  @override
+  Future<List<PostComment>> getComments(String postId) async {
+    return store.where((c) => c.postId == postId).toList();
+  }
+
+  @override
+  Future<void> createComment(PostComment comment) async {
+    store.add(comment);
+  }
+
+  @override
+  Future<void> deleteComment(PostComment comment) async {
+    store.removeWhere((c) => c.id == comment.id);
+  }
+}
+
+class _DummyActivityService extends ActivityService {
+  _DummyActivityService()
+      : super(databases: Databases(Client()), databaseId: 'db', collectionId: 'act');
+
+  @override
+  Future<void> logActivity(String userId, String actionType, {String? itemId, String? itemType}) async {}
+}
+
+void main() {
+  test('reply add/delete updates counts', () async {
+    Get.testMode = true;
+    Get.put<ActivityService>(_DummyActivityService());
+    final service = _RecordingFeedService();
+    final feed = FeedController(service: service);
+    Get.put(feed);
+
+    final post = FeedPost(id: 'p1', roomId: 'room', userId: 'u', username: 'user', content: 'post');
+    service.store.add(PostComment(id: 'parent', postId: 'p1', userId: 'u', username: 'user', content: 'parent'));
+    await feed.loadPosts('room');
+    final controller = CommentsController(service: service);
+    await controller.loadComments('p1');
+
+    final reply = PostComment(id: 'r1', postId: 'p1', parentId: 'parent', userId: 'u2', username: 'other', content: 'hi');
+    await controller.addComment(reply);
+    expect(feed.postCommentCount('p1'), 1);
+    expect(controller.comments.firstWhere((c) => c.id == 'parent').replyCount, 1);
+
+    await controller.deleteComment('r1');
+    expect(feed.postCommentCount('p1'), 0);
+    expect(controller.comments.firstWhere((c) => c.id == 'parent').replyCount, 0);
+
+    Get.reset();
+  });
+}

--- a/test/features/social_feed/feed_service_create_comment_test.dart
+++ b/test/features/social_feed/feed_service_create_comment_test.dart
@@ -1,0 +1,172 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:hive/hive.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:appwrite/models.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+import 'package:myapp/features/notifications/services/notification_service.dart';
+
+class _RecordingFunctions extends Functions {
+  _RecordingFunctions() : super(Client());
+  String? lastFunctionId;
+  @override
+  Future<Execution> createExecution({
+    required String functionId,
+    String? body,
+    Map<String, dynamic>? xHeaders,
+    String? path,
+  }) async {
+    lastFunctionId = functionId;
+    return Execution.fromMap({
+      '\$id': '1',
+      '\$createdAt': '',
+      '\$updatedAt': '',
+      '\$permissions': [],
+      'functionId': functionId,
+      'trigger': 'http',
+      'status': 'completed',
+      'requestMethod': 'GET',
+      'requestPath': '/',
+      'requestHeaders': [],
+      'responseStatusCode': 200,
+      'responseBody': '',
+      'responseHeaders': [],
+      'logs': '',
+      'errors': '',
+      'duration': 0.0,
+    });
+  }
+}
+
+class _FakeDatabases extends Databases {
+  _FakeDatabases() : super(Client());
+
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) async {
+    return Document.fromMap({
+      '\$id': documentId,
+      '\$collectionId': collectionId,
+      '\$databaseId': databaseId,
+      '\$createdAt': '',
+      '\$updatedAt': '',
+      '\$permissions': [],
+      ...data,
+    });
+  }
+
+  @override
+  Future<Document> getDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+  }) async {
+    return Document.fromMap({
+      '\$id': documentId,
+      '\$collectionId': collectionId,
+      '\$databaseId': databaseId,
+      '\$createdAt': '',
+      '\$updatedAt': '',
+      '\$permissions': [],
+      'user_id': 'post_owner',
+    });
+  }
+}
+
+class _RecordingNotificationService extends NotificationService {
+  int calls = 0;
+  _RecordingNotificationService()
+      : super(
+          databases: Databases(Client()),
+          databaseId: 'db',
+          collectionId: 'notifications',
+          connectivity: Connectivity(),
+        );
+  @override
+  Future<void> createNotification(
+    String userId,
+    String actorId,
+    String actionType, {
+    String? itemId,
+    String? itemType,
+  }) async {
+    calls++;
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late Directory dir;
+  late FeedService service;
+  late _RecordingNotificationService notification;
+  late _RecordingFunctions functions;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    for (final box in [
+      'posts',
+      'comments',
+      'action_queue',
+      'post_queue',
+      'bookmarks',
+      'hashtags',
+      'preferences',
+      'notifications',
+      'notification_queue'
+    ]) {
+      await Hive.openBox(box);
+    }
+    functions = _RecordingFunctions();
+    notification = _RecordingNotificationService();
+    Get.put<NotificationService>(notification);
+    service = FeedService(
+      databases: _FakeDatabases(),
+      storage: Storage(Client()),
+      functions: functions,
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'fetch_link_metadata',
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+    Get.reset();
+  });
+
+  test('createComment increments count and notifies owner', () async {
+    Hive.box('posts').put('key', [
+      {'id': 'p1', 'comment_count': 0}
+    ]);
+    final comment = PostComment(
+      id: 'c1',
+      postId: 'p1',
+      userId: 'actor',
+      username: 'name',
+      content: 'hi',
+    );
+
+    await service.createComment(comment);
+
+    expect(functions.lastFunctionId, 'increment_comment_count');
+    final cached = Hive.box('posts').get('key') as List;
+    expect(cached.first['comment_count'], 1);
+    expect(notification.calls, 1);
+  });
+}

--- a/test/features/social_feed/offline_queue_replay_test.dart
+++ b/test/features/social_feed/offline_queue_replay_test.dart
@@ -1,0 +1,123 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:get/get.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+
+class _OfflineDatabases extends Databases {
+  _OfflineDatabases() : super(Client());
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) async {
+    return Future.error('offline');
+  }
+}
+
+class _RecordingService extends FeedService {
+  final List<String> created = [];
+  _RecordingService()
+      : super(
+          databases: _FakeDatabases(),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          bookmarksCollectionId: 'bookmarks',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
+        );
+
+  @override
+  Future<void> createComment(PostComment comment) async {
+    created.add(comment.id);
+  }
+}
+
+class _FakeDatabases extends Databases {
+  _FakeDatabases() : super(Client());
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) async {
+    return Document.fromMap({
+      '\$id': documentId,
+      '\$collectionId': collectionId,
+      '\$databaseId': databaseId,
+      '\$createdAt': '',
+      '\$updatedAt': '',
+      '\$permissions': [],
+      ...data,
+    });
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late Directory dir;
+  late FeedService offline;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    for (final box in [
+      'posts',
+      'comments',
+      'action_queue',
+      'post_queue',
+      'bookmarks',
+      'hashtags',
+      'preferences'
+    ]) {
+      await Hive.openBox(box);
+    }
+    offline = FeedService(
+      databases: _OfflineDatabases(),
+      storage: Storage(Client()),
+      functions: Functions(Client()),
+      databaseId: 'db',
+      postsCollectionId: 'posts',
+      commentsCollectionId: 'comments',
+      likesCollectionId: 'likes',
+      repostsCollectionId: 'reposts',
+      bookmarksCollectionId: 'bookmarks',
+      connectivity: Connectivity(),
+      linkMetadataFunctionId: 'fetch_link_metadata',
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('queued comment keeps id after sync', () async {
+    final comment = PostComment(
+      id: 'offline1',
+      postId: 'post',
+      userId: 'u',
+      username: 'user',
+      content: 'hi',
+    );
+    await offline.createComment(comment);
+
+    final online = _RecordingService();
+    await online.syncQueuedActions();
+
+    expect(online.created.contains('offline1'), isTrue);
+  });
+}

--- a/test/features/social_feed/reaction_bar_update_test.dart
+++ b/test/features/social_feed/reaction_bar_update_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/social_feed/widgets/post_card.dart';
+import 'package:myapp/features/social_feed/controllers/feed_controller.dart';
+import 'package:myapp/features/social_feed/controllers/comments_controller.dart';
+import 'package:myapp/features/social_feed/models/feed_post.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/features/profile/services/activity_service.dart';
+
+class _FakeService extends FeedService {
+  _FakeService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
+        );
+
+  final List<FeedPost> posts = [];
+  final List<PostComment> comments = [];
+
+  @override
+  Future<List<FeedPost>> getPosts(String roomId, {List<String> blockedIds = const []}) async {
+    return posts.where((p) => p.roomId == roomId).toList();
+  }
+
+  @override
+  Future<void> createPost(FeedPost post) async {
+    posts.add(post);
+  }
+
+  @override
+  Future<List<PostComment>> getComments(String postId) async {
+    return comments.where((c) => c.postId == postId).toList();
+  }
+
+  @override
+  Future<void> createComment(PostComment comment) async {
+    comments.add(comment);
+  }
+
+  @override
+  Future<void> deleteComment(PostComment comment) async {
+    comments.removeWhere((c) => c.id == comment.id);
+  }
+}
+
+class _DummyActivityService extends ActivityService {
+  _DummyActivityService()
+      : super(databases: Databases(Client()), databaseId: 'db', collectionId: 'act');
+  @override
+  Future<void> logActivity(String userId, String actionType, {String? itemId, String? itemType}) async {}
+}
+
+void main() {
+  testWidgets('reaction bar updates on comment add and delete', (tester) async {
+    Get.testMode = true;
+    Get.put<ActivityService>(_DummyActivityService());
+    final service = _FakeService();
+    final feed = FeedController(service: service);
+    final comments = CommentsController(service: service);
+    Get.put(feed);
+    Get.put(comments);
+
+    final post = FeedPost(id: 'p1', roomId: 'room', userId: 'u', username: 'user', content: 'post');
+    service.posts.add(post);
+    await feed.loadPosts('room');
+
+    await tester.pumpWidget(MaterialApp(home: PostCard(post: post)));
+    await tester.pump();
+    expect(find.text('0'), findsWidgets);
+
+    final comment = PostComment(id: 'c1', postId: 'p1', userId: 'u2', username: 'other', content: 'hi');
+    await comments.addComment(comment);
+    await tester.pump();
+    expect(find.text('1'), findsWidgets);
+
+    await comments.deleteComment('c1');
+    await tester.pump();
+    expect(find.text('0'), findsWidgets);
+
+    Get.reset();
+  });
+}

--- a/test/features/social_feed/realtime_ui_update_test.dart
+++ b/test/features/social_feed/realtime_ui_update_test.dart
@@ -1,0 +1,97 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:myapp/features/social_feed/screens/comment_thread_page.dart';
+import 'package:myapp/features/social_feed/controllers/comments_controller.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+import 'package:myapp/features/profile/services/activity_service.dart';
+
+class _FakeFeedService extends FeedService {
+  _FakeFeedService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
+        );
+  final List<PostComment> comments = [];
+  @override
+  Future<List<PostComment>> getComments(String postId) async {
+    return comments.where((c) => c.postId == postId).toList();
+  }
+}
+
+class _FakeAuth extends AuthController {
+  _FakeAuth() {
+    userId = 'u1';
+    client.setEndpoint('http://localhost').setProject('p');
+  }
+  @override
+  void onInit() {}
+  @override
+  Future<void> checkExistingSession({bool navigateOnMissing = true}) async {}
+}
+
+class _FakeRealtime extends Realtime {
+  _FakeRealtime() : super(Client());
+  final controller = StreamController<RealtimeMessage>.broadcast();
+  @override
+  RealtimeSubscription subscribe(List<String> channels) {
+    return RealtimeSubscription(
+      close: () async {},
+      channels: channels,
+      controller: controller,
+    );
+  }
+  void emit(RealtimeMessage m) => controller.add(m);
+}
+
+class _DummyActivityService extends ActivityService {
+  _DummyActivityService()
+      : super(databases: Databases(Client()), databaseId: 'db', collectionId: 'a');
+  @override
+  Future<void> logActivity(String userId, String actionType, {String? itemId, String? itemType}) async {}
+}
+
+void main() {
+  testWidgets('ui updates from realtime events', (tester) async {
+    Get.testMode = true;
+    Get.put<ActivityService>(_DummyActivityService());
+    final realtime = _FakeRealtime();
+    final service = _FakeFeedService();
+    final controller = CommentsController(service: service, realtime: realtime);
+    final auth = _FakeAuth();
+    Get.put<AuthController>(auth);
+    Get.put<CommentsController>(controller);
+
+    final root = PostComment(id: 'c1', postId: 'p1', userId: 'u', username: 'root', content: 'root');
+    service.comments.add(root);
+    await controller.loadComments('p1');
+
+    await tester.pumpWidget(GetMaterialApp(home: CommentThreadPage(rootComment: root)));
+    await tester.pump();
+    expect(find.text('new'), findsNothing);
+
+    final newComment = PostComment(id: 'new', postId: 'p1', userId: 'u2', username: 'other', content: 'new');
+    realtime.emit(RealtimeMessage(events: ['create'], payload: {...newComment.toJson(), '\$id': 'new'}, channels: const [], timestamp: DateTime.now().toIso8601String()));
+    await tester.pump();
+    expect(find.text('new'), findsOneWidget);
+
+    realtime.emit(RealtimeMessage(events: ['delete'], payload: {'post_id': 'p1', '\$id': 'new'}, channels: const [], timestamp: DateTime.now().toIso8601String()));
+    await tester.pump();
+    expect(find.text('new'), findsNothing);
+
+    Get.reset();
+  });
+}


### PR DESCRIPTION
## Summary
- test FeedService.createComment comment count and notification calls
- verify CommentsController keeps post and reply counts updated
- ensure offline queued comments keep id during sync
- widget test reaction bar updates on comment events
- realtime widget test for live comment updates

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db719ff58832d8feb1b200232f135