### PR TITLE
Fix userId management and remove empty ID fallbacks

### DIFF
--- a/lib/features/authentication/controllers/auth_controller.dart
+++ b/lib/features/authentication/controllers/auth_controller.dart
@@ -140,6 +140,7 @@ class AuthController extends GetxController {
       logger.i(
           "[Auth] checkExistingSession: account.get() succeeded. User ID: ${session.$id}, Email: ${session.email}");
 
+      userId = session.$id;
       bool hasUsername = await ensureUsername();
       if (hasUsername) {
         logger.i(
@@ -318,7 +319,8 @@ class AuthController extends GetxController {
 
     isLoading.value = true;
     try {
-      await account.get();
+      final session = await account.get();
+      userId = session.$id;
       Get.offAllNamed('/home');
       clearControllers();
       isOTPSent.value = false;
@@ -337,11 +339,12 @@ class AuthController extends GetxController {
         return;
       }
       try {
-        await account.createSession(
+        final session = await account.createSession(
           userId: userId!,
           secret: otp,
         );
 
+        userId = session.$id;
         otpError.value = '';
         bool hasUsername = await ensureUsername();
         if (hasUsername) {
@@ -474,6 +477,7 @@ class AuthController extends GetxController {
     try {
       final session = await account.get();
       final uid = session.$id;
+      userId = uid;
       logger.i(
           "[Auth] ensureUsername: Fetched session successfully. User ID for query: $uid, Email: ${session.email}");
 

--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -41,10 +41,11 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
     if (!Get.isRegistered<NotificationService>()) return;
     try {
       final auth = Get.find<AuthController>();
-      if (authorId == auth.userId) return;
+      final uid = auth.userId;
+      if (uid == null || authorId == uid) return;
       await Get.find<NotificationService>().createNotification(
         authorId,
-        auth.userId ?? '',
+        uid,
         'reply',
         itemId: commentId,
         itemType: 'comment',
@@ -123,7 +124,11 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
                     }
 
                     final root = widget.rootComment;
-                    final uid = auth.userId ?? '';
+                    final uid = auth.userId;
+                    if (uid == null) {
+                      Get.snackbar('Error', 'Login required');
+                      return;
+                    }
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value
                         : 'You';

--- a/lib/features/social_feed/screens/compose_post_page.dart
+++ b/lib/features/social_feed/screens/compose_post_page.dart
@@ -85,7 +85,11 @@ class _ComposePostPageState extends State<ComposePostPage> {
                 const Spacer(),
                 AnimatedButton(
                   onPressed: () async {
-                    final uid = auth.userId ?? '';
+                    final uid = auth.userId;
+                    if (uid == null) {
+                      Get.snackbar('Error', 'Login required');
+                      return;
+                    }
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value
                         : 'You';

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -30,10 +30,11 @@ class _PostDetailPageState extends State<PostDetailPage> {
     if (!Get.isRegistered<NotificationService>()) return;
     try {
       final auth = Get.find<AuthController>();
-      if (authorId == auth.userId) return;
+      final uid = auth.userId;
+      if (uid == null || authorId == uid) return;
       await Get.find<NotificationService>().createNotification(
         authorId,
-        auth.userId ?? '',
+        uid,
         'comment',
         itemId: postId,
         itemType: 'post',
@@ -129,7 +130,11 @@ class _PostDetailPageState extends State<PostDetailPage> {
 
                     final sanitized = HtmlUnescape().convert(text);
 
-                    final uid = auth.userId ?? '';
+                    final uid = auth.userId;
+                    if (uid == null) {
+                      Get.snackbar('Error', 'Login required');
+                      return;
+                    }
                     final uname = auth.username.value.isNotEmpty
                         ? auth.username.value
                         : 'You';

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -95,8 +95,13 @@ class PostCard extends StatelessWidget {
     }
   }
 
-  void _handleBookmark(BookmarkController controller, String userId) {
-    controller.toggleBookmark(userId, post.id);
+  void _handleBookmark(BookmarkController controller) {
+    final uid = Get.find<AuthController>().userId;
+    if (uid == null) {
+      Get.snackbar('Error', 'Login required');
+      return;
+    }
+    controller.toggleBookmark(uid, post.id);
   }
 
 
@@ -263,7 +268,7 @@ class PostCard extends StatelessWidget {
               onLike: () => _handleLike(controller),
               onComment: _handleComment,
               onRepost: () => _handleRepost(controller),
-              onBookmark: () => _handleBookmark(bookmarkController, auth.userId ?? ''),
+              onBookmark: () => _handleBookmark(bookmarkController),
               postId: post.id,
               isReposted: controller.isPostReposted(post.id),
               isLiked: controller.isPostLiked(post.id),


### PR DESCRIPTION
## Summary
- store `userId` from returned `Session` whenever a session is fetched or created
- require a logged‑in user when posting, commenting or bookmarking instead of using empty IDs

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd7a146b4832dbc468eb0e7b32e3a