### PR TITLE
Restrict post editing window

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -105,6 +105,7 @@ class FeedController extends GetxController {
             isEdited: post.isEdited,
             isDeleted: post.isDeleted,
             editedAt: post.editedAt,
+            createdAt: post.createdAt,
           );
     await service.createPost(toSave);
     _posts.insert(0, toSave);
@@ -130,10 +131,11 @@ class FeedController extends GetxController {
       hashtags: limited,
       mentions: mentions,
     );
+    final now = DateTime.now();
     _posts.insert(
       0,
       FeedPost(
-        id: DateTime.now().toIso8601String(),
+        id: now.toIso8601String(),
         roomId: roomId,
         userId: userId,
         username: username,
@@ -141,6 +143,7 @@ class FeedController extends GetxController {
         mediaUrls: [image.path],
         hashtags: limited,
         mentions: mentions,
+        createdAt: now,
       ),
     );
     _commentCounts[_posts.first.id] = 0;
@@ -167,10 +170,11 @@ class FeedController extends GetxController {
       hashtags: limited,
       mentions: mentions,
     );
+    final now2 = DateTime.now();
     _posts.insert(
       0,
       FeedPost(
-        id: DateTime.now().toIso8601String(),
+        id: now2.toIso8601String(),
         roomId: roomId,
         userId: userId,
         username: username,
@@ -179,6 +183,7 @@ class FeedController extends GetxController {
         linkMetadata: metadata,
         hashtags: limited,
         mentions: mentions,
+        createdAt: now2,
       ),
     );
     _commentCounts[_posts.first.id] = 0;
@@ -287,6 +292,7 @@ class FeedController extends GetxController {
         mentions: mentions,
         isEdited: true,
         editedAt: DateTime.now(),
+        createdAt: post.createdAt,
       );
     }
   }

--- a/lib/features/social_feed/models/feed_post.dart
+++ b/lib/features/social_feed/models/feed_post.dart
@@ -20,6 +20,7 @@ class FeedPost {
   final bool isEdited;
   final bool isDeleted;
   final DateTime? editedAt;
+  final DateTime createdAt;
 
   FeedPost({
     required this.id,
@@ -41,6 +42,7 @@ class FeedPost {
     this.isEdited = false,
     this.isDeleted = false,
     this.editedAt,
+    required this.createdAt,
   });
 
   factory FeedPost.fromJson(Map<String, dynamic> json) {
@@ -66,6 +68,10 @@ class FeedPost {
       editedAt: json['edited_at'] != null
           ? DateTime.tryParse(json['edited_at'])
           : null,
+      createdAt: DateTime.tryParse(
+              json['\$createdAt'] ?? json['created_at'] ?? json['createdAt'] ??
+                  '') ??
+          DateTime.now(),
     );
   }
 

--- a/lib/features/social_feed/screens/compose_post_page.dart
+++ b/lib/features/social_feed/screens/compose_post_page.dart
@@ -151,14 +151,16 @@ class _ComposePostPageState extends State<ComposePostPage> {
                         'post',
                       );
                     } else {
+                      final now = DateTime.now();
                       final post = FeedPost(
-                        id: DateTime.now().toIso8601String(),
+                        id: now.toIso8601String(),
                         roomId: widget.roomId,
                         userId: uid,
                         username: uname,
                         content: sanitized,
                         hashtags: tags,
                         mentions: mentions,
+                        createdAt: now,
                       );
                       await feedController.createPost(post);
                       await Get.find<MentionService>().notifyMentions(

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -142,6 +142,7 @@ class FeedService {
             isEdited: post.isEdited,
             isDeleted: post.isDeleted,
             editedAt: post.editedAt,
+            createdAt: post.createdAt,
           );
     try {
       await databases.createDocument(
@@ -185,8 +186,9 @@ class FeedService {
     final limited = _limitHashtags(hashtags);
     try {
       final imageUrl = await uploadImage(image);
+      final now = DateTime.now();
       final post = FeedPost(
-        id: DateTime.now().toIso8601String(),
+        id: now.toIso8601String(),
         roomId: roomId ?? '',
         userId: userId,
         username: username,
@@ -194,6 +196,7 @@ class FeedService {
         mediaUrls: [imageUrl],
         hashtags: limited,
         mentions: mentions,
+        createdAt: now,
       );
       await createPost(post);
     } catch (_) {
@@ -232,8 +235,9 @@ class FeedService {
     final limited = _limitHashtags(hashtags);
     try {
       final metadata = await fetchLinkMetadata(linkUrl);
+      final now2 = DateTime.now();
       final post = FeedPost(
-        id: DateTime.now().toIso8601String(),
+        id: now2.toIso8601String(),
         roomId: roomId ?? '',
         userId: userId,
         username: username,
@@ -242,6 +246,7 @@ class FeedService {
         linkMetadata: metadata,
         hashtags: limited,
         mentions: mentions,
+        createdAt: now2,
       );
       await createPost(post);
     } catch (_) {

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -132,6 +132,9 @@ class PostCard extends StatelessWidget {
     final controller = Get.find<FeedController>();
     final bookmarkController = Get.find<BookmarkController>();
     final auth = Get.find<AuthController>();
+    final canEdit =
+        DateTime.now().difference(post.editedAt ?? post.createdAt).inMinutes <=
+            30;
     return Obx(
       () => GlassmorphicCard(
         padding: DesignTokens.md(context).all,
@@ -162,17 +165,18 @@ class PostCard extends StatelessWidget {
                   ),
                 const Spacer(),
                 if (auth.userId == post.userId) ...[
-                  AccessibilityWrapper(
-                    semanticLabel: 'Edit post',
-                    isButton: true,
-                    child: AnimatedButton(
-                      onPressed: () {
-                        Get.to(() => EditPostPage(post: post));
-                      },
-                      child: const Text('Edit'),
+                  if (canEdit)
+                    AccessibilityWrapper(
+                      semanticLabel: 'Edit post',
+                      isButton: true,
+                      child: AnimatedButton(
+                        onPressed: () {
+                          Get.to(() => EditPostPage(post: post));
+                        },
+                        child: const Text('Edit'),
+                      ),
                     ),
-                  ),
-                  SizedBox(width: DesignTokens.xs(context)),
+                  if (canEdit) SizedBox(width: DesignTokens.xs(context)),
                   AccessibilityWrapper(
                     semanticLabel: 'Delete post',
                     isButton: true,


### PR DESCRIPTION
## Summary
- expose `createdAt` in `FeedPost`
- include creation time when composing posts
- maintain timestamps through controller and service layers
- only show edit option within 30 minutes of creation

## Testing
- `flutter test` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df075b41c832d9a9dd4ec0f035218