### PR TITLE
Add block user tests

### DIFF
--- a/test/features/profile/profile_controller_test.dart
+++ b/test/features/profile/profile_controller_test.dart
@@ -116,4 +116,25 @@ void main() {
     expect(controller.isFollowing.value, isFalse);
     expect(controller.followerCount.value, 1);
   });
+
+  test('blockUser calls service', () async {
+    final service = FakeProfileService();
+    service.profile = UserProfile(id: '2', username: 'other');
+    Get.put<ProfileService>(service);
+    Get.put<AuthController>(FakeAuthController());
+    final controller = ProfileController();
+    await controller.blockUser('2');
+    expect(service.blocked, isTrue);
+  });
+
+  test('unblockUser calls service', () async {
+    final service = FakeProfileService();
+    service.profile = UserProfile(id: '2', username: 'other');
+    service.blocked = true;
+    Get.put<ProfileService>(service);
+    Get.put<AuthController>(FakeAuthController());
+    final controller = ProfileController();
+    await controller.unblockUser('2');
+    expect(service.blocked, isFalse);
+  });
 }

--- a/test/features/profile/profile_service_block_test.dart
+++ b/test/features/profile/profile_service_block_test.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:myapp/features/profile/services/profile_service.dart';
+
+class OfflineDatabases extends Databases {
+  OfflineDatabases() : super(Client());
+
+  @override
+  Future<Document> createDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+    required Map<dynamic, dynamic> data,
+    List<String>? permissions,
+  }) {
+    return Future.error('offline');
+  }
+
+  @override
+  Future<DocumentList> listDocuments({
+    required String databaseId,
+    required String collectionId,
+    List<String>? queries,
+  }) {
+    return Future.error('offline');
+  }
+
+  @override
+  Future<void> deleteDocument({
+    required String databaseId,
+    required String collectionId,
+    required String documentId,
+  }) {
+    return Future.error('offline');
+  }
+}
+
+void main() {
+  late Directory dir;
+  late ProfileService service;
+
+  setUp(() async {
+    dir = await Directory.systemTemp.createTemp();
+    Hive.init(dir.path);
+    await Hive.openBox('blocks');
+    service = ProfileService(
+      databases: OfflineDatabases(),
+      databaseId: 'db',
+      profilesCollection: 'profiles',
+      followsCollection: 'follows',
+      blocksCollection: 'blocks',
+    );
+  });
+
+  tearDown(() async {
+    await Hive.deleteFromDisk();
+    await dir.delete(recursive: true);
+  });
+
+  test('blockUser stores entry when offline', () async {
+    await service.blockUser('u1', 'u2');
+    expect(Hive.box('blocks').containsKey('u1_u2'), isTrue);
+  });
+
+  test('unblockUser removes entry when offline', () async {
+    Hive.box('blocks').put('u1_u2', {'blocked_id': 'u2'});
+    await service.unblockUser('u1', 'u2');
+    expect(Hive.box('blocks').containsKey('u1_u2'), isFalse);
+  });
+}

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -194,6 +194,20 @@ void main() {
     expect(controller.posts, isEmpty);
   });
 
+  test('loadPosts filters blocked user ids', () async {
+    final service = FakeFeedService();
+    final controller = FeedController(service: service);
+    service.store.addAll([
+      FeedPost(id: '1', roomId: 'room', userId: 'u1', username: 'user1', content: 'hi'),
+      FeedPost(id: '2', roomId: 'room', userId: 'u2', username: 'user2', content: 'yo'),
+    ]);
+
+    await controller.loadPosts('room', blockedIds: ['u2']);
+
+    expect(controller.posts.length, 1);
+    expect(controller.posts.first.id, '1');
+  });
+
   test('createPost adds to list', () async {
     final service = FakeFeedService();
     final controller = FeedController(service: service);


### PR DESCRIPTION
## Summary
- extend profile controller tests for block/unblock
- cover profile service block/unblock offline caching
- verify feed controller filters blocked user IDs

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dfe50e4e8832d865e4f8123825332