### PR TITLE
Enable tapping anywhere on PostCard

### DIFF
--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -144,10 +144,16 @@ class PostCard extends StatelessWidget {
     final canEdit =
         DateTime.now().difference(post.editedAt ?? post.createdAt).inMinutes <=
             30;
-    return Obx(
-      () => GlassmorphicCard(
-        padding: DesignTokens.md(context).all,
-        child: Column(
+    return InkWell(
+      borderRadius: BorderRadius.circular(DesignTokens.radiusMd(context)),
+      onTap: () {
+        MicroInteractions.selectionHaptic();
+        Get.to(() => PostDetailPage(post: post));
+      },
+      child: Obx(
+        () => GlassmorphicCard(
+          padding: DesignTokens.md(context).all,
+          child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
             if (controller.isPostReposted(post.id))
@@ -281,6 +287,7 @@ class PostCard extends StatelessWidget {
           ],
         ),
       ),
-    );
+    ),
+  );
   }
 }

--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:myapp/features/social_feed/models/feed_post.dart';
 import 'package:myapp/features/social_feed/widgets/post_card.dart';
+import 'package:myapp/features/social_feed/screens/post_detail_page.dart';
 import 'package:get/get.dart';
 import 'package:myapp/features/social_feed/controllers/feed_controller.dart';
 import 'package:myapp/features/social_feed/services/feed_service.dart';
@@ -102,6 +103,25 @@ void main() {
     await tester.pump();
 
     expect(find.bySemanticsLabel('Repost'), findsOneWidget);
+  });
+
+  testWidgets('tapping card navigates to detail page', (tester) async {
+    final post = FeedPost(
+      id: '1',
+      roomId: 'r1',
+      userId: 'u1',
+      username: 'user',
+      content: 'hello',
+    );
+
+    await tester.pumpWidget(
+      GetMaterialApp(home: PostCard(post: post)),
+    );
+
+    await tester.tap(find.byType(PostCard));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(PostDetailPage), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
## Summary
- wrap `PostCard` content in an `InkWell` to open post details on tap with haptics
- test that tapping the card navigates to `PostDetailPage`

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fde9465e8832d8da064f91eb8e91d