### PR TITLE
Fix comment ID caching

### DIFF
--- a/lib/features/social_feed/models/post_comment.dart
+++ b/lib/features/social_feed/models/post_comment.dart
@@ -43,6 +43,7 @@ class PostComment {
 
   Map<String, dynamic> toJson() {
     return {
+      'id': id,
       'post_id': postId,
       'user_id': userId,
       'username': username,

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -367,20 +367,30 @@ class FeedService {
           }
         } catch (_) {}
       }
-    } catch (_) {
+      } catch (_) {
       await commentsBox.put(
         comment.id,
-        {...comment.toJson(), '_cachedAt': DateTime.now().toIso8601String()},
+        {
+          ...comment.toJson(),
+          'id': comment.id,
+          '_cachedAt': DateTime.now().toIso8601String(),
+        },
       );
       final listKey = 'comments_${comment.postId}';
       final current =
           (commentsBox.get(listKey, defaultValue: []) as List).cast<dynamic>();
-      current.add(
-          {...comment.toJson(), '_cachedAt': DateTime.now().toIso8601String()});
+      current.add({
+        ...comment.toJson(),
+        'id': comment.id,
+        '_cachedAt': DateTime.now().toIso8601String(),
+      });
       await commentsBox.put(listKey, current);
       await _addToBoxWithLimit(queueBox, {
         'action': 'comment',
-        'data': comment.toJson(),
+        'data': {
+          ...comment.toJson(),
+          'id': comment.id,
+        },
         '_cachedAt': DateTime.now().toIso8601String(),
       });
     }

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -292,6 +292,7 @@ void main() {
     expect(queue.isNotEmpty, isTrue);
     final item = queue.getAt(queue.length - 1) as Map?;
     expect(item?['action'], 'comment');
+    expect(item?['data']['id'], 'c1');
   });
 
   test('deleteLike queues when offline', () async {
@@ -448,6 +449,10 @@ void main() {
 
     await controller.addComment(comment);
     expect(controller.comments.first.id, 'tmp1');
+    final queued = Hive.box('action_queue').getAt(
+      Hive.box('action_queue').length - 1,
+    ) as Map?;
+    expect(queued?['data']['id'], 'tmp1');
 
     final onlineService = FeedService(
       databases: _FakeDatabases(),


### PR DESCRIPTION
## Summary
- add `id` field to `PostComment.toJson`
- ensure comment offline caching stores the id
- verify queued comments include the id in unit tests

## Testing
- `flutter test test/features/social_feed/offline_feed_service_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684dd18f0b3c832d9153d42df96fc670