### PR TITLE
Enable comment pagination

### DIFF
--- a/test/features/social_feed/comment_card_test.dart
+++ b/test/features/social_feed/comment_card_test.dart
@@ -49,7 +49,11 @@ class _FakeService extends FeedService {
   final Map<String, String> likes = {};
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return store.where((e) => e.postId == postId).toList();
   }
 

--- a/test/features/social_feed/comment_thread_page_test.dart
+++ b/test/features/social_feed/comment_thread_page_test.dart
@@ -31,7 +31,11 @@ class TestFeedService extends FeedService {
   final List<PostComment> commentStore = [];
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return commentStore.where((c) => c.postId == postId).toList();
   }
 }

--- a/test/features/social_feed/comment_thread_page_widget_test.dart
+++ b/test/features/social_feed/comment_thread_page_widget_test.dart
@@ -33,7 +33,11 @@ class TestFeedService extends FeedService {
   final List<PostComment> commentStore = [];
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return commentStore.where((c) => c.postId == postId).toList();
   }
 

--- a/test/features/social_feed/comments_controller_actions_test.dart
+++ b/test/features/social_feed/comments_controller_actions_test.dart
@@ -27,7 +27,11 @@ class RecordingFeedService extends FeedService {
   final List<PostComment> store = [];
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return store.where((c) => c.postId == postId).toList();
   }
 

--- a/test/features/social_feed/comments_controller_counts_test.dart
+++ b/test/features/social_feed/comments_controller_counts_test.dart
@@ -27,7 +27,11 @@ class _RecordingFeedService extends FeedService {
   final List<PostComment> store = [];
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return store.where((c) => c.postId == postId).toList();
   }
 

--- a/test/features/social_feed/comments_controller_test.dart
+++ b/test/features/social_feed/comments_controller_test.dart
@@ -31,7 +31,11 @@ class FakeFeedService extends FeedService {
   final Map<String, String> likes = {};
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return store.where((c) => c.postId == postId).toList();
   }
 
@@ -110,7 +114,11 @@ class ServiceWithPosts extends FeedService {
   }
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return comments.where((c) => c.postId == postId).toList();
   }
 

--- a/test/features/social_feed/comments_pagination_test.dart
+++ b/test/features/social_feed/comments_pagination_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:get/get.dart';
+import 'package:myapp/features/social_feed/controllers/comments_controller.dart';
+import 'package:myapp/features/social_feed/models/post_comment.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+
+class PaginatedService extends FeedService {
+  PaginatedService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
+          bookmarksCollectionId: 'bookmarks',
+        );
+
+  final List<PostComment> store = [];
+
+  @override
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
+    final filtered = store.where((c) => c.postId == postId).toList();
+    final start = cursor == null
+        ? 0
+        : filtered.indexWhere((c) => c.id == cursor) + 1;
+    return filtered.skip(start).take(limit).toList();
+  }
+}
+
+void main() {
+  test('loadComments paginates results', () async {
+    final service = PaginatedService();
+    service.store.addAll(List.generate(
+      5,
+      (i) => PostComment(
+        id: 'c$i',
+        postId: 'p1',
+        userId: 'u',
+        username: 'user',
+        content: 'c$i',
+      ),
+    ));
+    final controller = CommentsController(service: service);
+
+    await controller.loadComments('p1', limit: 2);
+    expect(controller.comments.length, 2);
+
+    await controller.loadComments('p1', limit: 2, loadMore: true);
+    expect(controller.comments.length, 4);
+
+    await controller.loadComments('p1', limit: 2, loadMore: true);
+    expect(controller.comments.length, 5);
+  });
+}

--- a/test/features/social_feed/comments_realtime_test.dart
+++ b/test/features/social_feed/comments_realtime_test.dart
@@ -24,7 +24,11 @@ class FakeFeedService extends FeedService {
         );
 
   @override
-  Future<List<PostComment>> getComments(String postId) async => [];
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async => [];
 }
 
 class FakeAuthController extends AuthController {

--- a/test/features/social_feed/post_detail_page_test.dart
+++ b/test/features/social_feed/post_detail_page_test.dart
@@ -30,7 +30,12 @@ class _DelayedService extends FeedService {
         );
 
   @override
-  Future<List<PostComment>> getComments(String postId) => completer.future;
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) =>
+      completer.future;
 }
 
 void main() {

--- a/test/features/social_feed/post_detail_page_widget_test.dart
+++ b/test/features/social_feed/post_detail_page_widget_test.dart
@@ -37,7 +37,11 @@ class TestFeedService extends FeedService {
   final List<FeedPost> postStore = [];
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return commentStore.where((c) => c.postId == postId).toList();
   }
 
@@ -62,7 +66,11 @@ class DelayedFeedService extends TestFeedService {
 
 class DelayedCommentService extends TestFeedService {
   @override
-  Future<List<PostComment>> getComments(String postId) {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) {
     return Future.delayed(const Duration(milliseconds: 100), () => []);
   }
 }
@@ -71,7 +79,11 @@ class CountingService extends TestFeedService {
   int calls = 0;
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     calls++;
     return [];
   }

--- a/test/features/social_feed/reaction_bar_update_test.dart
+++ b/test/features/social_feed/reaction_bar_update_test.dart
@@ -40,7 +40,11 @@ class _FakeService extends FeedService {
   }
 
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return comments.where((c) => c.postId == postId).toList();
   }
 

--- a/test/features/social_feed/realtime_ui_update_test.dart
+++ b/test/features/social_feed/realtime_ui_update_test.dart
@@ -27,7 +27,11 @@ class _FakeFeedService extends FeedService {
         );
   final List<PostComment> comments = [];
   @override
-  Future<List<PostComment>> getComments(String postId) async {
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async {
     return comments.where((c) => c.postId == postId).toList();
   }
 }

--- a/test/features/social_feed/send_button_semantics_test.dart
+++ b/test/features/social_feed/send_button_semantics_test.dart
@@ -24,7 +24,11 @@ class _FakeService extends FeedService {
         );
 
   @override
-  Future<List<PostComment>> getComments(String postId) async => [];
+  Future<List<PostComment>> getComments(
+    String postId, {
+    int limit = 20,
+    String? cursor,
+  }) async => [];
 
   @override
   Future<String?> createComment(PostComment comment) async {


### PR DESCRIPTION
## Summary
- add pagination parameters to `FeedService.getComments`
- append cursor-based queries when fetching comments
- let `CommentsController.loadComments` request more pages
- adapt tests for new method signature and add pagination tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dbb05de70832dbdebdbf231bac8e1