### PR TITLE
Add profile page tests

### DIFF
--- a/lib/features/profile/controllers/profile_controller.dart
+++ b/lib/features/profile/controllers/profile_controller.dart
@@ -2,16 +2,21 @@ import 'package:get/get.dart';
 import '../models/user_profile.dart';
 import '../services/profile_service.dart';
 import '../../../controllers/auth_controller.dart';
-
 import '../services/activity_service.dart';
+
 class ProfileController extends GetxController {
   var profile = Rxn<UserProfile>();
+  var isFollowing = false.obs;
   var isLoading = false.obs;
 
   Future<void> loadProfile(String userId) async {
     isLoading.value = true;
     try {
       profile.value = await Get.find<ProfileService>().fetchProfile(userId);
+      final uid = Get.find<AuthController>().userId;
+      if (uid != null) {
+        isFollowing.value = Get.find<ProfileService>().isFollowing(uid, userId);
+      }
     } finally {
       isLoading.value = false;
     }
@@ -21,20 +26,33 @@ class ProfileController extends GetxController {
     final uid = Get.find<AuthController>().userId;
     if (uid == null) return;
     await Get.find<ProfileService>().followUser(uid, followedId);
-    await Get.find<ActivityService>().logActivity(uid, 'follow', itemId: followedId, itemType: 'user');
+    isFollowing.value = true;
+    await Get.find<ActivityService>()
+        .logActivity(uid, 'follow', itemId: followedId, itemType: 'user');
+  }
+
+  Future<void> unfollowUser(String unfollowedId) async {
+    final uid = Get.find<AuthController>().userId;
+    if (uid == null) return;
+    await Get.find<ProfileService>().unfollowUser(uid, unfollowedId);
+    isFollowing.value = false;
+    await Get.find<ActivityService>()
+        .logActivity(uid, 'unfollow', itemId: unfollowedId, itemType: 'user');
   }
 
   Future<void> blockUser(String blockedId) async {
     final uid = Get.find<AuthController>().userId;
     if (uid == null) return;
     await Get.find<ProfileService>().blockUser(uid, blockedId);
-    await Get.find<ActivityService>().logActivity(uid, 'block_user', itemId: blockedId, itemType: 'user');
+    await Get.find<ActivityService>()
+        .logActivity(uid, 'block_user', itemId: blockedId, itemType: 'user');
   }
 
   Future<void> unblockUser(String blockedId) async {
     final uid = Get.find<AuthController>().userId;
     if (uid == null) return;
     await Get.find<ProfileService>().unblockUser(uid, blockedId);
-    await Get.find<ActivityService>().logActivity(uid, 'unblock_user', itemId: blockedId, itemType: 'user');
+    await Get.find<ActivityService>()
+        .logActivity(uid, 'unblock_user', itemId: blockedId, itemType: 'user');
   }
 }

--- a/lib/features/profile/screens/profile_page.dart
+++ b/lib/features/profile/screens/profile_page.dart
@@ -28,7 +28,12 @@ class _UserProfilePageState extends State<UserProfilePage> {
       appBar: AppBar(title: const Text('Profile')),
       body: Obx(() {
         if (controller.isLoading.value) {
-          return const Center(child: CircularProgressIndicator());
+          return Center(
+            child: Padding(
+              padding: EdgeInsets.all(DesignTokens.md(context)),
+              child: SkeletonLoader(height: DesignTokens.lg(context)),
+            ),
+          );
         }
         final profile = controller.profile.value;
         if (profile == null) {
@@ -37,21 +42,27 @@ class _UserProfilePageState extends State<UserProfilePage> {
         return Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Text(profile.username, style: Theme.of(context).textTheme.headlineSmall),
-            if (profile.bio != null) Padding(
-              padding: const EdgeInsets.only(top: 8),
-              child: Text(profile.bio!),
-            ),
+            Text(profile.username,
+                style: Theme.of(context).textTheme.headlineSmall),
+            if (profile.bio != null)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(profile.bio!),
+              ),
             const SizedBox(height: 16),
             AnimatedButton(
-              onPressed: () => controller.followUser(profile.id),
+              onPressed: () => controller.isFollowing.value
+                  ? controller.unfollowUser(profile.id)
+                  : controller.followUser(profile.id),
               style: FilledButton.styleFrom(
                 padding: EdgeInsets.symmetric(
                   horizontal: DesignTokens.md(context),
                   vertical: DesignTokens.sm(context),
                 ),
               ),
-              child: const Text('Follow'),
+              child: Obx(() => Text(
+                    controller.isFollowing.value ? 'Unfollow' : 'Follow',
+                  )),
             ),
             Padding(
               padding: const EdgeInsets.only(top: 8),
@@ -61,7 +72,8 @@ class _UserProfilePageState extends State<UserProfilePage> {
                     context: context,
                     builder: (context) => AlertDialog(
                       title: const Text('Block User'),
-                      content: const Text('Are you sure you want to block this user?'),
+                      content: const Text(
+                          'Are you sure you want to block this user?'),
                       actions: [
                         TextButton(
                           onPressed: () => Navigator.pop(context, false),

--- a/test/features/profile/profile_controller_test.dart
+++ b/test/features/profile/profile_controller_test.dart
@@ -5,6 +5,7 @@ import 'package:myapp/features/profile/controllers/profile_controller.dart';
 import 'package:myapp/features/profile/services/profile_service.dart';
 import 'package:myapp/features/profile/models/user_profile.dart';
 import 'package:myapp/controllers/auth_controller.dart';
+import 'package:myapp/features/profile/services/activity_service.dart';
 
 class FakeProfileService extends ProfileService {
   FakeProfileService()
@@ -17,6 +18,7 @@ class FakeProfileService extends ProfileService {
         );
   UserProfile? profile;
   bool followed = false;
+  bool unfollowed = false;
   bool blocked = false;
 
   @override
@@ -30,6 +32,11 @@ class FakeProfileService extends ProfileService {
   }
 
   @override
+  Future<void> unfollowUser(String followerId, String followedId) async {
+    unfollowed = true;
+  }
+
+  @override
   Future<void> blockUser(String blockerId, String blockedId) async {
     blocked = true;
   }
@@ -38,12 +45,34 @@ class FakeProfileService extends ProfileService {
   Future<void> unblockUser(String blockerId, String blockedId) async {
     blocked = false;
   }
+
+  @override
+  bool isFollowing(String followerId, String followedId) =>
+      followed && !unfollowed;
 }
 
 class FakeAuthController extends AuthController {
   FakeAuthController() {
     userId = 'u1';
   }
+}
+
+class RecordingActivityService extends ActivityService {
+  final List<String> actions = [];
+  RecordingActivityService()
+      : super(
+            databases: Databases(Client()),
+            databaseId: 'db',
+            collectionId: 'act');
+
+  @override
+  Future<void> logActivity(String userId, String actionType,
+      {String? itemId, String? itemType}) async {
+    actions.add(actionType);
+  }
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchActivities(String userId) async => [];
 }
 
 void main() {
@@ -61,8 +90,24 @@ void main() {
     service.profile = UserProfile(id: '1', username: 'user');
     Get.put<ProfileService>(service);
     Get.put<AuthController>(FakeAuthController());
+    Get.put<ActivityService>(RecordingActivityService());
     final controller = ProfileController();
     await controller.followUser('1');
     expect(service.followed, isTrue);
+    expect(controller.isFollowing.value, isTrue);
+  });
+
+  test('unfollowUser calls service and logs activity', () async {
+    final service = FakeProfileService();
+    service.profile = UserProfile(id: '1', username: 'user');
+    Get.put<ProfileService>(service);
+    final activity = RecordingActivityService();
+    Get.put<ActivityService>(activity);
+    Get.put<AuthController>(FakeAuthController());
+    final controller = ProfileController();
+    await controller.unfollowUser('1');
+    expect(service.unfollowed, isTrue);
+    expect(controller.isFollowing.value, isFalse);
+    expect(activity.actions, contains('unfollow'));
   });
 }

--- a/test/features/profile/user_profile_page_test.dart
+++ b/test/features/profile/user_profile_page_test.dart
@@ -1,0 +1,135 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import 'package:myapp/features/profile/screens/profile_page.dart';
+import 'package:myapp/features/profile/controllers/profile_controller.dart';
+import 'package:myapp/features/profile/services/profile_service.dart';
+import 'package:myapp/features/profile/models/user_profile.dart';
+import 'package:myapp/features/profile/services/activity_service.dart';
+import 'package:myapp/design_system/modern_ui_system.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+
+class DelayedProfileService extends FakeProfileService {
+  @override
+  Future<UserProfile> fetchProfile(String userId) {
+    return Future.delayed(
+        const Duration(milliseconds: 100), () => super.fetchProfile(userId));
+  }
+}
+
+class FakeProfileService extends ProfileService {
+  FakeProfileService()
+      : super(
+            databases: Databases(Client()),
+            databaseId: 'db',
+            profilesCollection: 'p',
+            followsCollection: 'f',
+            blocksCollection: 'b');
+
+  UserProfile? profile;
+  bool followed = false;
+  bool unfollowed = false;
+
+  @override
+  Future<UserProfile> fetchProfile(String userId) async {
+    return profile!;
+  }
+
+  @override
+  Future<void> followUser(String followerId, String followedId) async {
+    followed = true;
+  }
+
+  @override
+  Future<void> unfollowUser(String followerId, String followedId) async {
+    unfollowed = true;
+  }
+
+  @override
+  bool isFollowing(String followerId, String followedId) =>
+      followed && !unfollowed;
+}
+
+class FakeAuth extends AuthController {
+  FakeAuth() {
+    userId = 'u1';
+  }
+
+  @override
+  Future<void> checkExistingSession({bool navigateOnMissing = true}) async {}
+}
+
+class StubActivityService extends ActivityService {
+  StubActivityService()
+      : super(
+            databases: Databases(Client()),
+            databaseId: 'db',
+            collectionId: 'a');
+
+  @override
+  Future<void> logActivity(String userId, String actionType,
+      {String? itemId, String? itemType}) async {}
+
+  @override
+  Future<List<Map<String, dynamic>>> fetchActivities(String userId) async => [];
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    Get.testMode = true;
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  testWidgets('shows skeleton loader while loading', (tester) async {
+    final service = DelayedProfileService();
+    service.profile = UserProfile(id: '1', username: 'user');
+    Get.put<ProfileService>(service);
+    Get.put<AuthController>(FakeAuth());
+    Get.put<ActivityService>(StubActivityService());
+    Get.put<ProfileController>(ProfileController());
+
+    await tester.pumpWidget(GetMaterialApp(
+      theme: MD3ThemeSystem.createTheme(seedColor: Colors.blue),
+      home: const UserProfilePage(userId: '1'),
+    ));
+
+    await tester.pump();
+    expect(find.byType(SkeletonLoader), findsOneWidget);
+    await tester.pump(const Duration(milliseconds: 150));
+  });
+
+  testWidgets('follow/unfollow button text toggles', (tester) async {
+    final service = FakeProfileService();
+    service.profile = UserProfile(id: '1', username: 'user');
+    Get.put<ProfileService>(service);
+    Get.put<AuthController>(FakeAuth());
+    Get.put<ActivityService>(StubActivityService());
+    Get.put<ProfileController>(ProfileController());
+
+    await tester.pumpWidget(GetMaterialApp(
+      theme: MD3ThemeSystem.createTheme(seedColor: Colors.blue),
+      home: const UserProfilePage(userId: '1'),
+    ));
+
+    await tester.pump();
+    expect(find.text('Follow'), findsOneWidget);
+
+    await tester.tap(find.text('Follow'));
+    await tester.pump();
+    expect(service.followed, isTrue);
+    expect(find.text('Unfollow'), findsOneWidget);
+
+    await tester.tap(find.text('Unfollow'));
+    await tester.pump();
+    expect(service.unfollowed, isTrue);
+    expect(find.text('Follow'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- implement unfollow logic in `ProfileService` and `ProfileController`
- add skeleton loader and follow/unfollow toggle in `UserProfilePage`
- expand profile controller tests
- add new widget tests for `UserProfilePage`

## Testing
- `flutter test --coverage` *(fails: Unable to 'pub upgrade' flutter tool)*

------
https://chatgpt.com/codex/tasks/task_e_684dc209d424832d9845735d327d71bf