### PR TITLE
Handle deletion errors with SnackBar

### DIFF
--- a/lib/assets/translations/app_translations.dart
+++ b/lib/assets/translations/app_translations.dart
@@ -56,6 +56,8 @@ class AppTranslations extends Translations {
         'delete_username': 'Delete Username',
         'username_deleted': 'Username deleted',
         'failed_to_delete_username': 'Failed to delete username',
+        'failed_to_delete_post': 'Failed to delete post.',
+        'failed_to_delete_comment': 'Failed to delete comment.',
         'invalid_username': 'Invalid username',
         'invalid_username_message':
             'Usernames must be 3-15 characters and can include letters, numbers, and underscores.',
@@ -132,6 +134,8 @@ class AppTranslations extends Translations {
         'delete_username': 'Eliminar nombre de usuario',
         'username_deleted': 'Nombre de usuario eliminado',
         'failed_to_delete_username': 'No se pudo eliminar el nombre de usuario',
+        'failed_to_delete_post': 'No se pudo eliminar la publicación.',
+        'failed_to_delete_comment': 'No se pudo eliminar el comentario.',
         'invalid_username': 'Nombre de usuario inválido',
         'invalid_username_message':
             'Los nombres deben tener entre 3 y 15 caracteres y solo pueden incluir letras, números y guiones bajos.',

--- a/lib/features/social_feed/widgets/comment_card.dart
+++ b/lib/features/social_feed/widgets/comment_card.dart
@@ -87,7 +87,16 @@ class CommentCard extends StatelessWidget {
         ),
       );
       if (confirm == true) {
-        await controller.deleteComment(comment.id);
+        try {
+          await controller.deleteComment(comment.id);
+        } catch (e) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(
+              content: Text('failed_to_delete_comment'.tr),
+              behavior: SnackBarBehavior.floating,
+            ),
+          );
+        }
       }
     }
 

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -123,7 +123,16 @@ class PostCard extends StatelessWidget {
       ),
     );
     if (confirm == true) {
-      await controller.deletePost(post.id);
+      try {
+        await controller.deletePost(post.id);
+      } catch (e) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text('failed_to_delete_post'.tr),
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
     }
   }
 


### PR DESCRIPTION
## Summary
- show SnackBar when deleting post fails
- show SnackBar when deleting comment fails
- add localized strings for post/comment deletion failures

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df2145ef0832dbf61f2480ca96d01