### PR TITLE
Fix feed page syntax and alias responsive utils

### DIFF
--- a/lib/features/profile/screens/profile_page.dart
+++ b/lib/features/profile/screens/profile_page.dart
@@ -9,7 +9,8 @@ import '../../reports/screens/report_user_page.dart';
 import '../../../bindings/report_binding.dart';
 import '../../../bindings/profile_binding.dart';
 import '../../../design_system/modern_ui_system.dart';
-import '../../../widgets/enhanced_responsive_layout.dart';
+import '../../../widgets/enhanced_responsive_layout.dart'
+    as responsive;
 
 class UserProfilePage extends StatefulWidget {
   final String userId;
@@ -41,7 +42,7 @@ class _UserProfilePageState extends State<UserProfilePage> {
         }
         final isFollowing = controller.isFollowing.value;
         final count = controller.followerCount.value;
-        return EnhancedResponsiveLayout(
+          return responsive.EnhancedResponsiveLayout(
           mobile: (context) =>
               _buildPortraitLayout(context, profile, isFollowing, count),
           mobileLandscape: (context) =>

--- a/lib/features/social_feed/screens/feed_page.dart
+++ b/lib/features/social_feed/screens/feed_page.dart
@@ -55,7 +55,8 @@ class _FeedPageState extends State<FeedPage> {
           ),
         ],
       ),
-    );
+    ),
+  );
   }
 
   @override


### PR DESCRIPTION
## Summary
- fix missing parentheses in `feed_page.dart`
- avoid `ResponsiveUtils` name clash in `profile_page.dart` by aliasing

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e14458ccc832dbacd4829bfe99607