### PR TITLE
Refactor profile page spacing and loading

### DIFF
--- a/lib/features/profile/screens/profile_page.dart
+++ b/lib/features/profile/screens/profile_page.dart
@@ -28,7 +28,7 @@ class _UserProfilePageState extends State<UserProfilePage> {
       appBar: AppBar(title: const Text('Profile')),
       body: Obx(() {
         if (controller.isLoading.value) {
-          return const Center(child: CircularProgressIndicator());
+          return Center(child: SkeletonLoader(height: DesignTokens.xl(context), width: DesignTokens.xl(context)));
         }
         final profile = controller.profile.value;
         if (profile == null) {
@@ -39,10 +39,10 @@ class _UserProfilePageState extends State<UserProfilePage> {
           children: [
             Text(profile.username, style: Theme.of(context).textTheme.headlineSmall),
             if (profile.bio != null) Padding(
-              padding: const EdgeInsets.only(top: 8),
+              padding: EdgeInsets.only(top: DesignTokens.sm(context)),
               child: Text(profile.bio!),
             ),
-            const SizedBox(height: 16),
+            SizedBox(height: DesignTokens.md(context)),
             AnimatedButton(
               onPressed: () => controller.followUser(profile.id),
               style: FilledButton.styleFrom(
@@ -54,7 +54,7 @@ class _UserProfilePageState extends State<UserProfilePage> {
               child: const Text('Follow'),
             ),
             Padding(
-              padding: const EdgeInsets.only(top: 8),
+              padding: EdgeInsets.only(top: DesignTokens.sm(context)),
               child: AnimatedButton(
                 onPressed: () async {
                   final confirm = await showDialog<bool>(
@@ -84,7 +84,7 @@ class _UserProfilePageState extends State<UserProfilePage> {
             if (Get.find<AuthController>().userId != null &&
                 Get.find<AuthController>().userId != profile.id)
               Padding(
-                padding: const EdgeInsets.only(top: 8),
+                padding: EdgeInsets.only(top: DesignTokens.sm(context)),
                 child: AnimatedButton(
                   onPressed: () {
                     Get.to(


### PR DESCRIPTION
## Summary
- use `DesignTokens` in `profile_page.dart`
- replace spinner with `SkeletonLoader` for profile page

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc2057fc0832da821446608e64770