### PR TITLE
Fix repost notifications

### DIFF
--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -536,10 +536,7 @@ class FeedService {
         functionId: 'increment_repost_count',
         body: jsonEncode({'post_id': repost['post_id']}),
       );
-      final comment = repost['comment'];
-      if (comment != null &&
-          comment.toString().isNotEmpty &&
-          Get.isRegistered<NotificationService>()) {
+      if (Get.isRegistered<NotificationService>()) {
         try {
           final res = await databases.getDocument(
             databaseId: databaseId,

--- a/test/features/social_feed/repost_service_test.dart
+++ b/test/features/social_feed/repost_service_test.dart
@@ -145,11 +145,21 @@ void main() {
     await dir.delete(recursive: true);
   });
 
-  test('createRepost triggers function and notification', () async {
+  test('createRepost triggers function and notification with comment', () async {
     final id = await service.createRepost({
       'post_id': 'p1',
       'user_id': 'u2',
       'comment': 'hi'
+    });
+    expect(id, isNotNull);
+    expect(functions.count, 1);
+    expect(notification.count, 1);
+  });
+
+  test('createRepost triggers notification without comment', () async {
+    final id = await service.createRepost({
+      'post_id': 'p1',
+      'user_id': 'u2'
     });
     expect(id, isNotNull);
     expect(functions.count, 1);


### PR DESCRIPTION
## Summary
- always notify post owner on repost
- add regression test for repost notification when no comment is provided

## Testing
- `dart test test/features/social_feed/repost_service_test.dart` *(fails: dart not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dd5e9cd1c832d889e6a72af2c60f8