### PR TITLE
Handle report errors

### DIFF
--- a/lib/features/reports/screens/report_post_page.dart
+++ b/lib/features/reports/screens/report_post_page.dart
@@ -62,13 +62,18 @@ class _ReportPostPageState extends State<ReportPostPage> {
                       Get.snackbar('Error', 'Login required');
                       return;
                     }
-                    await Get.find<ReportService>().reportPost(
-                      uid,
-                      widget.postId,
-                      _type,
-                      _descController.text,
-                    );
-                    Get.back();
+                    try {
+                      await Get.find<ReportService>().reportPost(
+                        uid,
+                        widget.postId,
+                        _type,
+                        _descController.text,
+                      );
+                      Get.snackbar('Reported', 'Post reported for review');
+                      Get.back();
+                    } catch (_) {
+                      Get.snackbar('Error', 'Failed to submit report');
+                    }
                   },
                   child: const Text('Submit'),
                 ),

--- a/lib/features/reports/screens/report_user_page.dart
+++ b/lib/features/reports/screens/report_user_page.dart
@@ -62,13 +62,18 @@ class _ReportUserPageState extends State<ReportUserPage> {
                       Get.snackbar('Error', 'Login required');
                       return;
                     }
-                    await Get.find<ReportService>().reportUser(
-                      uid,
-                      widget.userId,
-                      _type,
-                      _descController.text,
-                    );
-                    Get.back();
+                    try {
+                      await Get.find<ReportService>().reportUser(
+                        uid,
+                        widget.userId,
+                        _type,
+                        _descController.text,
+                      );
+                      Get.snackbar('Reported', 'User reported for review');
+                      Get.back();
+                    } catch (_) {
+                      Get.snackbar('Error', 'Failed to submit report');
+                    }
                   },
                   child: const Text('Submit'),
                 ),

--- a/lib/features/reports/services/report_service.dart
+++ b/lib/features/reports/services/report_service.dart
@@ -31,7 +31,6 @@ class ReportService {
           'status': 'pending',
         },
       );
-      Get.snackbar('Reported', 'Post reported for review');
     } catch (e) {
       throw Exception('Failed to report post: $e');
     }
@@ -56,7 +55,6 @@ class ReportService {
           'status': 'pending',
         },
       );
-      Get.snackbar('Reported', 'User reported for review');
     } catch (e) {
       throw Exception('Failed to report user: $e');
     }


### PR DESCRIPTION
## Summary
- show snackbar on success/failure of reporting in UI
- remove snackbars from ReportService

## Testing
- `flutter test` *(fails: flutter command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684df87a8110832d8d7d2c05383f2752