### PR TITLE
Move mention notifications to social feed service

### DIFF
--- a/lib/bindings/feed_binding.dart
+++ b/lib/bindings/feed_binding.dart
@@ -8,7 +8,7 @@ import '../features/social_feed/controllers/feed_controller.dart';
 import '../features/social_feed/controllers/comments_controller.dart';
 import '../features/bookmarks/controllers/bookmark_controller.dart';
 import 'package:appwrite/appwrite.dart' as appwrite;
-import '../features/notifications/services/mention_service.dart';
+import '../features/social_feed/services/mention_service.dart';
 import '../features/notifications/services/notification_service.dart';
 
 class FeedBinding extends Bindings {

--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -9,7 +9,7 @@ import '../widgets/comment_card.dart';
 import '../../../controllers/auth_controller.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
-import '../../notifications/services/mention_service.dart';
+import '../services/mention_service.dart';
 import '../../../utils/logger.dart';
 import 'package:flutter/foundation.dart';
 import 'package:html_unescape/html_unescape.dart';
@@ -144,9 +144,8 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                     commentsController.replyToComment(comment);
                     await Get.find<MentionService>().notifyMentions(
                       mentions,
-                      actorId: uid,
-                      itemId: comment.id,
-                      itemType: 'comment',
+                      comment.id,
+                      'comment',
                     );
                     await _notifyParentAuthor(root.userId, root.id);
                     _controller.clear();

--- a/lib/features/social_feed/screens/compose_post_page.dart
+++ b/lib/features/social_feed/screens/compose_post_page.dart
@@ -5,7 +5,7 @@ import 'package:image_picker/image_picker.dart';
 import 'package:validators/validators.dart';
 import 'package:html_unescape/html_unescape.dart';
 import '../../../utils/logger.dart';
-import '../../notifications/services/mention_service.dart';
+import '../services/mention_service.dart';
 import 'package:flutter/foundation.dart';
 import '../../../design_system/modern_ui_system.dart';
 import '../controllers/feed_controller.dart';
@@ -132,9 +132,8 @@ class _ComposePostPageState extends State<ComposePostPage> {
                       );
                       await Get.find<MentionService>().notifyMentions(
                         mentions,
-                        actorId: uid,
-                        itemId: feedController.posts.first.id,
-                        itemType: 'post',
+                        feedController.posts.first.id,
+                        'post',
                       );
                     } else if (_image != null) {
                       await feedController.createPostWithImage(
@@ -148,9 +147,8 @@ class _ComposePostPageState extends State<ComposePostPage> {
                       );
                       await Get.find<MentionService>().notifyMentions(
                         mentions,
-                        actorId: uid,
-                        itemId: feedController.posts.first.id,
-                        itemType: 'post',
+                        feedController.posts.first.id,
+                        'post',
                       );
                     } else {
                       final post = FeedPost(
@@ -165,9 +163,8 @@ class _ComposePostPageState extends State<ComposePostPage> {
                       await feedController.createPost(post);
                       await Get.find<MentionService>().notifyMentions(
                         mentions,
-                        actorId: uid,
-                        itemId: post.id,
-                        itemType: 'post',
+                        post.id,
+                        'post',
                       );
                     }
                     Get.back();

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -9,7 +9,7 @@ import '../widgets/comment_card.dart';
 import '../utils/comment_validation.dart';
 import '../widgets/post_card.dart';
 import '../../../utils/logger.dart';
-import '../../notifications/services/mention_service.dart';
+import '../services/mention_service.dart';
 import 'package:flutter/foundation.dart';
 import 'package:html_unescape/html_unescape.dart';
 
@@ -147,9 +147,8 @@ class _PostDetailPageState extends State<PostDetailPage> {
                     commentsController.addComment(comment);
                     await Get.find<MentionService>().notifyMentions(
                       mentions,
-                      actorId: uid,
-                      itemId: comment.id,
-                      itemType: 'comment',
+                      comment.id,
+                      'comment',
                     );
                     await _notifyPostAuthor(widget.post.userId, widget.post.id);
                     _textController.clear();

--- a/lib/features/social_feed/services/mention_service.dart
+++ b/lib/features/social_feed/services/mention_service.dart
@@ -1,5 +1,8 @@
 import 'package:appwrite/appwrite.dart';
-import 'notification_service.dart';
+import 'package:get/get.dart';
+
+import '../../notifications/services/notification_service.dart';
+import '../../../controllers/auth_controller.dart';
 import '../../../utils/logger.dart';
 
 class MentionService {
@@ -16,12 +19,13 @@ class MentionService {
   });
 
   Future<void> notifyMentions(
-    List<String> mentions, {
-    required String actorId,
-    required String itemId,
-    required String itemType,
-  }) async {
+    List<String> mentions,
+    String itemId,
+    String itemType,
+  ) async {
     if (mentions.isEmpty) return;
+    final actorId = Get.find<AuthController>().userId;
+    if (actorId == null) return;
     for (final name in mentions) {
       try {
         final res = await databases.listDocuments(

--- a/test/features/social_feed/notify_mentions_test.dart
+++ b/test/features/social_feed/notify_mentions_test.dart
@@ -3,7 +3,7 @@ import 'package:get/get.dart';
 import 'package:appwrite/appwrite.dart';
 import 'package:appwrite/models.dart' as models;
 import 'package:myapp/features/notifications/services/notification_service.dart';
-import 'package:myapp/features/notifications/services/mention_service.dart';
+import 'package:myapp/features/social_feed/services/mention_service.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:myapp/controllers/auth_controller.dart';
 
@@ -95,9 +95,8 @@ void main() {
     );
     await service.notifyMentions(
       ['bob'],
-      actorId: 'actor',
-      itemId: '1',
-      itemType: 'post',
+      '1',
+      'post',
     );
   });
 
@@ -112,9 +111,8 @@ void main() {
     );
     await service.notifyMentions(
       ['bob'],
-      actorId: 'actor',
-      itemId: '1',
-      itemType: 'post',
+      '1',
+      'post',
     );
     expect(recorder.count, 1);
   });


### PR DESCRIPTION
## Summary
- move MentionService to social_feed/services and refactor to read actor from AuthController
- update feed binding and pages to use the new service
- adapt notify_mentions_test for new API

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb0ddcd0832d8cad400edefb3201