### PR TITLE
Fix comment mentions field not supported by backend

### DIFF
--- a/lib/features/social_feed/models/post_comment.dart
+++ b/lib/features/social_feed/models/post_comment.dart
@@ -44,7 +44,7 @@ class PostComment {
     );
   }
 
-  Map<String, dynamic> toJson({bool includeId = true}) {
+  Map<String, dynamic> toJson({bool includeId = true, bool includeMentions = true}) {
     return {
       if (includeId) 'id': id,
       'post_id': postId,
@@ -54,7 +54,7 @@ class PostComment {
       'parent_id': parentId,
       'content': content,
       'media_urls': mediaUrls,
-      'mentions': mentions,
+      if (includeMentions) 'mentions': mentions,
       'like_count': likeCount,
       'reply_count': replyCount,
       'is_deleted': isDeleted,

--- a/lib/features/social_feed/services/feed_service.dart
+++ b/lib/features/social_feed/services/feed_service.dart
@@ -458,7 +458,7 @@ class FeedService {
         databaseId: databaseId,
         collectionId: commentsCollectionId,
         documentId: ID.unique(),
-        data: comment.toJson(includeId: false),
+        data: comment.toJson(includeId: false, includeMentions: false),
       );
       id = doc.data['\$id'] ?? doc.data['id'];
       await databases.updateDocument(


### PR DESCRIPTION
## Summary
- prevent mentions field from being sent when creating comments
- allow controlling mention inclusion via `PostComment.toJson`

## Testing
- `flutter test` *(fails: command not found)*
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68518ee29b00832d9071476fa3cb8fc7