### PR TITLE
Fix notification icon color with theme

### DIFF
--- a/lib/features/notifications/screens/notification_page.dart
+++ b/lib/features/notifications/screens/notification_page.dart
@@ -60,10 +60,13 @@ class _NotificationPageState extends State<NotificationPage> {
                   title: Text(
                       '${n.actorId} ${n.actionType}d your ${n.itemType ?? 'content'}'),
                   subtitle: Text(n.createdAt.toString()),
-                  trailing: n.isRead
-                      ? null
-                      : const Icon(Icons.circle,
-                          color: Colors.blue, size: 10),
+                    trailing: n.isRead
+                        ? null
+                        : Icon(
+                            Icons.circle,
+                            color: context.colorScheme.primary,
+                            size: 10,
+                          ),
                   onTap: () => controller.markAsRead(n.id),
                 ),
               ),


### PR DESCRIPTION
## Summary
- tweak unread notification indicator to use the app theme

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dded4f480832d87078295331169c0