### PR TITLE
Add follow state tracking and follower counts

### DIFF
--- a/lib/features/profile/screens/profile_page.dart
+++ b/lib/features/profile/screens/profile_page.dart
@@ -36,23 +36,21 @@ class _UserProfilePageState extends State<UserProfilePage> {
         if (profile == null) {
           return const Center(child: Text('Profile not found'));
         }
-        final authId = Get.find<AuthController>().userId;
-        final service = Get.find<ProfileService>();
-        final isFollowing = authId != null &&
-            service.followsBox.containsKey('${authId}_${profile.id}');
+        final isFollowing = controller.isFollowing.value;
+        final count = controller.followerCount.value;
         return EnhancedResponsiveLayout(
           mobile: (context) =>
-              _buildPortraitLayout(context, profile, isFollowing),
+              _buildPortraitLayout(context, profile, isFollowing, count),
           mobileLandscape: (context) =>
-              _buildLandscapeLayout(context, profile, isFollowing),
+              _buildLandscapeLayout(context, profile, isFollowing, count),
           tablet: (context) =>
-              _buildLandscapeLayout(context, profile, isFollowing),
+              _buildLandscapeLayout(context, profile, isFollowing, count),
           tabletLandscape: (context) =>
-              _buildLandscapeLayout(context, profile, isFollowing),
+              _buildLandscapeLayout(context, profile, isFollowing, count),
           desktop: (context) =>
-              _buildLandscapeLayout(context, profile, isFollowing),
+              _buildLandscapeLayout(context, profile, isFollowing, count),
           desktopLandscape: (context) =>
-              _buildLandscapeLayout(context, profile, isFollowing),
+              _buildLandscapeLayout(context, profile, isFollowing, count),
         );
       }),
     );
@@ -78,7 +76,7 @@ class _UserProfilePageState extends State<UserProfilePage> {
   }
 
   Widget _buildPortraitLayout(
-      BuildContext context, UserProfile profile, bool isFollowing) {
+      BuildContext context, UserProfile profile, bool isFollowing, int count) {
     final spacing = _spacing(context);
     return SingleChildScrollView(
       padding: _pagePadding(context),
@@ -98,6 +96,8 @@ class _UserProfilePageState extends State<UserProfilePage> {
             SizedBox(height: spacing),
             _buildFollowButton(context, profile.id, isFollowing),
             SizedBox(height: spacing * 0.5),
+            Text('Followers: \$count'),
+            SizedBox(height: spacing * 0.5),
             _buildBlockButton(context, profile.id),
             if (Get.find<AuthController>().userId != null &&
                 Get.find<AuthController>().userId != profile.id)
@@ -112,7 +112,7 @@ class _UserProfilePageState extends State<UserProfilePage> {
   }
 
   Widget _buildLandscapeLayout(
-      BuildContext context, UserProfile profile, bool isFollowing) {
+      BuildContext context, UserProfile profile, bool isFollowing, int count) {
     final spacing = _spacing(context);
     return SingleChildScrollView(
       padding: _pagePadding(context),
@@ -143,6 +143,8 @@ class _UserProfilePageState extends State<UserProfilePage> {
               children: [
                 _buildFollowButton(context, profile.id, isFollowing),
                 SizedBox(height: spacing * 0.5),
+                Text('Followers: \$count'),
+                SizedBox(height: spacing * 0.5),
                 _buildBlockButton(context, profile.id),
                 if (Get.find<AuthController>().userId != null &&
                     Get.find<AuthController>().userId != profile.id)
@@ -168,7 +170,6 @@ class _UserProfilePageState extends State<UserProfilePage> {
         } else {
           await controller.followUser(uid);
         }
-        setState(() {});
       },
       style: FilledButton.styleFrom(
         padding: EdgeInsets.symmetric(

--- a/test/features/profile/profile_service_is_following_test.dart
+++ b/test/features/profile/profile_service_is_following_test.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/profile/services/profile_service.dart';
+
+class OfflineDatabases extends Databases {
+  OfflineDatabases() : super(Client());
+
+  @override
+  Future<DocumentList> listDocuments({
+    required String databaseId,
+    required String collectionId,
+    List<String>? queries,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+void main() {
+  late Directory dir;
+  late ProfileService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('follows');
+    await Hive.openBox('profiles');
+    service = ProfileService(
+      databases: OfflineDatabases(),
+      databaseId: 'db',
+      profilesCollection: 'profiles',
+      followsCollection: 'follows',
+      blocksCollection: 'blocks',
+    );
+    Hive.box('follows').put('u1_u2', {'followed_id': 'u2'});
+    Hive.box('profiles').put('followers_u2', 5);
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('isFollowing reads from cache when offline', () async {
+    final result = await service.isFollowing('u1', 'u2');
+    expect(result, isTrue);
+  });
+
+  test('getFollowerCount reads from cache when offline', () async {
+    final count = await service.getFollowerCount('u2');
+    expect(count, 5);
+  });
+}


### PR DESCRIPTION
## Summary
- implement follow state checks and follower counts in `ProfileService`
- fetch follow state and follower counts in `ProfileController`
- show follower count on `UserProfilePage` and toggle button text
- add offline tests for follow state logic
- extend controller tests for new behaviour

## Testing
- `flutter test test/features/profile/profile_controller_test.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc99d9c70832d9f610467f9670c34