### PR TITLE
Fix username parsing

### DIFF
--- a/lib/features/social_feed/widgets/comment_card.dart
+++ b/lib/features/social_feed/widgets/comment_card.dart
@@ -21,7 +21,8 @@ class CommentCard extends StatelessWidget {
     final words = comment.content.split(RegExp(r'(\s+)'));
     for (final word in words) {
       if (word.startsWith('@')) {
-        final name = word.substring(1);
+        final name =
+            word.substring(1).replaceAll(RegExp(r'[!?,.:;]+$'), '');
         spans.add(TextSpan(
           text: '$word ',
           style: TextStyle(color: Theme.of(context).colorScheme.primary),

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -58,7 +58,8 @@ class PostCard extends StatelessWidget {
             },
         ));
       } else if (word.startsWith('@')) {
-        final name = word.substring(1);
+        final name =
+            word.substring(1).replaceAll(RegExp(r'[!?,.:;]+$'), '');
         spans.add(TextSpan(
           text: '$word ',
           style: TextStyle(color: Theme.of(context).colorScheme.primary),


### PR DESCRIPTION
## Summary
- sanitize usernames in `comment_card.dart` to avoid trailing punctuation
- do the same username sanitizing in `post_card.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e0d41d394832da2344442d1a7a78a