### PR TITLE
Implement cached reactions sync

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -126,7 +126,10 @@ class CommentsController extends GetxController {
       _likeCounts[commentId] =
           math.max(0, (_likeCounts[commentId] ?? 1) - 1);
     } else {
-      await service.likeComment(commentId, uid);
+      final isDup = await service.validateReaction('like', commentId, uid);
+      if (!isDup) {
+        await service.likeComment(commentId, uid);
+      }
       try {
         final like = await service.getUserLike(commentId, uid);
         if (like != null) {

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -1060,6 +1060,9 @@ class FeedService {
           case 'delete_repost':
             await deleteRepost(mapItem['id'], mapItem['post_id']);
             break;
+          case 'share':
+            await sharePost(mapItem['post_id']);
+            break;
           case 'post':
             final post =
                 FeedPost.fromJson(Map<String, dynamic>.from(mapItem['data']));
@@ -1561,7 +1564,12 @@ class FeedService {
       }
       return 'https://your-app.com/post/$postId';
     } catch (e) {
-      throw Exception('Failed to share post: $e');
+      await _addToBoxWithLimit(queueBox, {
+        'action': 'share',
+        'post_id': postId,
+        '_cachedAt': DateTime.now().toIso8601String(),
+      });
+      return 'https://your-app.com/post/$postId';
     }
   }
 }

--- a/lib/features/social_feed/widgets/post_card.dart
+++ b/lib/features/social_feed/widgets/post_card.dart
@@ -400,7 +400,7 @@ class PostCard extends StatelessWidget {
               likeCount: controller.postLikeCount(post.id),
               commentCount: controller.postCommentCount(post.id),
               repostCount: controller.postRepostCount(post.id),
-              shareCount: post.shareCount,
+              shareCount: controller.postShareCount(post.id),
               bookmarkCount: controller.postBookmarkCount(post.id),
             ),
             Padding(

--- a/lib/features/social_feed/widgets/reaction_bar.dart
+++ b/lib/features/social_feed/widgets/reaction_bar.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:get/get.dart';
 import 'package:share_plus/share_plus.dart';
+import '../controllers/feed_controller.dart';
 
 enum ReactionTarget { post, comment, repost }
 
@@ -126,7 +127,8 @@ class _ReactionBarState extends State<ReactionBar>
   Future<void> defaultShare() async {
     if (widget.postId == null) return;
     try {
-      final link = "https://example.com/post/${widget.postId}";
+      final controller = Get.find<FeedController>();
+      final link = await controller.sharePost(widget.postId!);
       await Share.share('Check out this post: $link');
     } catch (_) {
       Get.snackbar("Error", "Failed to share post");


### PR DESCRIPTION
## Summary
- track share counts in `FeedController`
- queue post share requests offline
- update realtime listeners with share count
- validate comment likes using the same flow as posts
- surface share counts in the UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685178e35db4832d963c5c956e449b28