### PR TITLE
Fix block button visibility

### DIFF
--- a/lib/features/profile/screens/profile_page.dart
+++ b/lib/features/profile/screens/profile_page.dart
@@ -108,7 +108,9 @@ class _UserProfilePageState extends State<UserProfilePage> {
             SizedBox(height: halfSpacing),
             Text('Followers: \$count'),
             SizedBox(height: halfSpacing),
-            _buildBlockButton(context, profile.id),
+            if (Get.find<AuthController>().userId != null &&
+                Get.find<AuthController>().userId != profile.id)
+              _buildBlockButton(context, profile.id),
             if (Get.find<AuthController>().userId != null &&
                 Get.find<AuthController>().userId != profile.id)
               Padding(
@@ -156,7 +158,9 @@ class _UserProfilePageState extends State<UserProfilePage> {
                 SizedBox(height: halfSpacing),
                 Text('Followers: \$count'),
                 SizedBox(height: halfSpacing),
-                _buildBlockButton(context, profile.id),
+                if (Get.find<AuthController>().userId != null &&
+                    Get.find<AuthController>().userId != profile.id)
+                  _buildBlockButton(context, profile.id),
                 if (Get.find<AuthController>().userId != null &&
                     Get.find<AuthController>().userId != profile.id)
                   Padding(


### PR DESCRIPTION
## Summary
- only show `Block` button on other user's profiles

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get update`
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_684df622e32c832db845e7d2209909c8