### PR TITLE
Ensure feed comment count handles replies

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -94,10 +94,11 @@ class CommentsController extends GetxController {
         .logActivity(comment.userId, action, itemId: id, itemType: 'comment');
     _likeCounts[id] = comment.likeCount;
     _replyCounts[id] = comment.replyCount;
+    if (Get.isRegistered<FeedController>()) {
+      Get.find<FeedController>().incrementCommentCount(comment.postId);
+    }
     if (comment.parentId != null) {
       incrementReplyCount(comment.parentId!);
-    } else if (Get.isRegistered<FeedController>()) {
-      Get.find<FeedController>().incrementCommentCount(comment.postId);
     }
     return id;
   }
@@ -143,10 +144,11 @@ class CommentsController extends GetxController {
     _likeCounts.remove(commentId);
     if (comment != null) {
       _replyCounts.remove(commentId);
+      if (Get.isRegistered<FeedController>()) {
+        Get.find<FeedController>().decrementCommentCount(comment.postId);
+      }
       if (comment.parentId != null) {
         decrementReplyCount(comment.parentId!);
-      } else if (Get.isRegistered<FeedController>()) {
-        Get.find<FeedController>().decrementCommentCount(comment.postId);
       }
     }
   }
@@ -189,10 +191,11 @@ class CommentsController extends GetxController {
             _comments.add(comment);
             _likeCounts[id] = comment.likeCount;
             _replyCounts[id] = comment.replyCount;
+            if (Get.isRegistered<FeedController>()) {
+              Get.find<FeedController>().incrementCommentCount(comment.postId);
+            }
             if (comment.parentId != null) {
               incrementReplyCount(comment.parentId!);
-            } else if (Get.isRegistered<FeedController>()) {
-              Get.find<FeedController>().incrementCommentCount(comment.postId);
             }
           }
         } else if ((event.events.any((e) => e.contains('.update')) &&
@@ -202,11 +205,12 @@ class CommentsController extends GetxController {
           _likedIds.remove(id);
           _likeCounts.remove(id);
           _replyCounts.remove(id);
+          if (Get.isRegistered<FeedController>()) {
+            Get.find<FeedController>().decrementCommentCount(payload['post_id']);
+          }
           final parentId = payload['parent_id'];
           if (parentId != null) {
             decrementReplyCount(parentId as String);
-          } else if (Get.isRegistered<FeedController>()) {
-            Get.find<FeedController>().decrementCommentCount(payload['post_id']);
           }
         }
       }

--- a/test/features/social_feed/comments_controller_counts_test.dart
+++ b/test/features/social_feed/comments_controller_counts_test.dart
@@ -66,6 +66,7 @@ void main() {
     final post = FeedPost(id: 'p1', roomId: 'room', userId: 'u', username: 'user', content: 'post');
     service.store.add(PostComment(id: 'parent', postId: 'p1', userId: 'u', username: 'user', content: 'parent'));
     await feed.loadPosts('room');
+    expect(feed.postCommentCount('p1'), 0);
     final controller = CommentsController(service: service);
     await controller.loadComments('p1');
 


### PR DESCRIPTION
## Summary
- call `FeedController.incrementCommentCount` whenever adding a comment
- always decrement the count on comment deletion
- update realtime handlers with the new logic
- verify reply operations update post counts in the comments controller counts test

## Testing
- `flutter test test/features/social_feed/comments_controller_counts_test.dart` *(fails: `flutter` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc6e99e2c832db7af24aba3c0c3bf