### PR TITLE
Fix ReactionBar wrapping

### DIFF
--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -92,9 +92,6 @@ class ReactionBar extends StatelessWidget {
     final children = <Widget>[];
 
     void addItem(Widget item) {
-      if (children.isNotEmpty) {
-        children.add(SizedBox(width: DesignTokens.sm(context)));
-      }
       children.add(item);
     }
 
@@ -168,6 +165,10 @@ class ReactionBar extends StatelessWidget {
       );
     }
 
-    return Row(children: children);
+    return Wrap(
+      spacing: DesignTokens.sm(context),
+      runSpacing: DesignTokens.sm(context),
+      children: children,
+    );
   }
 }

--- a/test/features/social_feed/reaction_bar_wrap_test.dart
+++ b/test/features/social_feed/reaction_bar_wrap_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:myapp/features/social_feed/widgets/reaction_bar.dart';
+
+void main() {
+  testWidgets('ReactionBar wraps in small width without overflow', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: SizedBox(
+          width: 150,
+          child: ReactionBar(
+            onLike: null,
+            onComment: null,
+            onRepost: null,
+            onBookmark: null,
+            onShare: null,
+            likeCount: 1,
+            commentCount: 1,
+            repostCount: 1,
+            shareCount: 1,
+          ),
+        ),
+      ),
+    );
+    await tester.pump();
+    expect(find.byType(Wrap), findsOneWidget);
+    expect(tester.takeException(), isNull);
+  });
+}


### PR DESCRIPTION
## Summary
- use Wrap for ReactionBar and DesignTokens spacing
- add widget test to ensure ReactionBar doesn't overflow

## Testing
- `flutter analyze` *(fails: 664 issues found)*
- `flutter test test/features/social_feed/reaction_bar_wrap_test.dart` *(fails to compile)*

------
https://chatgpt.com/codex/tasks/task_e_684fcf2be69c832d802dd86cfb6c02ea