### PR TITLE
Apply responsive layout for profile page

### DIFF
--- a/lib/features/profile/screens/profile_page.dart
+++ b/lib/features/profile/screens/profile_page.dart
@@ -6,6 +6,7 @@ import '../services/profile_service.dart';
 import '../../reports/screens/report_user_page.dart';
 import '../../../bindings/report_binding.dart';
 import '../../../design_system/modern_ui_system.dart';
+import '../../../widgets/enhanced_responsive_layout.dart';
 
 class UserProfilePage extends StatefulWidget {
   final String userId;
@@ -39,77 +40,183 @@ class _UserProfilePageState extends State<UserProfilePage> {
         final service = Get.find<ProfileService>();
         final isFollowing = authId != null &&
             service.followsBox.containsKey('${authId}_${profile.id}');
-        return Column(
-          mainAxisAlignment: MainAxisAlignment.center,
+        return EnhancedResponsiveLayout(
+          mobile: (context) =>
+              _buildPortraitLayout(context, profile, isFollowing),
+          mobileLandscape: (context) =>
+              _buildLandscapeLayout(context, profile, isFollowing),
+          tablet: (context) =>
+              _buildLandscapeLayout(context, profile, isFollowing),
+          tabletLandscape: (context) =>
+              _buildLandscapeLayout(context, profile, isFollowing),
+          desktop: (context) =>
+              _buildLandscapeLayout(context, profile, isFollowing),
+          desktopLandscape: (context) =>
+              _buildLandscapeLayout(context, profile, isFollowing),
+        );
+      }),
+    );
+  }
+
+  double _spacing(BuildContext context) {
+    return ResponsiveUtils.adaptiveValue(
+      context,
+      mobile: DesignTokens.sm(context),
+      tablet: DesignTokens.md(context),
+      desktop: DesignTokens.lg(context),
+    );
+  }
+
+  EdgeInsets _pagePadding(BuildContext context) {
+    final value = ResponsiveUtils.adaptiveValue(
+      context,
+      mobile: DesignTokens.md(context),
+      tablet: DesignTokens.lg(context),
+      desktop: DesignTokens.xl(context),
+    );
+    return EdgeInsets.all(value);
+  }
+
+  Widget _buildPortraitLayout(
+      BuildContext context, UserProfile profile, bool isFollowing) {
+    final spacing = _spacing(context);
+    return SingleChildScrollView(
+      padding: _pagePadding(context),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
           children: [
-            Text(profile.username, style: Theme.of(context).textTheme.headlineSmall),
-            if (profile.bio != null) Padding(
-              padding: EdgeInsets.only(top: DesignTokens.sm(context)),
-              child: Text(profile.bio!),
+            Text(
+              profile.username,
+              style: Theme.of(context).textTheme.headlineSmall,
             ),
-            SizedBox(height: DesignTokens.md(context)),
-            AnimatedButton(
-              onPressed: () async {
-                if (isFollowing) {
-                  await controller.unfollowUser(profile.id);
-                } else {
-                  await controller.followUser(profile.id);
-                }
-                setState(() {});
-              },
-              style: FilledButton.styleFrom(
-                padding: EdgeInsets.symmetric(
-                  horizontal: DesignTokens.md(context),
-                  vertical: DesignTokens.sm(context),
-                ),
+            if (profile.bio != null)
+              Padding(
+                padding: EdgeInsets.only(top: spacing),
+                child: Text(profile.bio!),
               ),
-              child: Text(isFollowing ? 'Unfollow' : 'Follow'),
-            ),
-            Padding(
-              padding: EdgeInsets.only(top: DesignTokens.sm(context)),
-              child: AnimatedButton(
-                onPressed: () async {
-                  final confirm = await showDialog<bool>(
-                    context: context,
-                    builder: (context) => AlertDialog(
-                      title: const Text('Block User'),
-                      content: const Text('Are you sure you want to block this user?'),
-                      actions: [
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, false),
-                          child: const Text('Cancel'),
-                        ),
-                        TextButton(
-                          onPressed: () => Navigator.pop(context, true),
-                          child: const Text('Block'),
-                        ),
-                      ],
-                    ),
-                  );
-                  if (confirm == true) {
-                    await controller.blockUser(profile.id);
-                  }
-                },
-                child: const Text('Block'),
-              ),
-            ),
+            SizedBox(height: spacing),
+            _buildFollowButton(context, profile.id, isFollowing),
+            SizedBox(height: spacing * 0.5),
+            _buildBlockButton(context, profile.id),
             if (Get.find<AuthController>().userId != null &&
                 Get.find<AuthController>().userId != profile.id)
               Padding(
-                padding: EdgeInsets.only(top: DesignTokens.sm(context)),
-                child: AnimatedButton(
-                  onPressed: () {
-                    Get.to(
-                      () => ReportUserPage(userId: profile.id),
-                      binding: ReportBinding(),
-                    );
-                  },
-                  child: const Text('Report'),
-                ),
+                padding: EdgeInsets.only(top: spacing * 0.5),
+                child: _buildReportButton(context, profile.id),
               ),
           ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLandscapeLayout(
+      BuildContext context, UserProfile profile, bool isFollowing) {
+    final spacing = _spacing(context);
+    return SingleChildScrollView(
+      padding: _pagePadding(context),
+      child: Center(
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Expanded(
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    profile.username,
+                    style: Theme.of(context).textTheme.headlineSmall,
+                  ),
+                  if (profile.bio != null)
+                    Padding(
+                      padding: EdgeInsets.only(top: spacing),
+                      child: Text(profile.bio!),
+                    ),
+                ],
+              ),
+            ),
+            SizedBox(width: spacing),
+            Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                _buildFollowButton(context, profile.id, isFollowing),
+                SizedBox(height: spacing * 0.5),
+                _buildBlockButton(context, profile.id),
+                if (Get.find<AuthController>().userId != null &&
+                    Get.find<AuthController>().userId != profile.id)
+                  Padding(
+                    padding: EdgeInsets.only(top: spacing * 0.5),
+                    child: _buildReportButton(context, profile.id),
+                  ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildFollowButton(
+      BuildContext context, String uid, bool isFollowing) {
+    return AnimatedButton(
+      onPressed: () async {
+        final controller = Get.find<ProfileController>();
+        if (isFollowing) {
+          await controller.unfollowUser(uid);
+        } else {
+          await controller.followUser(uid);
+        }
+        setState(() {});
+      },
+      style: FilledButton.styleFrom(
+        padding: EdgeInsets.symmetric(
+          horizontal: DesignTokens.md(context),
+          vertical: DesignTokens.sm(context),
+        ),
+      ),
+      child: Text(isFollowing ? 'Unfollow' : 'Follow'),
+    );
+  }
+
+  Widget _buildBlockButton(BuildContext context, String uid) {
+    return AnimatedButton(
+      onPressed: () async {
+        final confirm = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: const Text('Block User'),
+            content: const Text('Are you sure you want to block this user?'),
+            actions: [
+              TextButton(
+                onPressed: () => Navigator.pop(context, false),
+                child: const Text('Cancel'),
+              ),
+              TextButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('Block'),
+              ),
+            ],
+          ),
         );
-      }),
+        if (confirm == true) {
+          await Get.find<ProfileController>().blockUser(uid);
+        }
+      },
+      child: const Text('Block'),
+    );
+  }
+
+  Widget _buildReportButton(BuildContext context, String uid) {
+    return AnimatedButton(
+      onPressed: () {
+        Get.to(
+          () => ReportUserPage(userId: uid),
+          binding: ReportBinding(),
+        );
+      },
+      child: const Text('Report'),
     );
   }
 }


### PR DESCRIPTION
## Summary
- import `EnhancedResponsiveLayout` and refactor `profile_page.dart` to use it
- keep follow/unfollow toggle and block/report actions

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc72e6c84832d8f608fd9db0e5bd8