### PR TITLE
Fix card theme type for Flutter 3.22

### DIFF
--- a/lib/core/design_system/modern_ui_system.dart
+++ b/lib/core/design_system/modern_ui_system.dart
@@ -338,8 +338,8 @@ class MD3ThemeSystem {
     );
   }
 
-  static CardTheme _createCardTheme(ColorScheme colorScheme) {
-    return CardTheme(
+  static CardThemeData _createCardTheme(ColorScheme colorScheme) {
+    return CardThemeData(
       color: colorScheme.surface,
       surfaceTintColor: colorScheme.surfaceTint,
       elevation: 1,


### PR DESCRIPTION
## Summary
- update card theme creation to use `CardThemeData`

## Testing
- `flutter test` *(fails: `flutter` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d4b70a48832d87fa87fbbf00f32e