### PR TITLE
Add edited fields to PostComment

### DIFF
--- a/lib/features/social_feed/controllers/comments_controller.dart
+++ b/lib/features/social_feed/controllers/comments_controller.dart
@@ -150,6 +150,29 @@ class CommentsController extends GetxController {
     }
   }
 
+  Future<void> editComment(String commentId, String content) async {
+    final index = _comments.indexWhere((c) => c.id == commentId);
+    if (index == -1) return;
+    await service.editComment(commentId, content);
+    final existing = _comments[index];
+    _comments[index] = PostComment(
+      id: existing.id,
+      postId: existing.postId,
+      userId: existing.userId,
+      username: existing.username,
+      userAvatar: existing.userAvatar,
+      parentId: existing.parentId,
+      content: content,
+      mediaUrls: existing.mediaUrls,
+      mentions: existing.mentions,
+      likeCount: existing.likeCount,
+      replyCount: existing.replyCount,
+      isDeleted: existing.isDeleted,
+      isEdited: true,
+      editedAt: DateTime.now(),
+    );
+  }
+
   Future<void> deleteComment(String commentId) async {
     final comment = _comments.firstWhereOrNull((c) => c.id == commentId);
     if (comment != null) {

--- a/lib/features/social_feed/models/post_comment.dart
+++ b/lib/features/social_feed/models/post_comment.dart
@@ -11,6 +11,8 @@ class PostComment {
   final int likeCount;
   final int replyCount;
   final bool isDeleted;
+  final bool isEdited;
+  final DateTime? editedAt;
 
   PostComment({
     required this.id,
@@ -25,6 +27,8 @@ class PostComment {
     this.likeCount = 0,
     this.replyCount = 0,
     this.isDeleted = false,
+    this.isEdited = false,
+    this.editedAt,
   });
 
   factory PostComment.fromJson(Map<String, dynamic> json) {
@@ -41,6 +45,10 @@ class PostComment {
       likeCount: json['like_count'] ?? 0,
       replyCount: json['reply_count'] ?? 0,
       isDeleted: json['is_deleted'] ?? false,
+      isEdited: json['is_edited'] ?? false,
+      editedAt: json['edited_at'] != null
+          ? DateTime.tryParse(json['edited_at'])
+          : null,
     );
   }
 
@@ -58,6 +66,8 @@ class PostComment {
       'like_count': likeCount,
       'reply_count': replyCount,
       'is_deleted': isDeleted,
+      'is_edited': isEdited,
+      'edited_at': editedAt?.toIso8601String(),
     };
   }
 }


### PR DESCRIPTION
## Summary
- extend `PostComment` with `isEdited` and `editedAt`
- persist comment edits via `FeedService.editComment`
- update `CommentsController` to handle editing

## Testing
- `flutter --version` *(fails: command not found)*
- `dart format lib/features/social_feed/models/post_comment.dart lib/features/social_feed/services/feed_service.dart lib/features/social_feed/controllers/comments_controller.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851b25a6a10832d8d4bbd3f65b489a5