### PR TITLE
Fix report service logging

### DIFF
--- a/lib/features/reports/services/report_service.dart
+++ b/lib/features/reports/services/report_service.dart
@@ -1,5 +1,5 @@
 import 'package:appwrite/appwrite.dart';
-import 'package:get/get.dart';
+import '../../../utils/logger.dart';
 
 class ReportService {
   final Databases databases;
@@ -31,7 +31,8 @@ class ReportService {
           'status': 'pending',
         },
       );
-    } catch (e) {
+    } catch (e, st) {
+      logger.e('Failed to report post', error: e, stackTrace: st);
       throw Exception('Failed to report post: $e');
     }
   }
@@ -55,7 +56,8 @@ class ReportService {
           'status': 'pending',
         },
       );
-    } catch (e) {
+    } catch (e, st) {
+      logger.e('Failed to report user', error: e, stackTrace: st);
       throw Exception('Failed to report user: $e');
     }
   }


### PR DESCRIPTION
## Summary
- log errors instead of showing snackbars in `ReportService`

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684df91b6bc8832d99175ab378ede97a