### PR TITLE
Return created document IDs for posts and comments

### DIFF
--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -149,10 +149,10 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                       content: sanitized,
                       mentions: mentions,
                     );
-                    commentsController.replyToComment(comment);
+                    final id = await commentsController.replyToComment(comment);
                     await Get.find<MentionService>().notifyMentions(
                       mentions,
-                      comment.id,
+                      id,
                       'comment',
                     );
                     await _notifyParentAuthor(root.userId, root.id);

--- a/lib/features/social_feed/screens/compose_post_page.dart
+++ b/lib/features/social_feed/screens/compose_post_page.dart
@@ -128,7 +128,7 @@ class _ComposePostPageState extends State<ComposePostPage> {
                     final linkText = _linkController.text.trim();
                     if (linkText.isNotEmpty && isURL(linkText) &&
                         linkText.startsWith('http')) {
-                      await feedController.createPostWithLink(
+                      final id = await feedController.createPostWithLink(
                         uid,
                         uname,
                         sanitized,
@@ -139,11 +139,11 @@ class _ComposePostPageState extends State<ComposePostPage> {
                       );
                       await Get.find<MentionService>().notifyMentions(
                         mentions,
-                        feedController.posts.first.id,
+                        id,
                         'post',
                       );
                     } else if (_image != null) {
-                      await feedController.createPostWithImage(
+                      final id = await feedController.createPostWithImage(
                         uid,
                         uname,
                         sanitized,
@@ -154,7 +154,7 @@ class _ComposePostPageState extends State<ComposePostPage> {
                       );
                       await Get.find<MentionService>().notifyMentions(
                         mentions,
-                        feedController.posts.first.id,
+                        id,
                         'post',
                       );
                     } else {
@@ -169,10 +169,10 @@ class _ComposePostPageState extends State<ComposePostPage> {
                         mentions: mentions,
                         createdAt: now,
                       );
-                      await feedController.createPost(post);
+                      final id = await feedController.createPost(post);
                       await Get.find<MentionService>().notifyMentions(
                         mentions,
-                        post.id,
+                        id,
                         'post',
                       );
                     }

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -145,10 +145,10 @@ class _PostDetailPageState extends State<PostDetailPage> {
                       content: sanitized,
                       mentions: mentions,
                     );
-                    commentsController.addComment(comment);
+                    final id = await commentsController.addComment(comment);
                     await Get.find<MentionService>().notifyMentions(
                       mentions,
-                      comment.id,
+                      id,
                       'comment',
                     );
                     await _notifyPostAuthor(widget.post.userId, widget.post.id);

--- a/test/features/social_feed/comments_controller_counts_test.dart
+++ b/test/features/social_feed/comments_controller_counts_test.dart
@@ -36,8 +36,9 @@ class _RecordingFeedService extends FeedService {
   }
 
   @override
-  Future<void> createComment(PostComment comment) async {
+  Future<String?> createComment(PostComment comment) async {
     store.add(comment);
+    return comment.id;
   }
 
   @override

--- a/test/features/social_feed/comments_controller_test.dart
+++ b/test/features/social_feed/comments_controller_test.dart
@@ -109,8 +109,9 @@ class ServiceWithPosts extends FeedService {
   }
 
   @override
-  Future<void> createPost(FeedPost post) async {
+  Future<String?> createPost(FeedPost post) async {
     posts.add(post);
+    return post.id;
   }
 
   @override

--- a/test/features/social_feed/feed_controller_test.dart
+++ b/test/features/social_feed/feed_controller_test.dart
@@ -40,8 +40,9 @@ class FakeFeedService extends FeedService {
   }
 
   @override
-  Future<void> createPost(FeedPost post) async {
+  Future<String?> createPost(FeedPost post) async {
     store.add(post);
+    return post.id;
   }
 
   @override

--- a/test/features/social_feed/mentions_limit_test.dart
+++ b/test/features/social_feed/mentions_limit_test.dart
@@ -29,8 +29,9 @@ class RecordingFeedService extends FeedService {
   final List<FeedPost> store = [];
 
   @override
-  Future<void> createPost(FeedPost post) async {
+  Future<String?> createPost(FeedPost post) async {
     store.add(post);
+    return post.id;
   }
 }
 

--- a/test/features/social_feed/offline_queue_replay_test.dart
+++ b/test/features/social_feed/offline_queue_replay_test.dart
@@ -39,8 +39,9 @@ class _RecordingService extends FeedService {
         );
 
   @override
-  Future<void> createComment(PostComment comment) async {
+  Future<String?> createComment(PostComment comment) async {
     created.add(comment.id);
+    return comment.id;
   }
 }
 

--- a/test/features/social_feed/reaction_bar_update_test.dart
+++ b/test/features/social_feed/reaction_bar_update_test.dart
@@ -35,8 +35,9 @@ class _FakeService extends FeedService {
   }
 
   @override
-  Future<void> createPost(FeedPost post) async {
+  Future<String?> createPost(FeedPost post) async {
     posts.add(post);
+    return post.id;
   }
 
   @override
@@ -49,8 +50,9 @@ class _FakeService extends FeedService {
   }
 
   @override
-  Future<void> createComment(PostComment comment) async {
+  Future<String?> createComment(PostComment comment) async {
     comments.add(comment);
+    return comment.id;
   }
 
   @override


### PR DESCRIPTION
## Summary
- return created Appwrite IDs from posting helpers
- update feed and comments controllers to use the returned IDs
- notify mentions with the real IDs in post and comment pages
- update offline sync logic to notify mentions with real IDs
- adjust tests for new method signatures

## Testing
- `dart test` *(fails: `dart` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0a93a3ec832d9e3533e26cb5b93a