### PR TITLE
Optimize mention notifications

### DIFF
--- a/test/features/social_feed/mentions_limit_test.dart
+++ b/test/features/social_feed/mentions_limit_test.dart
@@ -37,23 +37,40 @@ class RecordingFeedService extends FeedService {
 
 class FakeDatabases extends Databases {
   FakeDatabases() : super(Client());
+
+  List<String> _parseNames(String query) {
+    final start = query.indexOf('[');
+    if (start != -1) {
+      final end = query.indexOf(']', start);
+      final inside =
+          query.substring(start + 1, end).replaceAll('"', '').trim();
+      if (inside.isEmpty) return [];
+      return inside.split(',').map((e) => e.trim()).toList();
+    }
+    final match = RegExp(r'"([^"]+)"').firstMatch(query);
+    return match != null ? [match.group(1)!] : [];
+  }
+
   @override
   Future<models.DocumentList> listDocuments({
     required String databaseId,
     required String collectionId,
     List<String>? queries,
   }) async {
-    return models.DocumentList(total: 1, documents: [
-      models.Document.fromMap({
-        '\$id': 'uid',
-        '\$collectionId': collectionId,
-        '\$databaseId': databaseId,
-        '\$createdAt': '',
-        '\$updatedAt': '',
-        '\$permissions': [],
-        'username': 'user0',
-      })
-    ]);
+    final query = queries?.first ?? '';
+    final names = _parseNames(query);
+    final docs = names
+        .map((n) => models.Document.fromMap({
+              '\$id': n,
+              '\$collectionId': collectionId,
+              '\$databaseId': databaseId,
+              '\$createdAt': '',
+              '\$updatedAt': '',
+              '\$permissions': [],
+              'username': n,
+            }))
+        .toList();
+    return models.DocumentList(total: docs.length, documents: docs);
   }
 }
 


### PR DESCRIPTION
## Summary
- batch fetch all mentioned users with a single query
- add fallback to individual fetches if the bulk query fails
- update mention service tests to cover bulk search

## Testing
- `flutter test test/features/social_feed/notify_mentions_test.dart` *(fails: `flutter: command not found`)*
- `dart test` *(fails: `dart: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684ff85c3c28832da53110ec35f3acce