### PR TITLE
Fix Material 3 theme types

### DIFF
--- a/lib/core/themes/enhanced_app_theme.dart
+++ b/lib/core/themes/enhanced_app_theme.dart
@@ -86,7 +86,7 @@ class EnhancedAppTheme {
       ),
       indicatorColor: _lightColorScheme.primaryContainer,
     ),
-    cardTheme: CardTheme(
+    cardTheme: const CardThemeData(
       elevation: 1,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),
@@ -192,7 +192,7 @@ class EnhancedAppTheme {
       color: _lightColorScheme.outlineVariant,
       thickness: 1,
     ),
-    dialogTheme: DialogTheme(
+    dialogTheme: const DialogThemeData(
       elevation: 6,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       backgroundColor: _lightColorScheme.surface,
@@ -286,7 +286,7 @@ class EnhancedAppTheme {
       ),
       indicatorColor: _darkColorScheme.primaryContainer,
     ),
-    cardTheme: CardTheme(
+    cardTheme: const CardThemeData(
       elevation: 1,
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(16),
@@ -392,7 +392,7 @@ class EnhancedAppTheme {
       color: _darkColorScheme.outlineVariant,
       thickness: 1,
     ),
-    dialogTheme: DialogTheme(
+    dialogTheme: const DialogThemeData(
       elevation: 6,
       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(20)),
       backgroundColor: _darkColorScheme.surface,


### PR DESCRIPTION
## Summary
- update `cardTheme` and `dialogTheme` to use `CardThemeData` and `DialogThemeData`

## Testing
- `dart --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6851d5f9e0e0832daa72c4fc54942061