### PR TITLE
Handle mention lists in cached feed data

### DIFF
--- a/lib/features/social_feed/models/post_comment.dart
+++ b/lib/features/social_feed/models/post_comment.dart
@@ -7,6 +7,7 @@ class PostComment {
   final String? parentId;
   final String content;
   final List<String> mediaUrls;
+  final List<String> mentions;
   final int likeCount;
   final int replyCount;
   final bool isDeleted;
@@ -20,6 +21,7 @@ class PostComment {
     this.parentId,
     required this.content,
     this.mediaUrls = const [],
+    this.mentions = const [],
     this.likeCount = 0,
     this.replyCount = 0,
     this.isDeleted = false,
@@ -35,6 +37,7 @@ class PostComment {
       parentId: json['parent_id'],
       content: json['content'] ?? '',
       mediaUrls: (json['media_urls'] as List?)?.cast<String>() ?? const [],
+      mentions: (json['mentions'] as List?)?.cast<String>() ?? const [],
       likeCount: json['like_count'] ?? 0,
       replyCount: json['reply_count'] ?? 0,
       isDeleted: json['is_deleted'] ?? false,
@@ -51,6 +54,7 @@ class PostComment {
       'parent_id': parentId,
       'content': content,
       'media_urls': mediaUrls,
+      'mentions': mentions,
       'like_count': likeCount,
       'reply_count': replyCount,
       'is_deleted': isDeleted,

--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -147,6 +147,7 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                       username: uname,
                       parentId: root.id,
                       content: sanitized,
+                      mentions: mentions,
                     );
                     commentsController.replyToComment(comment);
                     await Get.find<MentionService>().notifyMentions(

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -143,6 +143,7 @@ class _PostDetailPageState extends State<PostDetailPage> {
                       userId: uid,
                       username: uname,
                       content: sanitized,
+                      mentions: mentions,
                     );
                     commentsController.addComment(comment);
                     await Get.find<MentionService>().notifyMentions(

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -825,11 +825,15 @@ class FeedService {
             final c =
                 PostComment.fromJson(Map<String, dynamic>.from(item['data']));
             final newId = await createComment(c);
-            final mentionNames = _limitMentions(RegExp(r'@([A-Za-z0-9_]+)')
-                .allMatches(c.content)
-                .map((m) => m.group(1)!)
-                .toSet()
-                .toList());
+            final mentionNames = _limitMentions(
+              c.mentions.isNotEmpty
+                  ? c.mentions
+                  : RegExp(r'@([A-Za-z0-9_]+)')
+                      .allMatches(c.content)
+                      .map((m) => m.group(1)!)
+                      .toSet()
+                      .toList(),
+            );
             await commentsBox.delete(c.id);
             final listKey = 'comments_${c.postId}';
             final list = (commentsBox.get(listKey, defaultValue: []) as List)

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -206,12 +206,14 @@ void main() {
         'user_id': 'u',
         'username': 'name',
         'content': 'hi',
+        'mentions': ['bob'],
         '_cachedAt': DateTime.now().toIso8601String(),
       }
     ]);
     final posts = await service.getPosts('room');
     expect(posts, isNotEmpty);
     expect(posts.first.content, 'hi');
+    expect(posts.first.mentions, ['bob']);
   });
 
   test('createLike queues when offline', () async {
@@ -368,6 +370,7 @@ void main() {
       userId: 'u',
       username: 'name',
       content: 'hi',
+      mentions: ['alice'],
     );
     await service.createComment(comment);
     expect((Hive.box('comments').get('comments_p_restart') as List).isNotEmpty, isTrue);
@@ -399,6 +402,7 @@ void main() {
     final comments = await newService.getComments('p_restart');
     expect(comments.length, 1);
     expect(comments.first.id, 'c_restart');
+    expect(comments.first.mentions, ['alice']);
   });
 
   test('syncQueuedActions removes offline placeholder comments', () async {


### PR DESCRIPTION
## Summary
- add `mentions` field to `PostComment`
- store mentions when creating comments from UI
- persist comment mentions when syncing queued actions
- include mentions in cached posts and comments tests

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0792f798832db3e8e8001542b845