### PR TITLE
Add blocked users page

### DIFF
--- a/lib/bindings/profile_binding.dart
+++ b/lib/bindings/profile_binding.dart
@@ -6,6 +6,7 @@ import '../features/profile/controllers/profile_controller.dart';
 
 import '../features/profile/services/activity_service.dart';
 import '../features/profile/controllers/activity_controller.dart';
+import '../features/profile/controllers/blocked_users_controller.dart';
 class ProfileBinding extends Bindings {
   @override
   void dependencies() {
@@ -29,5 +30,6 @@ class ProfileBinding extends Bindings {
               dotenv.env['BLOCKS_COLLECTION_ID'] ?? 'blocked_users',
         ));
     Get.lazyPut<ProfileController>(() => ProfileController());
+    Get.lazyPut<BlockedUsersController>(() => BlockedUsersController());
   }
 }

--- a/lib/features/profile/controllers/blocked_users_controller.dart
+++ b/lib/features/profile/controllers/blocked_users_controller.dart
@@ -1,0 +1,23 @@
+import 'package:get/get.dart';
+import '../services/profile_service.dart';
+import 'profile_controller.dart';
+
+class BlockedUsersController extends GetxController {
+  final blockedIds = <String>[].obs;
+  final isLoading = false.obs;
+
+  void loadBlockedUsers(String userId) {
+    isLoading.value = true;
+    try {
+      final service = Get.find<ProfileService>();
+      blockedIds.assignAll(service.getBlockedIds(userId));
+    } finally {
+      isLoading.value = false;
+    }
+  }
+
+  Future<void> unblock(String blockedId) async {
+    await Get.find<ProfileController>().unblockUser(blockedId);
+    blockedIds.remove(blockedId);
+  }
+}

--- a/lib/features/profile/screens/blocked_users_page.dart
+++ b/lib/features/profile/screens/blocked_users_page.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:get/get.dart';
+import '../../../controllers/auth_controller.dart';
+import '../../../design_system/modern_ui_system.dart';
+import '../controllers/blocked_users_controller.dart';
+
+class BlockedUsersPage extends StatefulWidget {
+  const BlockedUsersPage({super.key});
+
+  @override
+  State<BlockedUsersPage> createState() => _BlockedUsersPageState();
+}
+
+class _BlockedUsersPageState extends State<BlockedUsersPage> {
+  @override
+  void initState() {
+    super.initState();
+    final uid = Get.isRegistered<AuthController>()
+        ? Get.find<AuthController>().userId
+        : null;
+    if (uid != null) {
+      Get.find<BlockedUsersController>().loadBlockedUsers(uid);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = Get.find<BlockedUsersController>();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Blocked Users')),
+      body: Obx(() {
+        if (controller.isLoading.value) {
+          return Padding(
+            padding: EdgeInsets.all(DesignTokens.md(context)),
+            child: Column(
+              children: List.generate(
+                3,
+                (_) => Padding(
+                  padding: EdgeInsets.only(bottom: DesignTokens.sm(context)),
+                  child: SkeletonLoader(
+                    height: DesignTokens.xl(context),
+                  ),
+                ),
+              ),
+            ),
+          );
+        }
+        return OptimizedListView(
+          itemCount: controller.blockedIds.length,
+          padding: EdgeInsets.all(DesignTokens.md(context)),
+          itemBuilder: (context, index) {
+            final id = controller.blockedIds[index];
+            return ListTile(
+              title: Text(id),
+              trailing: AnimatedButton(
+                onPressed: () async {
+                  await controller.unblock(id);
+                },
+                style: FilledButton.styleFrom(
+                  padding: EdgeInsets.symmetric(
+                    horizontal: DesignTokens.md(context),
+                    vertical: DesignTokens.sm(context),
+                  ),
+                ),
+                child: const Text('Unblock'),
+              ),
+            );
+          },
+        );
+      }),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'features/social_feed/screens/compose_post_page.dart';
 import 'features/search/screens/search_page.dart';
 import 'features/notifications/screens/notification_page.dart';
 import 'features/bookmarks/screens/bookmark_list_page.dart';
+import 'features/profile/screens/blocked_users_page.dart';
 import 'features/profile/screens/profile_page.dart';
 import 'features/reports/screens/report_post_page.dart';
 import 'features/reports/screens/report_user_page.dart';
@@ -201,6 +202,11 @@ class MyApp extends StatelessWidget {
               name: '/bookmarks',
               page: () => const BookmarkListPage(),
               bindings: [AuthBinding(), FeedBinding()],
+            ),
+            GetPage(
+              name: '/blocked-users',
+              page: () => const BlockedUsersPage(),
+              binding: ProfileBinding(),
             ),
             GetPage(
               name: '/user-profile/:userId',

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -4,6 +4,8 @@ import 'package:package_info_plus/package_info_plus.dart';
 import '../controllers/auth_controller.dart';
 import '../controllers/theme_controller.dart';
 import '../design_system/modern_ui_system.dart';
+import '../bindings/profile_binding.dart';
+import '../features/profile/screens/blocked_users_page.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({super.key});
@@ -45,6 +47,10 @@ class _SettingsPageState extends State<SettingsPage> {
             title: Text('push_notifications'.tr),
             value: notifications,
             onChanged: (v) => setState(() => notifications = v),
+          ),
+          ListTile(
+            title: const Text('Blocked Users'),
+            onTap: () => Get.to(() => const BlockedUsersPage(), binding: ProfileBinding()),
           ),
           ListTile(
             title: Text('version'.tr),


### PR DESCRIPTION
## Summary
- add controller for blocked users list
- create a page to show blocked IDs and allow unblocking
- register the controller in `ProfileBinding`
- link the page from Settings
- expose the page via `/blocked-users` route

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df744291c832d9f7689b3c891e1db