### PR TITLE
Implement skeleton loader for Search

### DIFF
--- a/lib/features/search/screens/search_page.dart
+++ b/lib/features/search/screens/search_page.dart
@@ -33,20 +33,35 @@ class _SearchPageState extends State<SearchPage> {
               decoration: const InputDecoration(labelText: 'Search users'),
               onChanged: (q) => searchController.searchUsers(q),
             ),
-            const SizedBox(height: 16),
+            SizedBox(height: DesignTokens.md(context)),
             Expanded(
-              child: Obx(() => searchController.isLoading.value
-                  ? const Center(child: CircularProgressIndicator())
-                  : ListView.builder(
-                      itemCount: searchController.searchResults.length,
-                      itemBuilder: (context, index) {
-                        final user = searchController.searchResults[index];
-                        return ListTile(
-                          title: Text(user.username),
-                          subtitle: user.bio != null ? Text(user.bio!) : null,
-                        );
-                      },
-                    )),
+              child: Obx(() {
+                if (searchController.isLoading.value) {
+                  return Column(
+                    children: List.generate(
+                      3,
+                      (_) => Padding(
+                        padding: EdgeInsets.only(
+                          bottom: DesignTokens.sm(context),
+                        ),
+                        child: SkeletonLoader(
+                          height: DesignTokens.xl(context),
+                        ),
+                      ),
+                    ),
+                  );
+                }
+                return OptimizedListView(
+                  itemCount: searchController.searchResults.length,
+                  itemBuilder: (context, index) {
+                    final user = searchController.searchResults[index];
+                    return ListTile(
+                      title: Text(user.username),
+                      subtitle: user.bio != null ? Text(user.bio!) : null,
+                    );
+                  },
+                );
+              }),
             ),
           ],
         ),

--- a/test/features/search/search_page_test.dart
+++ b/test/features/search/search_page_test.dart
@@ -1,13 +1,53 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/profile/models/user_profile.dart' as profile;
 import 'package:myapp/features/search/controllers/search_controller.dart' as my;
 import 'package:myapp/features/search/screens/search_page.dart';
+import 'package:myapp/features/search/services/search_service.dart' as srv;
+import 'package:myapp/design_system/modern_ui_system.dart'
+    show MD3ThemeSystem, SkeletonLoader;
 
 void main() {
   testWidgets('renders search page', (tester) async {
     Get.put(my.SearchController());
     await tester.pumpWidget(const GetMaterialApp(home: SearchPage()));
     expect(find.byType(TextField), findsOneWidget);
+  });
+
+  testWidgets('shows skeleton loader while loading', (tester) async {
+    class DelayedSearchService extends srv.SearchService {
+      DelayedSearchService()
+          : super(
+              databases: Databases(Client()),
+              databaseId: 'db',
+              profilesCollection: 'profiles',
+              namesHistoryCollection: 'history',
+            );
+
+      @override
+      Future<List<profile.UserProfile>> searchUsers(String query) {
+        return Future.delayed(const Duration(milliseconds: 100), () => []);
+      }
+    }
+
+    Get.put<srv.SearchService>(DelayedSearchService());
+    final controller = my.SearchController();
+    Get.put<my.SearchController>(controller);
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        theme: MD3ThemeSystem.createTheme(
+          seedColor: Colors.blue,
+          brightness: Brightness.light,
+        ),
+        home: const SearchPage(),
+      ),
+    );
+
+    await tester.enterText(find.byType(TextField), 'user');
+    await tester.pump();
+    expect(find.byType(SkeletonLoader), findsWidgets);
   });
 }


### PR DESCRIPTION
## Summary
- show skeleton loader while searching for users
- use `OptimizedListView` for search results
- cover loader with a widget test

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684de2c09648832db5b25a2af47419e2