### PR TITLE
Implement cache cleanup

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -87,6 +87,7 @@ Future<void> main() async {
   );
   Get.put(feedService, permanent: true);
   Get.put(notificationService, permanent: true);
+  await feedService.cleanupCachedEntries();
   if (!(await connectivity.checkConnectivity()).contains(ConnectivityResult.none)) {
     await feedService.syncQueuedActions();
     await notificationService.syncQueuedNotifications();


### PR DESCRIPTION
## Summary
- add `cleanupCachedEntries` method in `FeedService`
- run cleanup after syncing queued actions
- invoke cleanup during startup

## Testing
- `flutter test` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ff487fec4832da887ef10931f733d