### PR TITLE
Add mention parsing tests

### DIFF
--- a/test/features/social_feed/compose_post_mentions_limit_test.dart
+++ b/test/features/social_feed/compose_post_mentions_limit_test.dart
@@ -1,0 +1,128 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+
+import 'package:myapp/features/social_feed/screens/compose_post_page.dart';
+import 'package:myapp/features/social_feed/controllers/feed_controller.dart';
+import 'package:myapp/features/social_feed/models/feed_post.dart';
+import 'package:myapp/features/social_feed/services/feed_service.dart';
+import 'package:myapp/features/social_feed/services/mention_service.dart';
+import 'package:myapp/features/notifications/services/notification_service.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+import 'package:myapp/design_system/modern_ui_system.dart';
+
+class TestFeedService extends FeedService {
+  TestFeedService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          bookmarksCollectionId: 'bookmarks',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'link',
+        );
+
+  final List<FeedPost> posts = [];
+
+  @override
+  Future<String?> createPost(FeedPost post) async {
+    posts.add(post);
+    return post.id;
+  }
+
+  @override
+  Future<void> saveHashtags(List<String> tags) async {}
+}
+
+class RecordingMentionService extends MentionService {
+  RecordingMentionService({required super.databases, required super.notificationService, required super.databaseId, required super.profilesCollectionId});
+
+  final List<Map<String, dynamic>> calls = [];
+
+  @override
+  Future<void> notifyMentions(List<String> mentions, String itemId, String itemType) async {
+    calls.add({'mentions': mentions, 'itemId': itemId, 'itemType': itemType});
+  }
+}
+
+class DummyNotificationService extends NotificationService {
+  DummyNotificationService()
+      : super(
+          databases: Databases(Client()),
+          databaseId: 'db',
+          collectionId: 'col',
+          connectivity: Connectivity(),
+        );
+
+  @override
+  Future<void> createNotification(String userId, String actorId, String actionType, {String? itemId, String? itemType}) async {}
+}
+
+class TestAuthController extends AuthController {
+  TestAuthController() {
+    account = Account(client);
+    databases = Databases(client);
+    storage = Storage(client);
+    userId = 'u1';
+    username.value = 'tester';
+  }
+
+  @override
+  Future<void> checkExistingSession({bool navigateOnMissing = true}) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUp(() {
+    Get.testMode = true;
+    Get.put<AuthController>(TestAuthController());
+  });
+
+  tearDown(() {
+    Get.reset();
+  });
+
+  testWidgets('posting truncates mentions to first 10', (tester) async {
+    final service = TestFeedService();
+    final controller = FeedController(service: service);
+    Get.put<FeedController>(controller);
+
+    final mentionService = RecordingMentionService(
+      databases: Databases(Client()),
+      notificationService: DummyNotificationService(),
+      databaseId: 'db',
+      profilesCollectionId: 'profiles',
+    );
+    Get.put<MentionService>(mentionService);
+    Get.put<NotificationService>(DummyNotificationService());
+
+    await tester.pumpWidget(
+      GetMaterialApp(
+        theme: MD3ThemeSystem.createTheme(
+          seedColor: Colors.blue,
+          brightness: Brightness.light,
+        ),
+        home: const ComposePostPage(roomId: 'r1'),
+      ),
+    );
+
+    await tester.pump();
+    final text = List.generate(12, (i) => '@user$i').join(' ');
+    await tester.enterText(find.byType(TextField), text);
+    await tester.tap(find.text('Post'));
+    await tester.pump();
+
+    expect(service.posts.first.mentions.length, 10);
+    final call = mentionService.calls.first;
+    expect(call['mentions'].length, 10);
+  });
+}
+

--- a/test/features/social_feed/mention_punctuation_profile_test.dart
+++ b/test/features/social_feed/mention_punctuation_profile_test.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:get/get.dart';
+import 'package:appwrite/appwrite.dart';
+import 'package:appwrite/models.dart' as models;
+
+import 'package:myapp/features/social_feed/widgets/post_card.dart';
+import 'package:myapp/features/social_feed/models/feed_post.dart';
+import 'package:myapp/features/bookmarks/controllers/bookmark_controller.dart';
+import 'package:myapp/features/social_feed/controllers/feed_controller.dart';
+import 'package:myapp/controllers/auth_controller.dart';
+
+class RecordingDatabases extends Databases {
+  RecordingDatabases() : super(Client());
+  List<String>? queries;
+  @override
+  Future<models.DocumentList> listDocuments({
+    required String databaseId,
+    required String collectionId,
+    List<String>? queries,
+  }) async {
+    this.queries = queries;
+    return models.DocumentList(total: 1, documents: [
+      models.Document.fromMap({
+        '\$id': 'uid',
+        '\$collectionId': collectionId,
+        '\$databaseId': databaseId,
+        '\$createdAt': '',
+        '\$updatedAt': '',
+        '\$permissions': [],
+        'username': 'alice',
+      })
+    ]);
+  }
+}
+
+class TestAuthController extends AuthController {
+  TestAuthController(this.db) {
+    account = Account(client);
+    databases = db;
+    storage = Storage(client);
+    userId = 'u1';
+    username.value = 'tester';
+  }
+  final Databases db;
+  @override
+  Future<void> checkExistingSession({bool navigateOnMissing = true}) async {}
+}
+
+class FakeFeedService extends FeedService {
+  FakeFeedService()
+      : super(
+          databases: Databases(Client()),
+          storage: Storage(Client()),
+          functions: Functions(Client()),
+          databaseId: 'db',
+          postsCollectionId: 'posts',
+          commentsCollectionId: 'comments',
+          likesCollectionId: 'likes',
+          repostsCollectionId: 'reposts',
+          bookmarksCollectionId: 'bookmarks',
+          connectivity: Connectivity(),
+          linkMetadataFunctionId: 'fetch_link_metadata',
+        );
+
+  @override
+  Future<List<FeedPost>> getPosts(String roomId, {List<String> blockedIds = const []}) async => [];
+
+  @override
+  Future<PostLike?> getUserLike(String itemId, String userId) async => null;
+
+  @override
+  Future<String?> createRepost(Map<String, dynamic> repost) async => 'r1';
+
+  @override
+  Future<void> deleteRepost(String repostId, String postId) async {}
+
+  @override
+  Future<PostRepost?> getUserRepost(String postId, String userId) async => null;
+
+  @override
+  Future<void> createLike(Map<String, dynamic> like) async {}
+
+  @override
+  Future<void> deleteLike(String likeId, {required String itemId, required String itemType}) async {}
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late RecordingDatabases db;
+
+  setUp(() {
+    Get.testMode = true;
+    db = RecordingDatabases();
+    Get.put<AuthController>(TestAuthController(db));
+    final service = FakeFeedService();
+    Get.put<FeedController>(FeedController(service: service));
+    Get.put<BookmarkController>(BookmarkController(service: service));
+  });
+
+  tearDown(Get.reset);
+
+  testWidgets('mentions with punctuation open profile', (tester) async {
+    final post = FeedPost(
+      id: 'p1',
+      roomId: 'r1',
+      userId: 'u1',
+      username: 'tester',
+      content: 'hello @alice, welcome',
+      createdAt: DateTime.now(),
+    );
+
+    await tester.pumpWidget(GetMaterialApp(home: PostCard(post: post)));
+    await tester.tap(find.textContaining('@alice,'));
+    await tester.pump();
+
+    expect(db.queries?.first.contains('alice'), isTrue);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add widget test covering mention punctuation linking to profile
- add compose post mention limit test ensuring only first 10 mentions are kept

## Testing
- `flutter test test/features/social_feed/mention_punctuation_profile_test.dart` *(fails: flutter not installed)*
- `flutter test test/features/social_feed/compose_post_mentions_limit_test.dart` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684e0f39c104832db3b6be78038b5454