### PR TITLE
Update comment and reply counters

### DIFF
--- a/lib/features/social_feed/widgets/comment_card.dart
+++ b/lib/features/social_feed/widgets/comment_card.dart
@@ -124,7 +124,7 @@ class CommentCard extends StatelessWidget {
               target: ReactionTarget.comment,
               isLiked: controller.isCommentLiked(comment.id),
               likeCount: controller.commentLikeCount(comment.id),
-              commentCount: comment.replyCount,
+              commentCount: controller.commentReplyCount(comment.id),
               repostCount: 0,
             ),
           ],


### PR DESCRIPTION
## Summary
- keep local comment counts in sync with FeedController
- track comment reply counts for realtime updates
- show live reply count in `CommentCard`

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684db8e71188832dbcb2e7b0e3e5de48