### PR TITLE
Optimize data fetching and caching

### DIFF
--- a/lib/features/profile/services/profile_service.dart
+++ b/lib/features/profile/services/profile_service.dart
@@ -13,6 +13,7 @@ class ProfileService {
   final Box profileBox = Hive.box('profiles');
   final Box followsBox = Hive.box('follows');
   final Box blocksBox = Hive.box('blocks');
+  final Map<String, String> _usernameToId = {};
 
   ProfileService({
     required this.databases,
@@ -162,6 +163,24 @@ class ProfileService {
     } catch (_) {
       blocksBox.delete('${blockerId}_$blockedId');
     }
+  }
+
+  Future<String?> getUserIdByUsername(String username) async {
+    if (_usernameToId.containsKey(username)) return _usernameToId[username];
+    try {
+      final res = await databases.listDocuments(
+        databaseId: databaseId,
+        collectionId: profilesCollection,
+        queries: [Query.equal('username', username)],
+      );
+      if (res.documents.isNotEmpty) {
+        final id = res.documents.first.data['\$id'] ??
+            res.documents.first.data['id'];
+        _usernameToId[username] = id;
+        return id;
+      }
+    } catch (_) {}
+    return null;
   }
 
   List<String> getBlockedIds(String blockerId) {

--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -55,11 +55,13 @@ class CommentsController extends GetxController {
       _replyCounts.addAll({for (final c in data) c.id: c.replyCount});
       final auth = Get.find<AuthController>();
       final uid = auth.userId;
-      if (uid != null) {
-        for (final c in data) {
-          final like = await service.getUserLike(c.id, uid);
-          if (like != null) _likedIds[c.id] = like.id;
-        }
+      if (uid != null && data.isNotEmpty) {
+        final ids = data.map((c) => c.id).toList();
+        final likeMap =
+            await service.getUserLikesBulk(ids, uid, itemType: 'comment');
+        _likedIds.addAll({
+          for (final entry in likeMap.entries) entry.key: entry.value.id
+        });
       }
       if (data.isNotEmpty) _nextCursor = data.last.id;
       _listenToRealtime(postId);

--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -68,13 +68,17 @@ class FeedController extends GetxController {
       _commentCounts.assignAll({for (final p in filtered) p.id: p.commentCount});
       final auth = Get.find<AuthController>();
       final uid = auth.userId;
-      if (uid != null) {
-        for (final post in filtered) {
-          final like = await service.getUserLike(post.id, uid);
-          if (like != null) _likedIds[post.id] = like.id;
-          final repost = await service.getUserRepost(post.id, uid);
-          if (repost != null) _repostedIds[post.id] = repost.id;
-        }
+      if (uid != null && filtered.isNotEmpty) {
+        final ids = filtered.map((p) => p.id).toList();
+        final likeMap =
+            await service.getUserLikesBulk(ids, uid, itemType: 'post');
+        _likedIds.assignAll({
+          for (final entry in likeMap.entries) entry.key: entry.value.id
+        });
+        final repostMap = await service.getUserRepostsBulk(ids, uid);
+        _repostedIds.assignAll({
+          for (final entry in repostMap.entries) entry.key: entry.value.id
+        });
       }
     } finally {
       _isLoading.value = false;

--- a/lib/features/social_feed/widgets/comment_card.dart
+++ b/lib/features/social_feed/widgets/comment_card.dart
@@ -11,6 +11,7 @@ import 'package:appwrite/appwrite.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../../profile/screens/profile_page.dart';
 import '../../../bindings/profile_binding.dart';
+import '../../profile/services/profile_service.dart';
 
 class CommentCard extends StatelessWidget {
   final PostComment comment;
@@ -44,18 +45,11 @@ class CommentCard extends StatelessWidget {
   }
 
   Future<void> _openProfile(String username) async {
-    final auth = Get.find<AuthController>();
-    final dbId = dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB';
-    final profilesId =
-        dotenv.env['USER_PROFILES_COLLECTION_ID'] ?? 'user_profiles';
-    final res = await auth.databases.listDocuments(
-      databaseId: dbId,
-      collectionId: profilesId,
-      queries: [Query.equal('username', username)],
-    );
-    if (res.documents.isNotEmpty) {
+    final id = await Get.find<ProfileService>()
+        .getUserIdByUsername(username);
+    if (id != null) {
       Get.to(
-        () => UserProfilePage(userId: res.documents.first.data['\$id']),
+        () => UserProfilePage(userId: id),
         binding: ProfileBinding(),
       );
     }

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -20,24 +20,18 @@ import 'package:flutter_dotenv/flutter_dotenv.dart';
 import '../../profile/screens/profile_page.dart';
 import '../../../bindings/profile_binding.dart';
 import 'package:appwrite/appwrite.dart';
+import '../../profile/services/profile_service.dart';
 
 class PostCard extends StatelessWidget {
   final FeedPost post;
   const PostCard({super.key, required this.post});
 
   Future<void> _openProfile(String username) async {
-    final auth = Get.find<AuthController>();
-    final dbId = dotenv.env['APPWRITE_DATABASE_ID'] ?? 'StarChat_DB';
-    final profilesId =
-        dotenv.env['USER_PROFILES_COLLECTION_ID'] ?? 'user_profiles';
-    final res = await auth.databases.listDocuments(
-      databaseId: dbId,
-      collectionId: profilesId,
-      queries: [Query.equal('username', username)],
-    );
-    if (res.documents.isNotEmpty) {
+    final id = await Get.find<ProfileService>()
+        .getUserIdByUsername(username);
+    if (id != null) {
       Get.to(
-        () => UserProfilePage(userId: res.documents.first.data['\$id']),
+        () => UserProfilePage(userId: id),
         binding: ProfileBinding(),
       );
     }


### PR DESCRIPTION
## Summary
- cache usernames in `ProfileService` and use for profile page navigation
- fetch likes and reposts in batches to reduce sequential queries
- compress images on a background isolate
- update watchlist counts concurrently

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e17af10f0832d95df04dd515e811c