### PR TITLE
Fix Appwrite $increment usage

### DIFF
--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -457,9 +457,9 @@ class FeedService {
         databaseId: databaseId,
         collectionId: postsCollectionId,
         documentId: comment.postId,
-        data: {
-          'comment_count': {'\$increment': 1}
-        },
+          data: {
+            'comment_count': {'$increment': 1}
+          },
       );
       if (comment.parentId != null) {
         await databases.updateDocument(
@@ -467,7 +467,7 @@ class FeedService {
           collectionId: commentsCollectionId,
           documentId: comment.parentId!,
           data: {
-            'reply_count': {'\$increment': 1}
+            'reply_count': {'$increment': 1}
           },
         );
         if (Get.isRegistered<NotificationService>()) {
@@ -593,7 +593,7 @@ class FeedService {
           collectionId: commentsCollectionId,
           documentId: like['item_id'],
           data: {
-            'like_count': {'\$increment': 1}
+            'like_count': {'$increment': 1}
           },
         );
       } else {
@@ -602,7 +602,7 @@ class FeedService {
           collectionId: postsCollectionId,
           documentId: like['item_id'],
           data: {
-            'like_count': {'\$increment': 1}
+            'like_count': {'$increment': 1}
           },
         );
       }
@@ -670,7 +670,7 @@ class FeedService {
         collectionId: postsCollectionId,
         documentId: repost['post_id'],
         data: {
-          'repost_count': {'\$increment': 1}
+          'repost_count': {'$increment': 1}
         },
       );
       try {
@@ -713,7 +713,7 @@ class FeedService {
         collectionId: postsCollectionId,
         documentId: postId,
         data: {
-          'repost_count': {'\$increment': -1}
+          'repost_count': {'$increment': -1}
         },
       );
     } catch (_) {
@@ -829,7 +829,7 @@ class FeedService {
           collectionId: commentsCollectionId,
           documentId: itemId,
           data: {
-            'like_count': {'\$increment': -1}
+            'like_count': {'$increment': -1}
           },
         );
       } else {
@@ -838,7 +838,7 @@ class FeedService {
           collectionId: postsCollectionId,
           documentId: itemId,
           data: {
-            'like_count': {'\$increment': -1}
+            'like_count': {'$increment': -1}
           },
         );
       }
@@ -1188,7 +1188,7 @@ class FeedService {
         collectionId: postsCollectionId,
         documentId: postId,
         data: {
-          'bookmark_count': {'\$increment': 1}
+          'bookmark_count': {'$increment': 1}
         },
       );
       for (final key in postsBox.keys) {
@@ -1252,7 +1252,7 @@ class FeedService {
         collectionId: postsCollectionId,
         documentId: postId,
         data: {
-          'bookmark_count': {'\$increment': -1}
+          'bookmark_count': {'$increment': -1}
         },
       );
       for (final key in postsBox.keys) {
@@ -1318,9 +1318,9 @@ class FeedService {
             comment.parentId == null ? comment.postId : comment.parentId!,
         data: {
           if (comment.parentId == null)
-            'comment_count': {'\$increment': -1}
+            'comment_count': {'$increment': -1}
           else
-            'reply_count': {'\$increment': -1}
+            'reply_count': {'$increment': -1}
         },
       );
       for (final key in commentsBox.keys) {
@@ -1545,7 +1545,7 @@ class FeedService {
         collectionId: postsCollectionId,
         documentId: postId,
         data: {
-          'share_count': {'\$increment': 1}
+          'share_count': {'$increment': 1}
         },
       );
       for (final key in postsBox.keys) {

--- a/test/features/social_feed/comment_function_execution_test.dart
+++ b/test/features/social_feed/comment_function_execution_test.dart
@@ -110,7 +110,7 @@ void main() {
     );
     await service.createComment(comment);
     expect(db.updates.last['collectionId'], 'posts');
-    expect(db.updates.last['data'], {'comment_count': {'\$increment': 1}});
+    expect(db.updates.last['data'], {'comment_count': {'$increment': 1}});
     final cached = Hive.box('posts').get('k') as List;
     expect(cached.first['comment_count'], 1);
   });
@@ -133,9 +133,9 @@ void main() {
     await service.createComment(reply);
     expect(db.updates.length, 2);
     expect(db.updates.first['collectionId'], 'posts');
-    expect(db.updates.first['data'], {'comment_count': {'\$increment': 1}});
+    expect(db.updates.first['data'], {'comment_count': {'$increment': 1}});
     expect(db.updates.last['collectionId'], 'comments');
-    expect(db.updates.last['data'], {'reply_count': {'\$increment': 1}});
+    expect(db.updates.last['data'], {'reply_count': {'$increment': 1}});
     final cachedComments = Hive.box('comments').get('c_post') as List;
     expect(cachedComments.first['reply_count'], 1);
     final cachedPosts = Hive.box('posts').get('k') as List;
@@ -158,7 +158,7 @@ void main() {
     );
     await service.deleteComment(comment);
     expect(db.updates.last['collectionId'], 'posts');
-    expect(db.updates.last['data'], {'comment_count': {'\$increment': -1}});
+    expect(db.updates.last['data'], {'comment_count': {'$increment': -1}});
     final post = Hive.box('posts').get('k') as List;
     expect(post.first['comment_count'], 1);
     final cached = Hive.box('comments').get('c_post') as List;
@@ -180,7 +180,7 @@ void main() {
     );
     await service.deleteComment(reply);
     expect(db.updates.last['collectionId'], 'comments');
-    expect(db.updates.last['data'], {'reply_count': {'\$increment': -1}});
+    expect(db.updates.last['data'], {'reply_count': {'$increment': -1}});
     final cached = Hive.box('comments').get('c_post') as List;
     expect(cached.first['reply_count'], 0);
   });

--- a/test/features/social_feed/comments_controller_test.dart
+++ b/test/features/social_feed/comments_controller_test.dart
@@ -354,7 +354,7 @@ void main() {
     );
 
     await controller.replyToComment(reply);
-    expect(db.updates.any((u) => u['data']?['reply_count']?['\$increment'] == 1),
+    expect(db.updates.any((u) => u['data']?['reply_count']?['$increment'] == 1),
         isTrue);
 
     await Hive.deleteFromDisk();

--- a/test/features/social_feed/feed_service_create_comment_test.dart
+++ b/test/features/social_feed/feed_service_create_comment_test.dart
@@ -165,7 +165,7 @@ void main() {
     await service.createComment(comment);
 
     expect(db.updates.last['collectionId'], 'posts');
-    expect(db.updates.last['data'], {'comment_count': {'\$increment': 1}});
+    expect(db.updates.last['data'], {'comment_count': {'$increment': 1}});
     final cached = Hive.box('posts').get('key') as List;
     expect(cached.first['comment_count'], 1);
     expect(notification.calls, 1);

--- a/test/features/social_feed/feed_service_create_like_test.dart
+++ b/test/features/social_feed/feed_service_create_like_test.dart
@@ -156,7 +156,7 @@ void main() {
     });
 
     expect(db.updates.last['collectionId'], 'posts');
-    expect(db.updates.last['data'], {'like_count': {'\$increment': 1}});
+    expect(db.updates.last['data'], {'like_count': {'$increment': 1}});
     expect(notification.calls, 1);
   });
 
@@ -168,7 +168,7 @@ void main() {
     });
 
     expect(db.updates.last['collectionId'], 'comments');
-    expect(db.updates.last['data'], {'like_count': {'\$increment': 1}});
+    expect(db.updates.last['data'], {'like_count': {'$increment': 1}});
     expect(notification.calls, 1);
   });
 }

--- a/test/features/social_feed/offline_feed_service_test.dart
+++ b/test/features/social_feed/offline_feed_service_test.dart
@@ -353,7 +353,7 @@ void main() {
     await onlineService.syncQueuedActions();
     expect(
         dbOnline.updates
-            .any((u) => u['data']?['reply_count']?['\$increment'] == 1),
+            .any((u) => u['data']?['reply_count']?['$increment'] == 1),
         isTrue);
     expect(Hive.box('action_queue').isEmpty, isTrue);
   });

--- a/test/features/social_feed/repost_function_execution_test.dart
+++ b/test/features/social_feed/repost_function_execution_test.dart
@@ -131,7 +131,7 @@ void main() {
       validateReactionFunctionId: 'validate',
     );
     await service.createRepost({'post_id': '1', 'user_id': 'u'});
-    expect(db.updates.last['data'], {'repost_count': {'\$increment': 1}});
+    expect(db.updates.last['data'], {'repost_count': {'$increment': 1}});
   });
 
   test('deleteRepost triggers decrement function', () async {
@@ -151,7 +151,7 @@ void main() {
       validateReactionFunctionId: 'validate',
     );
     await service.deleteRepost('r1', '1');
-    expect(db.updates.last['data'], {'repost_count': {'\$increment': -1}});
+    expect(db.updates.last['data'], {'repost_count': {'$increment': -1}});
   });
 
   test('queued repost executes function on sync', () async {
@@ -185,6 +185,6 @@ void main() {
       linkMetadataFunctionId: 'link',
     );
     await service.syncQueuedActions();
-    expect(onlineDb.updates.last['data'], {'repost_count': {'\$increment': 1}});
+    expect(onlineDb.updates.last['data'], {'repost_count': {'$increment': 1}});
   });
 }


### PR DESCRIPTION
## Summary
- fix data update syntax by using `$increment` instead of `\$increment`
- update tests to expect `$increment`

## Testing
- `flutter test` *(fails: flutter: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851826a3360832db7dc5a362a3611ee