### PR TITLE
Refactor reporting types to enum

### DIFF
--- a/lib/features/reports/models/report_type.dart
+++ b/lib/features/reports/models/report_type.dart
@@ -1,0 +1,1 @@
+enum ReportType { spam, harassment, nudity, other }

--- a/lib/features/reports/screens/report_post_page.dart
+++ b/lib/features/reports/screens/report_post_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../reports/services/report_service.dart';
+import '../models/report_type.dart';
 import '../../../controllers/auth_controller.dart';
 import '../../../design_system/modern_ui_system.dart';
 
@@ -14,7 +15,7 @@ class ReportPostPage extends StatefulWidget {
 
 class _ReportPostPageState extends State<ReportPostPage> {
   final _descController = TextEditingController();
-  String _type = 'spam';
+  ReportType _type = ReportType.spam;
 
   @override
   void dispose() {
@@ -31,14 +32,15 @@ class _ReportPostPageState extends State<ReportPostPage> {
         padding: EdgeInsets.all(DesignTokens.md(context)),
         child: Column(
           children: [
-            DropdownButtonFormField<String>(
+            DropdownButtonFormField<ReportType>(
               value: _type,
               decoration: const InputDecoration(labelText: 'Type'),
               items: const [
-                DropdownMenuItem(value: 'spam', child: Text('Spam')),
-                DropdownMenuItem(value: 'harassment', child: Text('Harassment')),
-                DropdownMenuItem(value: 'nudity', child: Text('Nudity')),
-                DropdownMenuItem(value: 'other', child: Text('Other')),
+                DropdownMenuItem(value: ReportType.spam, child: Text('Spam')),
+                DropdownMenuItem(
+                    value: ReportType.harassment, child: Text('Harassment')),
+                DropdownMenuItem(value: ReportType.nudity, child: Text('Nudity')),
+                DropdownMenuItem(value: ReportType.other, child: Text('Other')),
               ],
               onChanged: (v) {
                 if (v != null) setState(() => _type = v);

--- a/lib/features/reports/screens/report_user_page.dart
+++ b/lib/features/reports/screens/report_user_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import '../../reports/services/report_service.dart';
+import '../models/report_type.dart';
 import '../../../controllers/auth_controller.dart';
 import '../../../design_system/modern_ui_system.dart';
 
@@ -14,7 +15,7 @@ class ReportUserPage extends StatefulWidget {
 
 class _ReportUserPageState extends State<ReportUserPage> {
   final _descController = TextEditingController();
-  String _type = 'spam';
+  ReportType _type = ReportType.spam;
 
   @override
   void dispose() {
@@ -31,14 +32,15 @@ class _ReportUserPageState extends State<ReportUserPage> {
         padding: EdgeInsets.all(DesignTokens.md(context)),
         child: Column(
           children: [
-            DropdownButtonFormField<String>(
+            DropdownButtonFormField<ReportType>(
               value: _type,
               decoration: const InputDecoration(labelText: 'Type'),
               items: const [
-                DropdownMenuItem(value: 'spam', child: Text('Spam')),
-                DropdownMenuItem(value: 'harassment', child: Text('Harassment')),
-                DropdownMenuItem(value: 'nudity', child: Text('Nudity')),
-                DropdownMenuItem(value: 'other', child: Text('Other')),
+                DropdownMenuItem(value: ReportType.spam, child: Text('Spam')),
+                DropdownMenuItem(
+                    value: ReportType.harassment, child: Text('Harassment')),
+                DropdownMenuItem(value: ReportType.nudity, child: Text('Nudity')),
+                DropdownMenuItem(value: ReportType.other, child: Text('Other')),
               ],
               onChanged: (v) {
                 if (v != null) setState(() => _type = v);

--- a/lib/features/reports/services/report_service.dart
+++ b/lib/features/reports/services/report_service.dart
@@ -1,5 +1,6 @@
 import 'package:appwrite/appwrite.dart';
 import '../../../utils/logger.dart';
+import '../models/report_type.dart';
 
 class ReportService {
   final Databases databases;
@@ -15,7 +16,7 @@ class ReportService {
   Future<void> reportPost(
     String reporterId,
     String postId,
-    String reportType,
+    ReportType reportType,
     String description,
   ) async {
     try {
@@ -26,7 +27,7 @@ class ReportService {
         data: {
           'reporter_id': reporterId,
           'reported_post_id': postId,
-          'report_type': reportType,
+          'report_type': reportType.name,
           'description': description,
           'status': 'pending',
         },
@@ -40,7 +41,7 @@ class ReportService {
   Future<void> reportUser(
     String reporterId,
     String reportedUserId,
-    String reportType,
+    ReportType reportType,
     String description,
   ) async {
     try {
@@ -51,7 +52,7 @@ class ReportService {
         data: {
           'reporter_id': reporterId,
           'reported_user_id': reportedUserId,
-          'report_type': reportType,
+          'report_type': reportType.name,
           'description': description,
           'status': 'pending',
         },

--- a/test/features/reports/report_user_page_test.dart
+++ b/test/features/reports/report_user_page_test.dart
@@ -5,6 +5,7 @@ import 'package:appwrite/appwrite.dart';
 
 import 'package:myapp/features/reports/screens/report_user_page.dart';
 import 'package:myapp/features/reports/services/report_service.dart';
+import 'package:myapp/features/reports/models/report_type.dart';
 import 'package:myapp/controllers/auth_controller.dart';
 
 class FakeReportService extends ReportService {
@@ -20,7 +21,7 @@ class FakeReportService extends ReportService {
   Future<void> reportUser(
     String reporterId,
     String reportedUserId,
-    String reportType,
+    ReportType reportType,
     String description,
   ) async {
     called = true;


### PR DESCRIPTION
## Summary
- add `ReportType` enum
- accept `ReportType` in `ReportService`
- use `ReportType` in report pages
- adjust tests for new enum

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfc4148ac832db218df211a411a9f