### PR TITLE
Fix self-reporting bug

### DIFF
--- a/lib/features/reports/screens/report_user_page.dart
+++ b/lib/features/reports/screens/report_user_page.dart
@@ -62,6 +62,10 @@ class _ReportUserPageState extends State<ReportUserPage> {
                       Get.snackbar('Error', 'Login required');
                       return;
                     }
+                    if (uid == widget.userId) {
+                      Get.snackbar('Error', 'You cannot report yourself');
+                      return;
+                    }
                     try {
                       await Get.find<ReportService>().reportUser(
                         uid,

--- a/test/features/reports/report_user_page_test.dart
+++ b/test/features/reports/report_user_page_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+
+import 'package:myapp/features/reports/screens/report_user_page.dart';
+import 'package:myapp/features/reports/services/report_service.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+
+class FakeReportService extends ReportService {
+  bool called = false;
+  FakeReportService()
+      : super(
+          databases: Databases(Client()),
+          databaseId: 'db',
+          collectionId: 'reports',
+        );
+
+  @override
+  Future<void> reportUser(
+    String reporterId,
+    String reportedUserId,
+    String reportType,
+    String description,
+  ) async {
+    called = true;
+  }
+}
+
+class TestAuthController extends AuthController {
+  TestAuthController(String id) {
+    userId = id;
+  }
+
+  @override
+  Future<void> checkExistingSession({bool navigateOnMissing = true}) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    Get.testMode = true;
+  });
+
+  testWidgets('self reporting shows snackbar and aborts', (tester) async {
+    final service = FakeReportService();
+    Get.put<ReportService>(service);
+    Get.put<AuthController>(TestAuthController('u1'));
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        home: const ReportUserPage(userId: 'u1'),
+      ),
+    );
+
+    await tester.tap(find.text('Submit'));
+    await tester.pump();
+
+    expect(service.called, isFalse);
+    expect(find.text('You cannot report yourself'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- prevent reporting yourself in `ReportUserPage`
- add a widget test for the new check

## Testing
- `flutter test --coverage` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfb42986c832d9507732b82694a0b