### PR TITLE
Handle edit errors

### DIFF
--- a/lib/features/social_feed/screens/edit_post_page.dart
+++ b/lib/features/social_feed/screens/edit_post_page.dart
@@ -57,13 +57,26 @@ class _EditPostPageState extends State<EditPostPage> {
                         .map((m) => m.group(1)!)
                         .toSet()
                         .toList();
-                    await feedController.editPost(
-                      widget.post.id,
-                      _controller.text,
-                      tags,
-                      mentions,
-                    );
-                    Get.back();
+                    try {
+                      await feedController.editPost(
+                        widget.post.id,
+                        _controller.text,
+                        tags,
+                        mentions,
+                      );
+                      Get.back();
+                    } catch (e) {
+                      final message = e
+                              .toString()
+                              .contains('Edit window expired')
+                          ? 'Edit window expired'
+                          : 'Failed to edit post';
+                      Get.snackbar(
+                        'Error',
+                        message,
+                        snackPosition: SnackPosition.BOTTOM,
+                      );
+                    }
                   },
                   child: const Text('Save'),
                 ),


### PR DESCRIPTION
## Summary
- catch exceptions when editing a post
- show snackbar feedback if edit fails

## Testing
- `flutter --version` *(fails: command not found)*
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684def877fb4832dad59ade23666b886