### PR TITLE
Check auth before posting/commenting

### DIFF
--- a/lib/features/social_feed/screens/comment_thread_page.dart
+++ b/lib/features/social_feed/screens/comment_thread_page.dart
@@ -29,6 +29,14 @@ class _CommentThreadPageState extends State<CommentThreadPage> {
   @override
   void initState() {
     super.initState();
+    final auth = Get.find<AuthController>();
+    if (auth.userId == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Get.snackbar('Error', 'Login required');
+        Get.back();
+      });
+      return;
+    }
     final commentsController = Get.find<CommentsController>();
     if (commentsController.comments.isEmpty ||
         commentsController.comments.first.postId !=

--- a/lib/features/social_feed/screens/compose_post_page.dart
+++ b/lib/features/social_feed/screens/compose_post_page.dart
@@ -25,6 +25,18 @@ class _ComposePostPageState extends State<ComposePostPage> {
   final _linkController = TextEditingController();
   XFile? _image;
 
+  @override
+  void initState() {
+    super.initState();
+    final auth = Get.find<AuthController>();
+    if (auth.userId == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Get.snackbar('Error', 'Login required');
+        Get.back();
+      });
+    }
+  }
+
 
   Future<void> _pickImage() async {
     final picker = ImagePicker();

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -47,6 +47,14 @@ class _PostDetailPageState extends State<PostDetailPage> {
   @override
   void initState() {
     super.initState();
+    final auth = Get.find<AuthController>();
+    if (auth.userId == null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        Get.snackbar('Error', 'Login required');
+        Get.back();
+      });
+      return;
+    }
     commentsController = Get.find<CommentsController>();
     commentsController.loadComments(widget.post.id);
   }


### PR DESCRIPTION
## Summary
- guard against null `auth.userId` when opening ComposePostPage, PostDetailPage and CommentThreadPage

## Testing
- `dart format` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdd225e70832da8e619dbbd963fb8