### PR TITLE
Add submenu open step in post card menu test

### DIFF
--- a/test/features/social_feed/post_card_test.dart
+++ b/test/features/social_feed/post_card_test.dart
@@ -174,6 +174,10 @@ void main() {
     await tester.tap(find.byIcon(Icons.more_vert));
     await tester.pumpAndSettle();
     expect(find.text('Flag or Report Post'), findsOneWidget);
+
+    // Open the submenu to reveal user actions
+    await tester.tap(find.text('@other'));
+    await tester.pumpAndSettle();
     expect(find.text('Follow User'), findsOneWidget);
     expect(find.text('Block User'), findsOneWidget);
   });


### PR DESCRIPTION
## Summary
- verify `Follow User` and `Block User` menu items by opening the submenu

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fe6f8fe20832dab1a9febd2e21f83