### PR TITLE
Add post refresh in detail page

### DIFF
--- a/lib/features/social_feed/controllers/feed_controller.dart
+++ b/lib/features/social_feed/controllers/feed_controller.dart
@@ -613,6 +613,17 @@ class FeedController extends GetxController {
     _commentCounts[postId] = math.max(0, (_commentCounts[postId] ?? 1) - 1);
   }
 
+  void updatePostCounts(FeedPost post) {
+    _likeCounts[post.id] = post.likeCount;
+    _repostCounts[post.id] = post.repostCount;
+    _commentCounts[post.id] = post.commentCount;
+    _bookmarkCount[post.id] = post.bookmarkCount;
+    final index = _posts.indexWhere((p) => p.id == post.id);
+    if (index != -1) {
+      _posts[index] = post;
+    }
+  }
+
   @override
   void onClose() {
     disposeSubscription();

--- a/lib/features/social_feed/screens/post_detail_page.dart
+++ b/lib/features/social_feed/screens/post_detail_page.dart
@@ -9,6 +9,7 @@ import '../../authentication/controllers/auth_controller.dart';
 import '../widgets/comment_card.dart';
 import '../utils/comment_validation.dart';
 import '../widgets/post_card.dart';
+import '../controllers/feed_controller.dart';
 import '../../../shared/utils/logger.dart';
 import '../services/mention_service.dart';
 import 'package:flutter/foundation.dart';
@@ -57,6 +58,12 @@ class _PostDetailPageState extends State<PostDetailPage> {
     }
     commentsController = Get.find<CommentsController>();
     commentsController.loadComments(widget.post.id);
+    if (Get.isRegistered<FeedController>()) {
+      final feed = Get.find<FeedController>();
+      feed.service.getPostById(widget.post.id).then((post) {
+        if (post != null) feed.updatePostCounts(post);
+      });
+    }
   }
 
   @override

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -167,6 +167,28 @@ class FeedService {
         .toList();
   }
 
+  Future<FeedPost?> getPostById(String postId) async {
+    try {
+      final doc = await databases.getDocument(
+        databaseId: databaseId,
+        collectionId: postsCollectionId,
+        documentId: postId,
+      );
+      return FeedPost.fromJson(doc.data);
+    } catch (_) {
+      for (final key in postsBox.keys) {
+        final cached = postsBox.get(key, defaultValue: []) as List;
+        for (final item in cached) {
+          if (item is Map &&
+              (item['id'] == postId || item['\$id'] == postId)) {
+            return FeedPost.fromJson(Map<String, dynamic>.from(item));
+          }
+        }
+      }
+      return null;
+    }
+  }
+
   Future<String?> createPost(FeedPost post) async {
     final limitedTags = _limitHashtags(post.hashtags);
     final limitedMentions = _limitMentions(post.mentions);


### PR DESCRIPTION
## Summary
- add a `getPostById` helper to `FeedService`
- allow `FeedController` to update post counts from a fetched post
- refresh post stats in `PostDetailPage` on init

## Testing
- `dart format lib/features/social_feed/services/feed_service.dart lib/features/social_feed/controllers/feed_controller.dart lib/features/social_feed/screens/post_detail_page.dart` *(fails: `dart` not found)*
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685023704724832d8b24d27e0ed01ffe