### PR TITLE
refactor: token-based sizing for PostCard preview

### DIFF
--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -222,8 +222,8 @@ class PostCard extends StatelessWidget {
                           padding: EdgeInsets.only(right: DesignTokens.sm(context)),
                           child: SafeNetworkImage(
                             imageUrl: post.linkMetadata!['image'] as String?,
-                            width: 60,
-                            height: 60,
+                            width: DesignTokens.spacing(context, 60),
+                            height: DesignTokens.spacing(context, 60),
                             fit: BoxFit.cover,
                           ),
                         ),


### PR DESCRIPTION
## Summary
- use `DesignTokens.spacing` for link preview thumbnail size

## Testing
- `flutter test` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb11a1e0832dba1a9d658ae5ba90